### PR TITLE
docs: add templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,25 @@
 <p align="center">
   <img width="150px" src="documentation/public/midgard-icon-green.png" align="center" alt="Midgard Logo"/>
   <h1 align="center">Midgard</h1>
-  <p align="center">Cardano's first optimistic rollup solution for highly scalable, secure Layer 2 transactions</p>
+  <p align="center">Cardano's first optimistic rollup protocol</p>
 </p>
 
-# Build the onchain code
+## Build the onchain code
 
-Install Aiken and run `aiken build`.
+Install [Aiken](https://aiken-lang.org/) and run 
 
-## Build the spec
-
-Run `make spec` and open `technical-spec/midgard.pdf`.
-
-## Documentation Site
-
-To run the documentation site locally:
-
-```
-cd docs           
-pnpm install
-pnpm dev
+``` 
+aiken build
 ```
 
-The documentation will be available at http://localhost:3000
+## Technical Specification
+
+Run 
+```
+make spec
+```
+
+ and open `technical-spec/midgard.pdf`.
 
 ## Contributor guidelines
 
@@ -31,3 +28,29 @@ All contributors must enable the project's standardized git hooks:
 ```
 make enable-git-hooks
 ```
+
+Take a look at the [contribution guidelines](./CONTRIBUTING.md) for more details.
+
+## Documentation / Architectural Decision Records (ADRs)
+
+To run the documentation site locally:
+
+1. Navigate to documentation
+
+```
+cd documentation
+```
+
+2. Install dependencies
+
+```
+pnpm install
+```
+
+3. Start development server
+
+```
+pnpm dev
+```
+
+> Local development server will be available at http://localhost:3000, you can read more about how to add new documentation [here](https://github.com/Anastasia-Labs/midgard/blob/main/documentation/README.md).

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -6,27 +6,41 @@ This directory contains the documentation website for Midgard, built with [Nextr
 
 To start the development server:
 
-```bash
-# Install dependencies
+```
 pnpm install
+```
 
-# Start development server
+```
 pnpm dev
 ```
 
-The site will be available at [http://localhost:3000](http://localhost:3000).
+> Local development server will be available at [http://localhost:3000](http://localhost:3000).
 
 ## Structure
 
 ```
-docs/
-├── app/           # Next.js app directory
-├── content/       # Documentation content (MDX files)
-├── components/    # React components
-├── public/        # Static assets
-└── styles/        # CSS styles
+documentation/
+├── app/
+├── components/
+├── content/          # Documentation content (MDX files)
+│   ├── index.mdx     # Landing page
+│   ├── user-facing/
+│   └── architectural-decision-records/
+│       └── 000-example-adr.mdx # ADR template
+│
+├── public/
+└── styles/
 ```
 
-## Adding Content
+## Writing Documentation
 
-Documentation content is written in MDX and stored in the `content` directory. The sidebar navigation is automatically generated from the file structure.
+### Regular Documentation
+
+Add your `.mdx` files to the appropriate directory under `content/`.Documentation content is written in MDX with optional Nextra components and stored in the `content` directory. The sidebar navigation is automatically generated from the file structure.
+
+### Architectural Decisions
+
+For new ADRs, copy the template from `content/architectural-decision-records/000-example-adr.mdx`:
+
+1. Create a new file: `content/architectural-decision-records/00X-title.mdx`
+2. Fill in the sections

--- a/documentation/content/_meta.js
+++ b/documentation/content/_meta.js
@@ -1,0 +1,21 @@
+export default {
+  Informational: {
+    title: "Information",
+    type: "menu",
+    items: {
+      website: {
+        title: "Website",
+        href: "https://midgardprotocol.com/",
+      },
+    },
+  },
+  "user-facing": {
+    title: "User Facing Content",
+  },
+  "architectural-decision-records": {
+    title: "Architectural Decision Records",
+  },
+  "###": {
+    type: "separator",
+  },
+};

--- a/documentation/content/architectural-decision-records/000-example-adr.mdx
+++ b/documentation/content/architectural-decision-records/000-example-adr.mdx
@@ -1,0 +1,94 @@
+import { Table, Callout } from "nextra/components";
+
+# [000 - Example Decision]
+
+<Callout type="info">
+  Keep the title clear and specific. For example: "Using SQLite as Database" or
+  "Adopting Convention X".
+</Callout>
+
+## Motivation
+
+[Explain the reasoning for the decision]
+
+- What triggered this decision?
+- Why does it matter now?
+
+## Decision
+
+[Describe what is being proposed]
+
+### Example Diagram
+
+```mermaid
+graph TD
+    subgraph Transaction Generator
+    TG[Tx Generator]
+    Scheduler[Scheduler]
+    end
+
+    subgraph Midgard Node
+    API[HTTP API]
+    BlockProcessor[Block Processor]
+    Other[Other Node<br/>Components]
+    end
+
+    subgraph Storage
+    MempoolDB[(Mempool DB)]
+    ImmutableDB[(Immutable DB)]
+    end
+
+    TG --> |Generate L2 Txs| Scheduler
+    Scheduler --> |Submit via HTTP| API
+    API --> |Store Pending| MempoolDB
+    BlockProcessor --> |Read Pending| MempoolDB
+    BlockProcessor --> |Store Processed| ImmutableDB
+
+    style API fill:#2E7D32,stroke:#1B5E20,color:#ffffff
+    style BlockProcessor fill:#D84315,stroke:#BF360C,color:#ffffff
+    style Other fill:#546E7A,stroke:#37474F,color:#ffffff
+    style MempoolDB fill:#4527A0,stroke:#311B92,color:#ffffff
+    style ImmutableDB fill:#4527A0,stroke:#311B92,color:#ffffff
+
+```
+
+<Callout type="info">
+  For more examples on mermaid diagrams, see the [mermaid
+  docs](https://mermaid.js.org/syntax/flowchart.html).
+</Callout>
+
+## (Optional) Alternatives
+
+[Describe the alternatives considered]
+
+<Table>
+  <thead>
+    <Table.Tr>
+      <Table.Th>Alternatives</Table.Th>
+      <Table.Th>Pros</Table.Th>
+      <Table.Th>Cons</Table.Th>
+    </Table.Tr>
+  </thead>
+  <tbody>
+    <Table.Tr>
+      <Table.Td>Option A</Table.Td>
+      <Table.Td>- Easy to implement</Table.Td>
+      <Table.Td>- Limited scalability</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Option B</Table.Td>
+      <Table.Td>- Better performance</Table.Td>
+      <Table.Td>- More costs</Table.Td>
+    </Table.Tr>
+  </tbody>
+</Table>
+
+## Impact
+
+[Describe the impact of the decision]
+
+## Notes
+
+- [Key discussion]
+- [Open questions]
+- [Related decisions]

--- a/documentation/content/index.mdx
+++ b/documentation/content/index.mdx
@@ -1,3 +1,3 @@
-# Welcome to Midgard
+## Welcome to Midgard
 
 Midgard is a Layer 2 scaling solution built for Cardano that processes transactions off-chain while maintaining the security guarantees of the main chain.

--- a/documentation/content/user-facing/example-user-facing-content.mdx
+++ b/documentation/content/user-facing/example-user-facing-content.mdx
@@ -1,0 +1,39 @@
+import { Callout, Steps, Tabs, FileTree, Table } from "nextra/components";
+
+# Example Header - 1
+
+Wen Midgard?
+
+## Example Header - 2
+
+Why Midgard?
+
+### Example Header - 3
+
+How does Midgard work?
+
+<Steps>
+### Step 1
+
+### Step 2
+
+<Callout type="info">
+Can make a file tree like this explaining the structure of the topic:
+
+<FileTree>
+  <FileTree.Folder name="validators" defaultOpen>
+    <FileTree.File name="validator-1.ak" />
+    <FileTree.File name="validator-2.ak" />
+    <FileTree.File name="validator-3.ak" />
+  </FileTree.Folder>
+</FileTree>
+</Callout>
+### Step 3
+
+</Steps>
+
+<Callout type="warning">Example callout</Callout>
+
+<Callout type="info">Example callout</Callout>
+
+<Callout type="tip">Example callout</Callout>


### PR DESCRIPTION
Extends on the initial implementation for issue #103 with templates for:

- Architectural decision records (ADR)
- User facing content