### PR TITLE
Bump Dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aiken-lang/setup-aiken@v1
         with:
-          version: v1.1.7
+          version: v1.1.9
       - run: aiken fmt --check
       - run: aiken check -D
       - run: aiken build

--- a/aiken.lock
+++ b/aiken.lock
@@ -3,7 +3,7 @@
 
 [[requirements]]
 name = "aiken-lang/stdlib"
-version = "v2.1.0"
+version = "v2.2.0"
 source = "github"
 
 [[requirements]]
@@ -13,12 +13,12 @@ source = "github"
 
 [[requirements]]
 name = "anastasia-labs/aiken-design-patterns"
-version = "v1.1.0"
+version = "v1.2.0"
 source = "github"
 
 [[packages]]
 name = "aiken-lang/stdlib"
-version = "v2.1.0"
+version = "v2.2.0"
 requirements = []
 source = "github"
 
@@ -30,7 +30,7 @@ source = "github"
 
 [[packages]]
 name = "anastasia-labs/aiken-design-patterns"
-version = "v1.1.0"
+version = "v1.2.0"
 requirements = []
 source = "github"
 

--- a/aiken.toml
+++ b/aiken.toml
@@ -1,6 +1,6 @@
 name = "al-ft/midgard"
 version = "0.0.0"
-compiler = "v1.1.7"
+compiler = "v1.1.9"
 plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken contracts for project 'al-ft/midgard'"
@@ -12,7 +12,7 @@ platform = "github"
 
 [[dependencies]]
 name = "aiken-lang/stdlib"
-version = "v2.1.0"
+version = "v2.2.0"
 source = "github"
 
 [[dependencies]]
@@ -22,7 +22,7 @@ source = "github"
 
 [[dependencies]]
 name = "anastasia-labs/aiken-design-patterns"
-version = "v1.1.0"
+version = "v1.2.0"
 source = "github"
 
 [config]

--- a/plutus.json
+++ b/plutus.json
@@ -6,7 +6,7 @@
     "plutusVersion": "v3",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.1.7+e2fb28b"
+      "version": "v1.1.9+2217206"
     },
     "license": "Apache-2.0"
   },


### PR DESCRIPTION
This PR gives us:
- The new record type update syntax in Aiken v1.1.9
- `builtin.unconstr_fields` which is slightly cheaper than `builtin.un_constr_data`
- `merkelized_validator.generic_delegated_validation` in `aiken-design-patterns`, allowing for unsafe coercion on the withdrawal redeemer

Updating `stdlib` might not be needed for these, but I've bumped it regardless.