### PR TITLE
build: add git to flake.nix

### DIFF
--- a/technical-spec/flake.nix
+++ b/technical-spec/flake.nix
@@ -15,6 +15,7 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             texliveFull
+            git
           ];
         };
       });


### PR DESCRIPTION
Git is used during PDF build but isn't available in Nix shell