### PR TITLE
Finished exlusion proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+# Aiken compilation artifacts
+artifacts/
+# Aiken's project working directory
+build/
+# Aiken's default documentation export
+docs/
 .direnv
 utils.log

--- a/onchain/aiken/lib/midgard/fraud-proof/common/types.ak
+++ b/onchain/aiken/lib/midgard/fraud-proof/common/types.ak
@@ -8,6 +8,20 @@ pub type MembershipProofInputs {
   tx_to_root_proof_path: Proof,
 }
 
+pub type ExclusionProofInputTx {
+  tx_root: ByteArray,
+  invalid_input_tx_hash: ByteArray,
+  invalid_input_info_hash: ByteArray,
+  input_to_root_proof_path: Proof,
+}
+
+pub type ExclusionProofUtxo {
+  utxo_root: ByteArray,
+  invalid_utxo: ByteArray,
+  invalid_utxo_info_hash: ByteArray,
+  utxo_to_root_proof_path: Proof,
+}
+
 // Last step datum for fraud proofs
 pub type FraudProofDatum {
   fraud_prover: ByteArray,

--- a/onchain/aiken/lib/midgard/fraud-proof/common/utils.ak
+++ b/onchain/aiken/lib/midgard/fraud-proof/common/utils.ak
@@ -8,7 +8,10 @@ use cardano/assets.{PolicyId, lovelace_of}
 use cardano/transaction.{InlineDatum, Input, Output, Transaction}
 use midgard/common/utils.{get_singleton_asset_with_policy} as get_singleton_asset_with_policy
 use midgard/computation_thread.{StepDatum, Success}
-use midgard/fraud_proof/common/types.{FraudProofDatum, MembershipProofInputs}
+use midgard/fraud_proof/common/types.{
+  ExclusionProofInputTx, ExclusionProofUtxo, FraudProofDatum,
+  MembershipProofInputs,
+}
 use midgard/ledger_state.{Header}
 
 // ------------ ABSTRACTIONS FOR ALL FRAUD PROOF STEPS ------------
@@ -50,6 +53,25 @@ pub fn get_tx_root_validate_block_hash(
   extracted_tx_root
 }
 
+// Relevant to (1): tx_root provided by fraud prover in redeemer matches block_hash from the state queue block from the reference input
+pub fn get_prev_utxo_root(
+  tx: Transaction,
+  state_queue_node_ref_input_index: Int,
+) -> ByteArray {
+  // Reference input with block_hash 
+  expect Some(state_queue_node_input) =
+    list.at(tx.reference_inputs, state_queue_node_ref_input_index)
+
+  // Extract tx_root via the state queue block hash
+  expect InlineDatum(state_queue_datum_data) =
+    state_queue_node_input.output.datum
+  expect state_queue_node_datum: unordered.NodeDatum = state_queue_datum_data
+  expect parsed_state_queue_datum: Header = state_queue_node_datum.data
+  let extracted_prev_utxo_root = parsed_state_queue_datum.prev_utxos_root
+
+  extracted_prev_utxo_root
+}
+
 // tx_root, merkle root of transactions in the state queue block
 // tx_hash, hash of the transaction that is being proven to be in tx_root
 // proof_path: minimum set of hashes needed to reconstruct the path from the tx to the root
@@ -71,6 +93,54 @@ pub fn validate_membership_proof(
       staking_validator: plutarch_midgard_merkle_validator,
       input_data_coercer: fn(withdraw_redeemer: Data) {
         expect coerced: MembershipProofInputs = withdraw_redeemer
+        coerced
+      },
+      redeemers: tx.redeemers,
+    )
+  True
+}
+
+// Relevant to (2)
+pub fn validate_exclusion_proof(
+  tx: Transaction,
+  plutarch_midgard_merkle_validator: ScriptHash,
+  proof_input: ExclusionProofInputTx,
+) -> Bool {
+  expect
+    merkelized_validator.delegated_validation(
+      function_input: ExclusionProofInputTx {
+        tx_root: proof_input.tx_root,
+        invalid_input_tx_hash: proof_input.invalid_input_tx_hash,
+        invalid_input_info_hash: proof_input.invalid_input_info_hash,
+        input_to_root_proof_path: proof_input.input_to_root_proof_path,
+      },
+      staking_validator: plutarch_midgard_merkle_validator,
+      input_data_coercer: fn(withdraw_redeemer: Data) {
+        expect coerced: ExclusionProofInputTx = withdraw_redeemer
+        coerced
+      },
+      redeemers: tx.redeemers,
+    )
+  True
+}
+
+// Relevant to (2)
+pub fn validate_exclusion_utxo_proof(
+  tx: Transaction,
+  plutarch_midgard_merkle_validator: ScriptHash,
+  proof_input: ExclusionProofUtxo,
+) -> Bool {
+  expect
+    merkelized_validator.delegated_validation(
+      function_input: ExclusionProofUtxo {
+        utxo_root: proof_input.utxo_root,
+        invalid_utxo: proof_input.invalid_utxo,
+        invalid_utxo_info_hash: proof_input.invalid_utxo_info_hash,
+        utxo_to_root_proof_path: proof_input.utxo_to_root_proof_path,
+      },
+      staking_validator: plutarch_midgard_merkle_validator,
+      input_data_coercer: fn(withdraw_redeemer: Data) {
+        expect coerced: ExclusionProofUtxo = withdraw_redeemer
         coerced
       },
       redeemers: tx.redeemers,

--- a/onchain/aiken/lib/midgard/fraud-proof/non-existing-input/step.ak
+++ b/onchain/aiken/lib/midgard/fraud-proof/non-existing-input/step.ak
@@ -12,6 +12,10 @@ pub type StepRedeemer {
     bad_tx_body: MidgardTxBodyCompact,
     bad_spend_inputs: Data,
     bad_input: Data,
+    bad_input_utxo_info_hash: ByteArray,
+    bad_input_utxo_to_root_proof_path: Proof,
+    bad_input_tx_info_hash: ByteArray,
+    bad_input_tx_to_root_proof_path: Proof,
     index_output: Int,
     computation_thread_redeemer_index: Int,
   }

--- a/onchain/aiken/validators/fraud-proof/non-existent-input/step.ak
+++ b/onchain/aiken/validators/fraud-proof/non-existent-input/step.ak
@@ -111,7 +111,7 @@ validator main(
 
         expect list.has(builtin.un_list_data(bad_spend_inputs), bad_input)
 
-        // TODO: exclusion proof that bad_input is not in the block's prev_utxos_root.
+        // Exclusion proof that bad_input is not in the block's prev_utxos_root.
         expect True
         let extracted_prev_utxo_root =
           get_prev_utxo_root(tx, bad_state_queue_node_ref_input_index)
@@ -128,8 +128,7 @@ validator main(
             },
           )
 
-        //TODO: exclusion proof that bad_input.tx_hash is not in the block's tx_root.
-        //TODO: ASK to George, should not we check that in case is present the index should be wrong?
+        // Exclusion proof that bad_input.tx_hash is not in the block's tx_root.
         expect invalid_input: Input = bad_input
         expect
           validate_exclusion_proof(

--- a/onchain/aiken/validators/fraud-proof/non-existent-input/step.ak
+++ b/onchain/aiken/validators/fraud-proof/non-existent-input/step.ak
@@ -4,12 +4,15 @@ use aiken/builtin
 use aiken/collection/list
 use aiken/crypto.{ScriptHash}
 use cardano/assets.{PolicyId}
-use cardano/transaction.{OutputReference, Transaction}
+use cardano/transaction.{Input, OutputReference, Transaction}
 use midgard/common/utils.{verify_hash_32}
 use midgard/computation_thread.{StepDatum}
-use midgard/fraud_proof/common/types.{MembershipProofInputs}
+use midgard/fraud_proof/common/types.{
+  ExclusionProofInputTx, ExclusionProofUtxo, MembershipProofInputs,
+}
 use midgard/fraud_proof/common/utils.{
-  get_singleton_ct_token, get_tx_root_validate_block_hash, handle_cancel,
+  get_prev_utxo_root, get_singleton_ct_token, get_tx_root_validate_block_hash,
+  handle_cancel, validate_exclusion_proof, validate_exclusion_utxo_proof,
   validate_final_step_output, validate_membership_proof,
 } as fraud_proof_utils
 use midgard/fraud_proof/non_existing_input/step.{
@@ -23,7 +26,7 @@ use midgard/fraud_proof/non_existing_input/step.{
 //   Inputs (tx_in1): [UTxO_A]
 //   Outputs (tx_out1): [UTxO_B, UTxO_C]
 
-// Transaction2 (tx2):
+// Transaction2 (tx2)
 //   Inputs (tx_in2): [UTxO_A]  <- Same UTxO as tx1
 //   Outputs (tx_out2): [UTxO_D]
 
@@ -31,7 +34,11 @@ validator main(
   // Fraud proof token policy
   fraud_proof_token_policy: PolicyId,
   // Script hash of stake validator (forwarded merkle proof logic)
-  plutarch_midgard_merkle_validator: ScriptHash,
+  plutarch_midgard_merkle_validator_inclusion: ScriptHash,
+  // Script hash of stake validator (forwarded merkle proof logic)
+  plutarch_midgard_merkle_validator_utxo_exclusion: ScriptHash,
+  // Script hash of stake validator (forwarded merkle proof logic)
+  plutarch_midgard_merkle_validator_exclusion: ScriptHash,
   // Computation thread token policy
   ct_token_policy_id: PolicyId,
 ) {
@@ -67,6 +74,10 @@ validator main(
         bad_tx_body,
         bad_spend_inputs,
         bad_input,
+        bad_input_utxo_info_hash,
+        bad_input_utxo_to_root_proof_path,
+        bad_input_tx_info_hash,
+        bad_input_tx_to_root_proof_path,
         index_output,
         computation_thread_redeemer_index,
       } -> {
@@ -84,7 +95,7 @@ validator main(
         expect
           validate_membership_proof(
             tx,
-            plutarch_midgard_merkle_validator,
+            plutarch_midgard_merkle_validator_inclusion,
             MembershipProofInputs {
               tx_root: extracted_tx_root,
               tx_hash: bad_tx_hash,
@@ -102,9 +113,35 @@ validator main(
 
         // TODO: exclusion proof that bad_input is not in the block's prev_utxos_root.
         expect True
+        let extracted_prev_utxo_root =
+          get_prev_utxo_root(tx, bad_state_queue_node_ref_input_index)
+        expect invalid_input: ByteArray = bad_input
+        expect
+          validate_exclusion_utxo_proof(
+            tx,
+            plutarch_midgard_merkle_validator_utxo_exclusion,
+            ExclusionProofUtxo {
+              utxo_root: extracted_prev_utxo_root,
+              invalid_utxo: invalid_input,
+              invalid_utxo_info_hash: bad_input_utxo_info_hash,
+              utxo_to_root_proof_path: bad_input_utxo_to_root_proof_path,
+            },
+          )
 
-        // TODO: exclusion proof that bad_input.tx_hash is not in the block's tx_root.
-        expect True
+        //TODO: exclusion proof that bad_input.tx_hash is not in the block's tx_root.
+        //TODO: ASK to George, should not we check that in case is present the index should be wrong?
+        expect invalid_input: Input = bad_input
+        expect
+          validate_exclusion_proof(
+            tx,
+            plutarch_midgard_merkle_validator_exclusion,
+            ExclusionProofInputTx {
+              tx_root: extracted_tx_root,
+              invalid_input_tx_hash: invalid_input.output_reference.transaction_id,
+              invalid_input_info_hash: bad_input_tx_info_hash,
+              input_to_root_proof_path: bad_input_tx_to_root_proof_path,
+            },
+          )
 
         // -------- Non-existent input: validation-specific logic END --------
         expect


### PR DESCRIPTION
- Added `get_prev_utxo_root` in the fraud proof to get also the previous utxo_root, this function does not check the validity of the block since it's done already in another function, will add it in case we want to use it stand alone

- Added `validate_exclusion_utxo_proof` to delegate the computation to a staking script

- Added `validate_exclusion_proof` to delegate the computation of the tx hash of bad input not being part of current block

- Validator is single step and requires more parameters now, 3 hashes of staking scripts

Question for @GeorgeFlerovsky 

Proving that the tx hash of the input is not in the current block is enough?

Could be a tx in the current block but the index maybe is not valid



