### PR TITLE
Use `VerificationKeyHash` for Settlement Queue's Operator

### DIFF
--- a/onchain/aiken/lib/midgard/settlement-queue.ak
+++ b/onchain/aiken/lib/midgard/settlement-queue.ak
@@ -1,4 +1,4 @@
-use aiken/crypto.{VerificationKey}
+use aiken/crypto.{VerificationKeyHash}
 use aiken/merkle_patricia_forestry as mpf
 use aiken_design_patterns/linked_list/unordered.{NodeDatum}
 use cardano/assets.{AssetName}
@@ -18,7 +18,7 @@ pub type NodeData {
 
 pub type ResolutionClaim {
   resolution_time: PosixTime,
-  operator: VerificationKey,
+  operator: VerificationKeyHash,
 }
 
 pub type SpendRedeemer {
@@ -29,7 +29,7 @@ pub type SpendRedeemer {
     hub_ref_input_index: Int,
     active_operators_node_input_index: Int,
     active_operators_redeemer_index: Int,
-    operator: VerificationKey,
+    operator: VerificationKeyHash,
     scheduler_ref_input_index: Int,
   }
   DisproveResolutionClaim {
@@ -37,7 +37,7 @@ pub type SpendRedeemer {
     node_output_index: Int,
     hub_ref_input_index: Int,
     operators_redeemer_index: Int,
-    operator: VerificationKey,
+    operator: VerificationKeyHash,
     operator_status: OperatorStatus,
     unresolved_event_ref_input_index: Int,
     unresolved_event_asset_name: AssetName,

--- a/onchain/aiken/plutus.json
+++ b/onchain/aiken/plutus.json
@@ -1369,8 +1369,8 @@
         }
       ]
     },
-    "VerificationKey": {
-      "title": "VerificationKey",
+    "VerificationKeyHash": {
+      "title": "VerificationKeyHash",
       "dataType": "bytes"
     },
     "aiken/interval/IntervalBound$Int": {
@@ -2796,7 +2796,7 @@
             },
             {
               "title": "operator",
-              "$ref": "#/definitions/VerificationKey"
+              "$ref": "#/definitions/VerificationKeyHash"
             },
             {
               "title": "scheduler_ref_input_index",
@@ -2827,7 +2827,7 @@
             },
             {
               "title": "operator",
-              "$ref": "#/definitions/VerificationKey"
+              "$ref": "#/definitions/VerificationKeyHash"
             },
             {
               "title": "operator_status",


### PR DESCRIPTION
Closes #237 

So far we had used `VerificationKey` in two places: settlement queue's operator, and also in `ledger-state`'s transaction witnesses.

Since in settlement queue we need to check for the operators' signatures, we should use `VerificationKeyHash` instead. The use of `VerificationKey` in `ledger-state` is valid as it's synonymous with L1.