### PR TITLE
Refine Node SDK

### DIFF
--- a/demo/midgard-node/pnpm-lock.yaml
+++ b/demo/midgard-node/pnpm-lock.yaml
@@ -15,16 +15,16 @@ importers:
         specifier: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz
         version: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@effect/experimental':
-        specifier: ^0.46.0
+        specifier: ^0.46.8
         version: 0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
       '@effect/opentelemetry':
-        specifier: ^0.44.6
+        specifier: ^0.44.12
         version: 0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.12)
       '@effect/platform':
-        specifier: ^0.80.0
+        specifier: ^0.80.21
         version: 0.80.21(effect@3.16.12)
       '@effect/platform-node':
-        specifier: ^0.80.0
+        specifier: ^0.80.3
         version: 0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       '@effect/sql':
         specifier: ^0.34.1
@@ -39,7 +39,7 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0
       '@lucid-evolution/lucid':
-        specifier: ^0.4.23
+        specifier: ^0.4.29
         version: 0.4.29(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@opentelemetry/api':
         specifier: ^1.9.0
@@ -66,10 +66,10 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       dotenv:
-        specifier: ^16.4.7
+        specifier: ^16.6.1
         version: 16.6.1
       effect:
-        specifier: ^3.14.22
+        specifier: ^3.16.12
         version: 3.16.12
       lru-cache:
         specifier: ^11.1.0
@@ -78,32 +78,32 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       vitest:
-        specifier: ^3.0.7
+        specifier: ^3.2.4
         version: 3.2.4(@types/node@22.16.0)
     devDependencies:
       '@commander-js/extra-typings':
         specifier: ^13.1.0
         version: 13.1.0(commander@13.1.0)
       '@effect/vitest':
-        specifier: ^0.22.0
+        specifier: ^0.22.5
         version: 0.22.5(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))
       '@types/express':
-        specifier: ^5.0.0
+        specifier: ^5.0.3
         version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: ^22.13.5
+        specifier: ^22.16.0
         version: 22.16.0
       prettier:
-        specifier: ^3.5.2
+        specifier: ^3.6.2
         version: 3.6.2
       tsup:
-        specifier: ^8.4.0
+        specifier: ^8.5.0
         version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
@@ -115,7 +115,7 @@ packages:
     resolution: {integrity: sha512-yEie4HFRoQS+ShbEYGNcVEQKFvnClXHFEysYT7lqoL1FGVxwvWWTBsctsEXolUIvusslztzrnJyUG67KGljBKw==}
 
   '@al-ft/midgard-sdk@file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz':
-    resolution: {integrity: sha512-bKvWKUpgpiO+wv1VVTC1yOv76Jkw0iIyO4VBVm1I/r/u1ZnCab1XnnlLk1GxapB0nLmKWk3m3DRWoTry2cOwBA==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
+    resolution: {integrity: sha512-aJZOPsMAPBIRZy9Usi3Rn0kLQofhJ7c+RHnaDOv5HjGw6NTkEkJoeQaTIJbmKGoUV9QLtYnYXN4ZKiP1FhznlA==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
     version: 0.1.0
 
   '@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2':
@@ -341,152 +341,158 @@ packages:
   '@emurgo/cardano-message-signing-nodejs@1.1.0':
     resolution: {integrity: sha512-PQRc8K8wZshEdmQenNUzVtiI8oJNF/1uAnBhidee5C4o1l2mDLOW+ur46HWHIFKQ6x8mSJTllcjMscHgzju0gQ==}
 
-  '@esbuild/aix-ppc64@0.25.5':
-    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
+  '@esbuild/aix-ppc64@0.25.6':
+    resolution: {integrity: sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.5':
-    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
+  '@esbuild/android-arm64@0.25.6':
+    resolution: {integrity: sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.5':
-    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
+  '@esbuild/android-arm@0.25.6':
+    resolution: {integrity: sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.5':
-    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
+  '@esbuild/android-x64@0.25.6':
+    resolution: {integrity: sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.5':
-    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
+  '@esbuild/darwin-arm64@0.25.6':
+    resolution: {integrity: sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.5':
-    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
+  '@esbuild/darwin-x64@0.25.6':
+    resolution: {integrity: sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.5':
-    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
+  '@esbuild/freebsd-arm64@0.25.6':
+    resolution: {integrity: sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.5':
-    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
+  '@esbuild/freebsd-x64@0.25.6':
+    resolution: {integrity: sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.5':
-    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
+  '@esbuild/linux-arm64@0.25.6':
+    resolution: {integrity: sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.5':
-    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
+  '@esbuild/linux-arm@0.25.6':
+    resolution: {integrity: sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.5':
-    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
+  '@esbuild/linux-ia32@0.25.6':
+    resolution: {integrity: sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.5':
-    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
+  '@esbuild/linux-loong64@0.25.6':
+    resolution: {integrity: sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.5':
-    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
+  '@esbuild/linux-mips64el@0.25.6':
+    resolution: {integrity: sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.5':
-    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
+  '@esbuild/linux-ppc64@0.25.6':
+    resolution: {integrity: sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.5':
-    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
+  '@esbuild/linux-riscv64@0.25.6':
+    resolution: {integrity: sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.5':
-    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
+  '@esbuild/linux-s390x@0.25.6':
+    resolution: {integrity: sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.5':
-    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
+  '@esbuild/linux-x64@0.25.6':
+    resolution: {integrity: sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
+  '@esbuild/netbsd-arm64@0.25.6':
+    resolution: {integrity: sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.5':
-    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
+  '@esbuild/netbsd-x64@0.25.6':
+    resolution: {integrity: sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
+  '@esbuild/openbsd-arm64@0.25.6':
+    resolution: {integrity: sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.5':
-    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
+  '@esbuild/openbsd-x64@0.25.6':
+    resolution: {integrity: sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.25.5':
-    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
+  '@esbuild/openharmony-arm64@0.25.6':
+    resolution: {integrity: sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.6':
+    resolution: {integrity: sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.5':
-    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
+  '@esbuild/win32-arm64@0.25.6':
+    resolution: {integrity: sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.5':
-    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
+  '@esbuild/win32-ia32@0.25.6':
+    resolution: {integrity: sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.5':
-    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
+  '@esbuild/win32-x64@0.25.6':
+    resolution: {integrity: sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1384,8 +1390,8 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.25.5:
-    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
+  esbuild@0.25.6:
+    resolution: {integrity: sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2576,79 +2582,82 @@ snapshots:
 
   '@emurgo/cardano-message-signing-nodejs@1.1.0': {}
 
-  '@esbuild/aix-ppc64@0.25.5':
+  '@esbuild/aix-ppc64@0.25.6':
     optional: true
 
-  '@esbuild/android-arm64@0.25.5':
+  '@esbuild/android-arm64@0.25.6':
     optional: true
 
-  '@esbuild/android-arm@0.25.5':
+  '@esbuild/android-arm@0.25.6':
     optional: true
 
-  '@esbuild/android-x64@0.25.5':
+  '@esbuild/android-x64@0.25.6':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.5':
+  '@esbuild/darwin-arm64@0.25.6':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.5':
+  '@esbuild/darwin-x64@0.25.6':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.5':
+  '@esbuild/freebsd-arm64@0.25.6':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.5':
+  '@esbuild/freebsd-x64@0.25.6':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.5':
+  '@esbuild/linux-arm64@0.25.6':
     optional: true
 
-  '@esbuild/linux-arm@0.25.5':
+  '@esbuild/linux-arm@0.25.6':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.5':
+  '@esbuild/linux-ia32@0.25.6':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.5':
+  '@esbuild/linux-loong64@0.25.6':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.5':
+  '@esbuild/linux-mips64el@0.25.6':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.5':
+  '@esbuild/linux-ppc64@0.25.6':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.5':
+  '@esbuild/linux-riscv64@0.25.6':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.5':
+  '@esbuild/linux-s390x@0.25.6':
     optional: true
 
-  '@esbuild/linux-x64@0.25.5':
+  '@esbuild/linux-x64@0.25.6':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.5':
+  '@esbuild/netbsd-arm64@0.25.6':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.5':
+  '@esbuild/netbsd-x64@0.25.6':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.5':
+  '@esbuild/openbsd-arm64@0.25.6':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.5':
+  '@esbuild/openbsd-x64@0.25.6':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.5':
+  '@esbuild/openharmony-arm64@0.25.6':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.5':
+  '@esbuild/sunos-x64@0.25.6':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.5':
+  '@esbuild/win32-arm64@0.25.6':
     optional: true
 
-  '@esbuild/win32-x64@0.25.5':
+  '@esbuild/win32-ia32@0.25.6':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.6':
     optional: true
 
   '@ethereumjs/mpt@7.0.0-alpha.1':
@@ -3455,9 +3464,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bundle-require@5.1.0(esbuild@0.25.5):
+  bundle-require@5.1.0(esbuild@0.25.6):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.6
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -3627,33 +3636,34 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.25.5:
+  esbuild@0.25.6:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.5
-      '@esbuild/android-arm': 0.25.5
-      '@esbuild/android-arm64': 0.25.5
-      '@esbuild/android-x64': 0.25.5
-      '@esbuild/darwin-arm64': 0.25.5
-      '@esbuild/darwin-x64': 0.25.5
-      '@esbuild/freebsd-arm64': 0.25.5
-      '@esbuild/freebsd-x64': 0.25.5
-      '@esbuild/linux-arm': 0.25.5
-      '@esbuild/linux-arm64': 0.25.5
-      '@esbuild/linux-ia32': 0.25.5
-      '@esbuild/linux-loong64': 0.25.5
-      '@esbuild/linux-mips64el': 0.25.5
-      '@esbuild/linux-ppc64': 0.25.5
-      '@esbuild/linux-riscv64': 0.25.5
-      '@esbuild/linux-s390x': 0.25.5
-      '@esbuild/linux-x64': 0.25.5
-      '@esbuild/netbsd-arm64': 0.25.5
-      '@esbuild/netbsd-x64': 0.25.5
-      '@esbuild/openbsd-arm64': 0.25.5
-      '@esbuild/openbsd-x64': 0.25.5
-      '@esbuild/sunos-x64': 0.25.5
-      '@esbuild/win32-arm64': 0.25.5
-      '@esbuild/win32-ia32': 0.25.5
-      '@esbuild/win32-x64': 0.25.5
+      '@esbuild/aix-ppc64': 0.25.6
+      '@esbuild/android-arm': 0.25.6
+      '@esbuild/android-arm64': 0.25.6
+      '@esbuild/android-x64': 0.25.6
+      '@esbuild/darwin-arm64': 0.25.6
+      '@esbuild/darwin-x64': 0.25.6
+      '@esbuild/freebsd-arm64': 0.25.6
+      '@esbuild/freebsd-x64': 0.25.6
+      '@esbuild/linux-arm': 0.25.6
+      '@esbuild/linux-arm64': 0.25.6
+      '@esbuild/linux-ia32': 0.25.6
+      '@esbuild/linux-loong64': 0.25.6
+      '@esbuild/linux-mips64el': 0.25.6
+      '@esbuild/linux-ppc64': 0.25.6
+      '@esbuild/linux-riscv64': 0.25.6
+      '@esbuild/linux-s390x': 0.25.6
+      '@esbuild/linux-x64': 0.25.6
+      '@esbuild/netbsd-arm64': 0.25.6
+      '@esbuild/netbsd-x64': 0.25.6
+      '@esbuild/openbsd-arm64': 0.25.6
+      '@esbuild/openbsd-x64': 0.25.6
+      '@esbuild/openharmony-arm64': 0.25.6
+      '@esbuild/sunos-x64': 0.25.6
+      '@esbuild/win32-arm64': 0.25.6
+      '@esbuild/win32-ia32': 0.25.6
+      '@esbuild/win32-x64': 0.25.6
 
   escape-string-regexp@2.0.0: {}
 
@@ -4317,12 +4327,12 @@ snapshots:
 
   tsup@8.5.0(postcss@8.5.6)(typescript@5.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.5)
+      bundle-require: 5.1.0(esbuild@0.25.6)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.1
-      esbuild: 0.25.5
+      esbuild: 0.25.6
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -4407,7 +4417,7 @@ snapshots:
 
   vite@6.3.5(@types/node@22.16.0):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.6
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6

--- a/demo/midgard-node/pnpm-lock.yaml
+++ b/demo/midgard-node/pnpm-lock.yaml
@@ -16,22 +16,22 @@ importers:
         version: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@effect/experimental':
         specifier: ^0.46.0
-        version: 0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
+        version: 0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
       '@effect/opentelemetry':
         specifier: ^0.44.6
-        version: 0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.33.0)(effect@3.15.2)
+        version: 0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.12)
       '@effect/platform':
         specifier: ^0.80.0
-        version: 0.80.21(effect@3.15.2)
+        version: 0.80.21(effect@3.16.12)
       '@effect/platform-node':
         specifier: ^0.80.0
-        version: 0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)
+        version: 0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       '@effect/sql':
         specifier: ^0.34.1
-        version: 0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
+        version: 0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
       '@effect/sql-pg':
         specifier: ^0.35.1
-        version: 0.35.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)
+        version: 0.35.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       '@ethereumjs/mpt':
         specifier: 7.0.0-alpha.1
         version: 7.0.0-alpha.1
@@ -40,7 +40,7 @@ importers:
         version: 9.1.0
       '@lucid-evolution/lucid':
         specifier: ^0.4.23
-        version: 0.4.27(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
+        version: 0.4.29(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -67,10 +67,10 @@ importers:
         version: 13.1.0
       dotenv:
         specifier: ^16.4.7
-        version: 16.5.0
+        version: 16.6.1
       effect:
         specifier: ^3.14.22
-        version: 3.15.2
+        version: 3.16.12
       lru-cache:
         specifier: ^11.1.0
         version: 11.1.0
@@ -79,35 +79,35 @@ importers:
         version: 6.0.1
       vitest:
         specifier: ^3.0.7
-        version: 3.1.3(@types/node@22.15.19)
+        version: 3.2.4(@types/node@22.16.0)
     devDependencies:
       '@commander-js/extra-typings':
         specifier: ^13.1.0
         version: 13.1.0(commander@13.1.0)
       '@effect/vitest':
         specifier: ^0.22.0
-        version: 0.22.2(effect@3.15.2)(vitest@3.1.3(@types/node@22.15.19))
+        version: 0.22.5(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))
       '@types/express':
         specifier: ^5.0.0
-        version: 5.0.2
+        version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
         specifier: ^22.13.5
-        version: 22.15.19
+        version: 22.16.0
       prettier:
         specifier: ^3.5.2
-        version: 3.5.3
+        version: 3.6.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.0(postcss@8.5.3)(typescript@5.8.3)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)
       typescript:
         specifier: ^5.7.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.19)
+        version: 6.3.5(@types/node@22.16.0)
 
 packages:
 
@@ -115,7 +115,7 @@ packages:
     resolution: {integrity: sha512-yEie4HFRoQS+ShbEYGNcVEQKFvnClXHFEysYT7lqoL1FGVxwvWWTBsctsEXolUIvusslztzrnJyUG67KGljBKw==}
 
   '@al-ft/midgard-sdk@file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz':
-    resolution: {integrity: sha512-Uf2tM6glrW0SUaEisMLkUeHAOEwBX6IIa3ecm76UXckltibb2WNCnVJ6b3sM6JOCSc9+B6YEhlbqR3Ysf4pz6A==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
+    resolution: {integrity: sha512-bKvWKUpgpiO+wv1VVTC1yOv76Jkw0iIyO4VBVm1I/r/u1ZnCab1XnnlLk1GxapB0nLmKWk3m3DRWoTry2cOwBA==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
     version: 0.1.0
 
   '@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2':
@@ -150,8 +150,8 @@ packages:
     resolution: {integrity: sha512-e7QVLF+dQMIv9p+p5CWQjMfBmkERYRa2wK2AjyehQZCJnecZ0gvTbRqewdX5VW4mVXf6KUfFyphsxWK46Pg6LA==}
     engines: {node: '>=14'}
 
-  '@cardano-sdk/core@0.45.8':
-    resolution: {integrity: sha512-Yh0vSzqwtzpXcwhZ7194rB09JnHO23RLIZHWXxRWY6iHeSHg5HzGLr05KllrNGfkHC0AUbKCoyCoYfMDKaDFpg==}
+  '@cardano-sdk/core@0.45.10':
+    resolution: {integrity: sha512-PU/onQuPgsy0CtFKDlHcozGHMTHrigWztTmKq54tL0TdWRcClXbMh5Q63ALcP388ZouPC1nKomOAooVgyrrEfw==}
     engines: {node: '>=16.20.2'}
     peerDependencies:
       rxjs: ^7.4.0
@@ -230,11 +230,11 @@ packages:
       '@effect/sql': ^0.34.1
       effect: ^3.14.22
 
-  '@effect/experimental@0.46.3':
-    resolution: {integrity: sha512-DkKWiSnMEF2EDgKodwPdChdTPd4T7s437DFhL3kWgn4dYAIEa6nlO5HmXEXxoQVK5oo/gW5u1Cj3GmvwNlohJQ==}
+  '@effect/experimental@0.46.8':
+    resolution: {integrity: sha512-2XasqFLQZFy2PGybFdBjgflXFfPuorc/6DMxogeTDHknZa0RH4KoJQQlWaCngbKMsZrZcv0jV+Zi4aDZsVGl7g==}
     peerDependencies:
-      '@effect/platform': ^0.82.3
-      effect: ^3.15.2
+      '@effect/platform': ^0.82.8
+      effect: ^3.15.4
       ioredis: ^5
       lmdb: ^3
     peerDependenciesMeta:
@@ -329,10 +329,10 @@ packages:
       '@effect/platform': ^0.81.1
       effect: ^3.14.22
 
-  '@effect/vitest@0.22.2':
-    resolution: {integrity: sha512-EZudN92GRXqD1FLk7wW5yjW3HN5BEWnDoBoi01Pn5os+8+RxLU8Bk4cXcjhgWUDsHjoPzGRJTn42x6GvR7lTkA==}
+  '@effect/vitest@0.22.5':
+    resolution: {integrity: sha512-umf9pPPaAP9ecoPPOEvMhxmppFAaEyCE2WF8sQ7tzQ9Vf2BwHWwoXAN1sx+j9v9jdLbeE10UQcSKHI6Mtrhk1g==}
     peerDependencies:
-      effect: ^3.15.2
+      effect: ^3.15.5
       vitest: ^3.0.0
 
   '@emurgo/cardano-message-signing-browser@1.1.0':
@@ -341,152 +341,152 @@ packages:
   '@emurgo/cardano-message-signing-nodejs@1.1.0':
     resolution: {integrity: sha512-PQRc8K8wZshEdmQenNUzVtiI8oJNF/1uAnBhidee5C4o1l2mDLOW+ur46HWHIFKQ6x8mSJTllcjMscHgzju0gQ==}
 
-  '@esbuild/aix-ppc64@0.25.4':
-    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+  '@esbuild/aix-ppc64@0.25.5':
+    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.4':
-    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+  '@esbuild/android-arm64@0.25.5':
+    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.4':
-    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+  '@esbuild/android-arm@0.25.5':
+    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.4':
-    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+  '@esbuild/android-x64@0.25.5':
+    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.4':
-    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+  '@esbuild/darwin-arm64@0.25.5':
+    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.4':
-    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+  '@esbuild/darwin-x64@0.25.5':
+    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.4':
-    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+  '@esbuild/freebsd-arm64@0.25.5':
+    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.4':
-    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+  '@esbuild/freebsd-x64@0.25.5':
+    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.4':
-    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+  '@esbuild/linux-arm64@0.25.5':
+    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.4':
-    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+  '@esbuild/linux-arm@0.25.5':
+    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.4':
-    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+  '@esbuild/linux-ia32@0.25.5':
+    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.4':
-    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+  '@esbuild/linux-loong64@0.25.5':
+    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.4':
-    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+  '@esbuild/linux-mips64el@0.25.5':
+    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.4':
-    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+  '@esbuild/linux-ppc64@0.25.5':
+    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.4':
-    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+  '@esbuild/linux-riscv64@0.25.5':
+    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.4':
-    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+  '@esbuild/linux-s390x@0.25.5':
+    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.4':
-    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+  '@esbuild/linux-x64@0.25.5':
+    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+  '@esbuild/netbsd-arm64@0.25.5':
+    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.4':
-    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+  '@esbuild/netbsd-x64@0.25.5':
+    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+  '@esbuild/openbsd-arm64@0.25.5':
+    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.4':
-    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+  '@esbuild/openbsd-x64@0.25.5':
+    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.25.4':
-    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+  '@esbuild/sunos-x64@0.25.5':
+    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.4':
-    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+  '@esbuild/win32-arm64@0.25.5':
+    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.4':
-    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+  '@esbuild/win32-ia32@0.25.5':
+    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.4':
-    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+  '@esbuild/win32-x64@0.25.5':
+    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -563,6 +563,14 @@ packages:
       '@harmoniclabs/pair': ^1.0.0
       '@harmoniclabs/plutus-data': ^1.2.4
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -579,23 +587,18 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
 
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -609,26 +612,26 @@ packages:
   '@lucid-evolution/crc8@0.1.8':
     resolution: {integrity: sha512-88+/S6n+sPgxYtG05rvbJDVb8MoFGzckkR3p26uGrzngYzlJGfxBWIzNhVwfI2mgINPo2C5lkZW3GYnfY0MjuA==}
 
-  '@lucid-evolution/lucid@0.4.27':
-    resolution: {integrity: sha512-/QXlF5dtCEENjqHSmqhqdTEdgG8abWCKa8AUHjkyJfLpXennk/egehrcRAe2jyPuZVh48e6nmdPBUt5O+zbtVg==}
+  '@lucid-evolution/lucid@0.4.29':
+    resolution: {integrity: sha512-+9pXlHivIGE4xJC6EZ62vtOBfgHgPpbJHgd7d6Ztk3lmbBwsM1PZVQ1WSE2upXSvqGE8KT/99IxmZ3kKfbtDUg==}
 
   '@lucid-evolution/plutus@0.1.29':
     resolution: {integrity: sha512-GHmq9Pso+xeFszwKAd9jvRFnmnV4fRKdm+OHYLrS58yh3uazKr9VR+amtT9SmKufoLy/gNo5sL7i6gcNSW+yIg==}
 
-  '@lucid-evolution/provider@0.1.89':
-    resolution: {integrity: sha512-i4xdEN6iwlb/0UQw/1eHe+mlFGO38LbLcvQZppMSN70oRLoIkQBoGFk+yHiOnXiIjyO1idkI92Q1CeAKC0WQ8g==}
+  '@lucid-evolution/provider@0.1.90':
+    resolution: {integrity: sha512-8vzVDlWJiDfuvuE2Un18N5uTK8qDkVB5GiglwoDV/qgBNRljQjiih53LbhcGa4KMXgufjZNyNDH854jFkJ95cg==}
 
   '@lucid-evolution/sign_data@0.1.25':
     resolution: {integrity: sha512-ZDDl3SyO3Lf+/ji9u0Fg6I9oNs+tW//aHkgz4NlS+9xbx2bT9YU+mV9ZLLjWSZVGTb0TbzT4NGvVqdgRNspdYQ==}
 
-  '@lucid-evolution/uplc@0.2.19':
-    resolution: {integrity: sha512-t0UhCCD6Dxlz82fLjkiECWWlLwEXg2VzG91Lef7AKpsAF1KnvhgiYyGrhljJlgy29GTNV/H06+Rxir0O0u6rkw==}
+  '@lucid-evolution/uplc@0.2.20':
+    resolution: {integrity: sha512-+40qeHmjMnM4Sjdq9JAf190a1t3TMbV1vegVLQGqt2AouOkIunZfziBZwuaqcgUVVbynW+j2Qx2ijK83Pap4XQ==}
 
-  '@lucid-evolution/utils@0.1.65':
-    resolution: {integrity: sha512-1YeinOiv9aKUhF86aTfvhbi2Nq6Mgb1AtUK+DA3aOHHR8eoVBoIb/Elw9fyH1CFAVbtBQafBI9Or3Pd66D4lkQ==}
+  '@lucid-evolution/utils@0.1.66':
+    resolution: {integrity: sha512-sp6vsxrc0u9rYgb4ExRP4LRQM0oK6mVxqt70axK0T4DSS06KYtCqUWX6kjcOHY8jxDGfjK5RLh9hBY+Gul4OSQ==}
 
-  '@lucid-evolution/wallet@0.1.71':
-    resolution: {integrity: sha512-AXRx4vSkSFdT2v/lAOEyniXo1hr5KD11wrsKVTIbS6jK1FDlLbd2xH5R5ucJRJH6zZGtfPBnSBCUoM05tKUkOg==}
+  '@lucid-evolution/wallet@0.1.72':
+    resolution: {integrity: sha512-keGeDV4jUX2MAld79zAGja4mFNQ9FP4HJM8OB8DEnakewTVG4fk38SMSfvuQAh6yH8ZxTNoGUphrMSeVFU4OjQ==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -666,8 +669,8 @@ packages:
   '@multiformats/mafmt@12.1.6':
     resolution: {integrity: sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==}
 
-  '@multiformats/multiaddr@12.4.0':
-    resolution: {integrity: sha512-FL7yBTLijJ5JkO044BGb2msf+uJLrwpD6jD6TkXlbjA9N12+18HT40jvd4o5vL4LOJMc86dPX6tGtk/uI9kYKg==}
+  '@multiformats/multiaddr@12.5.1':
+    resolution: {integrity: sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -784,8 +787,8 @@ packages:
     resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
     engines: {node: '>=14'}
 
-  '@opentelemetry/semantic-conventions@1.33.0':
-    resolution: {integrity: sha512-TIpZvE8fiEILFfTlfPnltpBaD3d9/+uQHVCyC3vfdh6WfCXKhNFzoP5RyDDIndfvZC5GrA4pyEDNyjPloJud+w==}
+  '@opentelemetry/semantic-conventions@1.34.0':
+    resolution: {integrity: sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==}
     engines: {node: '>=14'}
 
   '@parcel/watcher-android-arm64@2.5.1':
@@ -904,111 +907,111 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@rollup/rollup-android-arm-eabi@4.41.0':
-    resolution: {integrity: sha512-KxN+zCjOYHGwCl4UCtSfZ6jrq/qi88JDUtiEFk8LELEHq2Egfc/FgW+jItZiOLRuQfb/3xJSgFuNPC9jzggX+A==}
+  '@rollup/rollup-android-arm-eabi@4.44.2':
+    resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.41.0':
-    resolution: {integrity: sha512-yDvqx3lWlcugozax3DItKJI5j05B0d4Kvnjx+5mwiUpWramVvmAByYigMplaoAQ3pvdprGCTCE03eduqE/8mPQ==}
+  '@rollup/rollup-android-arm64@4.44.2':
+    resolution: {integrity: sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.41.0':
-    resolution: {integrity: sha512-2KOU574vD3gzcPSjxO0eyR5iWlnxxtmW1F5CkNOHmMlueKNCQkxR6+ekgWyVnz6zaZihpUNkGxjsYrkTJKhkaw==}
+  '@rollup/rollup-darwin-arm64@4.44.2':
+    resolution: {integrity: sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.41.0':
-    resolution: {integrity: sha512-gE5ACNSxHcEZyP2BA9TuTakfZvULEW4YAOtxl/A/YDbIir/wPKukde0BNPlnBiP88ecaN4BJI2TtAd+HKuZPQQ==}
+  '@rollup/rollup-darwin-x64@4.44.2':
+    resolution: {integrity: sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.41.0':
-    resolution: {integrity: sha512-GSxU6r5HnWij7FoSo7cZg3l5GPg4HFLkzsFFh0N/b16q5buW1NAWuCJ+HMtIdUEi6XF0qH+hN0TEd78laRp7Dg==}
+  '@rollup/rollup-freebsd-arm64@4.44.2':
+    resolution: {integrity: sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.41.0':
-    resolution: {integrity: sha512-KGiGKGDg8qLRyOWmk6IeiHJzsN/OYxO6nSbT0Vj4MwjS2XQy/5emsmtoqLAabqrohbgLWJ5GV3s/ljdrIr8Qjg==}
+  '@rollup/rollup-freebsd-x64@4.44.2':
+    resolution: {integrity: sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.41.0':
-    resolution: {integrity: sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+    resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.41.0':
-    resolution: {integrity: sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+    resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.41.0':
-    resolution: {integrity: sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw==}
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+    resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.41.0':
-    resolution: {integrity: sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ==}
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
+    resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.41.0':
-    resolution: {integrity: sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+    resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.41.0':
-    resolution: {integrity: sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+    resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.41.0':
-    resolution: {integrity: sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+    resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.41.0':
-    resolution: {integrity: sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A==}
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+    resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.41.0':
-    resolution: {integrity: sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw==}
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+    resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.41.0':
-    resolution: {integrity: sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==}
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
+    resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.41.0':
-    resolution: {integrity: sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg==}
+  '@rollup/rollup-linux-x64-musl@4.44.2':
+    resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.41.0':
-    resolution: {integrity: sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg==}
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+    resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.41.0':
-    resolution: {integrity: sha512-tmazCrAsKzdkXssEc65zIE1oC6xPHwfy9d5Ta25SRCDOZS+I6RypVVShWALNuU9bxIfGA0aqrmzlzoM5wO5SPQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+    resolution: {integrity: sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.41.0':
-    resolution: {integrity: sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA==}
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
+    resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
     cpu: [x64]
     os: [win32]
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
-  '@scure/base@1.2.5':
-    resolution: {integrity: sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==}
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
@@ -1031,26 +1034,32 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
-  '@types/body-parser@1.19.5':
-    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/dns-packet@5.6.5':
     resolution: {integrity: sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/express-serve-static-core@5.0.6':
     resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
 
-  '@types/express@5.0.2':
-    resolution: {integrity: sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==}
+  '@types/express@5.0.3':
+    resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
 
-  '@types/http-errors@2.0.4':
-    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1070,8 +1079,8 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/node@22.15.19':
-    resolution: {integrity: sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==}
+  '@types/node@22.16.0':
+    resolution: {integrity: sha512-B2egV9wALML1JCpv3VQoQ+yesQKAmNMBIAY7OteVrikcOcAkWm+dGL6qpeCktPjAv6N1JLnhbNiqS35UpFyBsQ==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -1079,11 +1088,11 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/send@0.17.4':
-    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+  '@types/send@0.17.5':
+    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
 
-  '@types/serve-static@1.15.7':
-    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+  '@types/serve-static@1.15.8':
+    resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1094,44 +1103,47 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
-  '@vitest/expect@3.1.3':
-    resolution: {integrity: sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==}
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/mocker@3.1.3':
-    resolution: {integrity: sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==}
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.1.3':
-    resolution: {integrity: sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==}
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/runner@3.1.3':
-    resolution: {integrity: sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==}
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  '@vitest/snapshot@3.1.3':
-    resolution: {integrity: sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==}
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/spy@3.1.3':
-    resolution: {integrity: sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==}
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/utils@3.1.3':
-    resolution: {integrity: sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==}
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@zxing/text-encoding@0.9.0':
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
+
+  abort-error@1.0.1:
+    resolution: {integrity: sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==}
 
   abstract-level@1.0.4:
     resolution: {integrity: sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==}
     engines: {node: '>=12'}
 
-  acorn@8.14.1:
-    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1190,8 +1202,8 @@ packages:
   blake2b@2.1.4:
     resolution: {integrity: sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1290,8 +1302,8 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  create-hash@1.2.0:
-    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+  create-hash@1.1.3:
+    resolution: {integrity: sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==}
 
   create-hmac@1.1.7:
     resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
@@ -1337,8 +1349,8 @@ packages:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
 
-  dotenv@16.5.0:
-    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -1348,8 +1360,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  effect@3.15.2:
-    resolution: {integrity: sha512-0JNwvfs4Wwbo3f6IOydBFlp+zxuO8Iny2UAWNW3+FNn9x8FJf7q67QnQagUZgPl/BLl/xuPLVksrmNyIrJ8k/Q==}
+  effect@3.16.12:
+    resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1372,8 +1384,8 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.25.4:
-    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+  esbuild@0.25.5:
+    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1394,8 +1406,8 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
-  expect-type@1.2.1:
-    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
@@ -1409,8 +1421,8 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
-  fdir@6.4.4:
-    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1458,8 +1470,8 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.2:
-    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -1485,9 +1497,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hash-base@3.1.0:
-    resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
-    engines: {node: '>=4'}
+  hash-base@2.0.2:
+    resolution: {integrity: sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==}
 
   hashlru@2.3.0:
     resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
@@ -1550,6 +1561,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1565,8 +1579,8 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.1.0:
-    resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
 
   jest-diff@29.7.0:
@@ -1595,6 +1609,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
@@ -1637,8 +1654,8 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  loupe@3.1.3:
-    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+  loupe@3.1.4:
+    resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
 
   lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
@@ -1658,9 +1675,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  md5.js@1.3.5:
-    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -1670,8 +1684,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
 
   minimatch@9.0.5:
@@ -1699,8 +1713,8 @@ packages:
   msgpackr@1.11.4:
     resolution: {integrity: sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==}
 
-  multiformats@13.3.4:
-    resolution: {integrity: sha512-JXpM5p9TpJ/BHsUtmLaWuRN0ft0gJPGa6BhkX2KXjFHvkFQOQkDManoar3gx0JsTLNrOojBE2Mj4hFxohGnXZA==}
+  multiformats@13.3.7:
+    resolution: {integrity: sha512-meL9DERHj+fFVWoOX9fXqfcYcSpUfSYJPcFvDPKrxitICbwAoWR+Ut4j5NO9zAT917HUHLQmqzQbAsGNHlDcxQ==}
 
   multipasta@0.2.5:
     resolution: {integrity: sha512-c8eMDb1WwZcE02WVjHoOmUVk7fnKU/RmUcosHACglrWAuPQsEJv+E8430sXj6jNc1jHw0zrS16aCjQh4BcEb4A==}
@@ -1849,12 +1863,12 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pathval@2.0.0:
-    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
-  pbkdf2@3.1.2:
-    resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
+  pbkdf2@3.1.3:
+    resolution: {integrity: sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==}
     engines: {node: '>=0.12'}
 
   picocolors@1.1.1:
@@ -1897,16 +1911,16 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postgres@3.4.5:
-    resolution: {integrity: sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==}
+  postgres@3.4.7:
+    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1917,8 +1931,8 @@ packages:
   progress-events@1.0.1:
     resolution: {integrity: sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw==}
 
-  protobufjs@7.5.2:
-    resolution: {integrity: sha512-f2ls6rpO6G153Cy+o2XQ+Y0sARLOZ17+OGVLHrc3VUKcLHYKEKWbkSujdBWQXM7gKn5NTfp0XnRPZn1MIu8n9w==}
+  protobufjs@7.5.3:
+    resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -1933,10 +1947,6 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1955,11 +1965,11 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  ripemd160@2.0.2:
-    resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
+  ripemd160@2.0.1:
+    resolution: {integrity: sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==}
 
-  rollup@4.41.0:
-    resolution: {integrity: sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==}
+  rollup@4.44.2:
+    resolution: {integrity: sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1986,8 +1996,9 @@ packages:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
 
-  sha.js@2.4.11:
-    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
     hasBin: true
 
   shebang-command@2.0.0:
@@ -2038,9 +2049,6 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2048,6 +2056,9 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -2071,21 +2082,25 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.13:
-    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.0.2:
-    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
+
+  to-buffer@1.2.1:
+    resolution: {integrity: sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==}
+    engines: {node: '>= 0.4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2138,6 +2153,10 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -2158,12 +2177,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.9.0:
-    resolution: {integrity: sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==}
+  undici@7.11.0:
+    resolution: {integrity: sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==}
     engines: {node: '>=20.18.1'}
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -2172,8 +2188,8 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
-  vite-node@3.1.3:
-    resolution: {integrity: sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==}
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -2217,16 +2233,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.1.3:
-    resolution: {integrity: sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==}
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.1.3
-      '@vitest/ui': 3.1.3
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2294,8 +2310,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2316,9 +2332,9 @@ snapshots:
   '@al-ft/midgard-sdk@file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)':
     dependencies:
       '@aiken-lang/merkle-patricia-forestry': 1.2.0
-      '@lucid-evolution/lucid': 0.4.27(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
+      '@lucid-evolution/lucid': 0.4.29(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@noble/hashes': 1.8.0
-      effect: 3.15.2
+      effect: 3.16.12
     transitivePeerDependencies:
       - '@dcspark/cardano-multiplatform-lib-asmjs'
       - '@dcspark/cardano-multiplatform-lib-browser'
@@ -2352,9 +2368,9 @@ snapshots:
   '@biglup/is-cid@1.0.3':
     dependencies:
       '@multiformats/mafmt': 12.1.6
-      '@multiformats/multiaddr': 12.4.0
+      '@multiformats/multiaddr': 12.5.1
       iso-url: 1.2.1
-      multiformats: 13.3.4
+      multiformats: 13.3.7
       uint8arrays: 5.1.0
 
   '@cardano-ogmios/client@6.9.0':
@@ -2376,7 +2392,7 @@ snapshots:
 
   '@cardano-ogmios/schema@6.9.0': {}
 
-  '@cardano-sdk/core@0.45.8':
+  '@cardano-sdk/core@0.45.10':
     dependencies:
       '@biglup/is-cid': 1.0.3
       '@cardano-ogmios/client': 6.9.0
@@ -2384,7 +2400,7 @@ snapshots:
       '@cardano-sdk/crypto': 0.2.3
       '@cardano-sdk/util': 0.16.0
       '@foxglove/crc': 0.0.3
-      '@scure/base': 1.2.5
+      '@scure/base': 1.2.6
       fraction.js: 4.0.1
       ip-address: 9.0.5
       lodash: 4.17.21
@@ -2407,7 +2423,7 @@ snapshots:
       libsodium-wrappers-sumo: 0.7.15
       lodash: 4.17.21
       npm: 9.9.4
-      pbkdf2: 3.1.2
+      pbkdf2: 3.1.3
       ts-custom-error: 3.3.1
       ts-log: 2.2.7
 
@@ -2452,187 +2468,187 @@ snapshots:
     dependencies:
       commander: 13.1.0
 
-  '@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)':
+  '@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/platform': 0.80.21(effect@3.15.2)
-      '@effect/rpc': 0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      '@effect/sql': 0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      effect: 3.15.2
+      '@effect/platform': 0.80.21(effect@3.16.12)
+      '@effect/rpc': 0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      '@effect/sql': 0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      effect: 3.16.12
 
-  '@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)':
+  '@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/platform': 0.80.21(effect@3.15.2)
-      effect: 3.15.2
+      '@effect/platform': 0.80.21(effect@3.16.12)
+      effect: 3.16.12
       uuid: 11.1.0
 
-  '@effect/opentelemetry@0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.33.0)(effect@3.15.2)':
+  '@effect/opentelemetry@0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.12)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.33.0
-      effect: 3.15.2
+      '@opentelemetry/semantic-conventions': 1.34.0
+      effect: 3.16.12
     optionalDependencies:
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-web': 1.30.1(@opentelemetry/api@1.9.0)
 
-  '@effect/platform-node-shared@0.34.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)':
+  '@effect/platform-node-shared@0.34.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/cluster': 0.31.1(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)
-      '@effect/platform': 0.80.21(effect@3.15.2)
-      '@effect/rpc': 0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      '@effect/sql': 0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
+      '@effect/cluster': 0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.80.21(effect@3.16.12)
+      '@effect/rpc': 0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      '@effect/sql': 0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
       '@parcel/watcher': 2.5.1
-      effect: 3.15.2
+      effect: 3.16.12
       multipasta: 0.2.5
-      ws: 8.18.2
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)':
+  '@effect/platform-node@0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/cluster': 0.31.1(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)
-      '@effect/platform': 0.80.21(effect@3.15.2)
-      '@effect/platform-node-shared': 0.34.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)
-      '@effect/rpc': 0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      '@effect/sql': 0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      effect: 3.15.2
+      '@effect/cluster': 0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.80.21(effect@3.16.12)
+      '@effect/platform-node-shared': 0.34.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+      '@effect/rpc': 0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      '@effect/sql': 0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      effect: 3.16.12
       mime: 3.0.0
-      undici: 7.9.0
-      ws: 8.18.2
+      undici: 7.11.0
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.71.7(effect@3.15.2)':
+  '@effect/platform@0.71.7(effect@3.16.12)':
     dependencies:
-      effect: 3.15.2
+      effect: 3.16.12
       find-my-way-ts: 0.1.5
       multipasta: 0.2.5
 
-  '@effect/platform@0.80.21(effect@3.15.2)':
+  '@effect/platform@0.80.21(effect@3.16.12)':
     dependencies:
-      effect: 3.15.2
+      effect: 3.16.12
       find-my-way-ts: 0.1.5
       msgpackr: 1.11.4
       multipasta: 0.2.5
 
-  '@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)':
+  '@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/platform': 0.80.21(effect@3.15.2)
-      effect: 3.15.2
+      '@effect/platform': 0.80.21(effect@3.16.12)
+      effect: 3.16.12
 
-  '@effect/schema@0.66.16(effect@3.15.2)(fast-check@3.23.2)':
+  '@effect/schema@0.66.16(effect@3.16.12)(fast-check@3.23.2)':
     dependencies:
-      effect: 3.15.2
+      effect: 3.16.12
       fast-check: 3.23.2
 
-  '@effect/schema@0.68.27(effect@3.15.2)':
+  '@effect/schema@0.68.27(effect@3.16.12)':
     dependencies:
-      effect: 3.15.2
+      effect: 3.16.12
       fast-check: 3.23.2
 
-  '@effect/sql-pg@0.35.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(effect@3.15.2)':
+  '@effect/sql-pg@0.35.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/experimental': 0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      '@effect/platform': 0.80.21(effect@3.15.2)
-      '@effect/sql': 0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      '@opentelemetry/semantic-conventions': 1.33.0
-      effect: 3.15.2
-      postgres: 3.4.5
+      '@effect/experimental': 0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.80.21(effect@3.16.12)
+      '@effect/sql': 0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      '@opentelemetry/semantic-conventions': 1.34.0
+      effect: 3.16.12
+      postgres: 3.4.7
 
-  '@effect/sql@0.34.1(@effect/experimental@0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2))(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)':
+  '@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/experimental': 0.46.3(@effect/platform@0.80.21(effect@3.15.2))(effect@3.15.2)
-      '@effect/platform': 0.80.21(effect@3.15.2)
-      '@opentelemetry/semantic-conventions': 1.33.0
-      effect: 3.15.2
+      '@effect/experimental': 0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.80.21(effect@3.16.12)
+      '@opentelemetry/semantic-conventions': 1.34.0
+      effect: 3.16.12
       uuid: 11.1.0
 
-  '@effect/vitest@0.22.2(effect@3.15.2)(vitest@3.1.3(@types/node@22.15.19))':
+  '@effect/vitest@0.22.5(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))':
     dependencies:
-      effect: 3.15.2
-      vitest: 3.1.3(@types/node@22.15.19)
+      effect: 3.16.12
+      vitest: 3.2.4(@types/node@22.16.0)
 
   '@emurgo/cardano-message-signing-browser@1.1.0': {}
 
   '@emurgo/cardano-message-signing-nodejs@1.1.0': {}
 
-  '@esbuild/aix-ppc64@0.25.4':
+  '@esbuild/aix-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm64@0.25.4':
+  '@esbuild/android-arm64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm@0.25.4':
+  '@esbuild/android-arm@0.25.5':
     optional: true
 
-  '@esbuild/android-x64@0.25.4':
+  '@esbuild/android-x64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.4':
+  '@esbuild/darwin-arm64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.4':
+  '@esbuild/darwin-x64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.4':
+  '@esbuild/freebsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.4':
+  '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.4':
+  '@esbuild/linux-arm64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm@0.25.4':
+  '@esbuild/linux-arm@0.25.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.4':
+  '@esbuild/linux-ia32@0.25.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.4':
+  '@esbuild/linux-loong64@0.25.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.4':
+  '@esbuild/linux-mips64el@0.25.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.4':
+  '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.4':
+  '@esbuild/linux-riscv64@0.25.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.4':
+  '@esbuild/linux-s390x@0.25.5':
     optional: true
 
-  '@esbuild/linux-x64@0.25.4':
+  '@esbuild/linux-x64@0.25.5':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.4':
+  '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.4':
+  '@esbuild/netbsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.4':
+  '@esbuild/openbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.4':
+  '@esbuild/openbsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.4':
+  '@esbuild/sunos-x64@0.25.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.4':
+  '@esbuild/win32-arm64@0.25.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.4':
+  '@esbuild/win32-ia32@0.25.5':
     optional: true
 
-  '@esbuild/win32-x64@0.25.4':
+  '@esbuild/win32-x64@0.25.5':
     optional: true
 
   '@ethereumjs/mpt@7.0.0-alpha.1':
@@ -2712,6 +2728,12 @@ snapshots:
       '@harmoniclabs/plutus-data': 1.2.6(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)
       '@harmoniclabs/uint8array-utils': 1.0.4
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2734,26 +2756,23 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@jridgewell/gen-mapping@0.3.8':
+  '@jridgewell/gen-mapping@0.3.12':
     dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/set-array@1.2.1': {}
+  '@jridgewell/sourcemap-codec@1.5.4': {}
 
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
-  '@jridgewell/trace-mapping@0.3.25':
+  '@jridgewell/trace-mapping@0.3.29':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -2769,21 +2788,21 @@ snapshots:
 
   '@lucid-evolution/crc8@0.1.8': {}
 
-  '@lucid-evolution/lucid@0.4.27(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)':
+  '@lucid-evolution/lucid@0.4.29(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)':
     dependencies:
       '@anastasia-labs/cardano-multiplatform-lib-browser': 6.0.2-3
       '@anastasia-labs/cardano-multiplatform-lib-nodejs': 6.0.2-3
-      '@effect/schema': 0.66.16(effect@3.15.2)(fast-check@3.23.2)
+      '@effect/schema': 0.66.16(effect@3.16.12)(fast-check@3.23.2)
       '@emurgo/cardano-message-signing-nodejs': 1.1.0
       '@lucid-evolution/core-types': 0.1.22
       '@lucid-evolution/core-utils': 0.1.16
       '@lucid-evolution/plutus': 0.1.29
-      '@lucid-evolution/provider': 0.1.89(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
+      '@lucid-evolution/provider': 0.1.90(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
       '@lucid-evolution/sign_data': 0.1.25
-      '@lucid-evolution/uplc': 0.2.19
-      '@lucid-evolution/utils': 0.1.65(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
-      '@lucid-evolution/wallet': 0.1.71(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
-      effect: 3.15.2
+      '@lucid-evolution/uplc': 0.2.20
+      '@lucid-evolution/utils': 0.1.66(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
+      '@lucid-evolution/wallet': 0.1.72(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
+      effect: 3.16.12
     transitivePeerDependencies:
       - '@dcspark/cardano-multiplatform-lib-asmjs'
       - '@dcspark/cardano-multiplatform-lib-browser'
@@ -2806,17 +2825,17 @@ snapshots:
       '@lucid-evolution/core-utils': 0.1.16
       '@sinclair/typebox': 0.32.35
 
-  '@lucid-evolution/provider@0.1.89(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)':
+  '@lucid-evolution/provider@0.1.90(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)':
     dependencies:
       '@anastasia-labs/cardano-multiplatform-lib-browser': 6.0.2-3
       '@anastasia-labs/cardano-multiplatform-lib-nodejs': 6.0.2-3
-      '@effect/platform': 0.71.7(effect@3.15.2)
-      '@effect/schema': 0.68.27(effect@3.15.2)
+      '@effect/platform': 0.71.7(effect@3.16.12)
+      '@effect/schema': 0.68.27(effect@3.16.12)
       '@lucid-evolution/core-types': 0.1.22
       '@lucid-evolution/core-utils': 0.1.16
-      '@lucid-evolution/utils': 0.1.65(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
-      '@lucid-evolution/wallet': 0.1.71(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
-      effect: 3.15.2
+      '@lucid-evolution/utils': 0.1.66(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
+      '@lucid-evolution/wallet': 0.1.72(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
+      effect: 3.16.12
     transitivePeerDependencies:
       - '@dcspark/cardano-multiplatform-lib-asmjs'
       - '@dcspark/cardano-multiplatform-lib-browser'
@@ -2839,24 +2858,24 @@ snapshots:
       '@lucid-evolution/core-types': 0.1.22
       '@lucid-evolution/core-utils': 0.1.16
 
-  '@lucid-evolution/uplc@0.2.19': {}
+  '@lucid-evolution/uplc@0.2.20': {}
 
-  '@lucid-evolution/utils@0.1.65(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)':
+  '@lucid-evolution/utils@0.1.66(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)':
     dependencies:
       '@anastasia-labs/cardano-multiplatform-lib-browser': 6.0.2-3
       '@anastasia-labs/cardano-multiplatform-lib-nodejs': 6.0.2-3
-      '@cardano-sdk/core': 0.45.8
-      '@effect/schema': 0.68.27(effect@3.15.2)
+      '@cardano-sdk/core': 0.45.10
+      '@effect/schema': 0.68.27(effect@3.16.12)
       '@harmoniclabs/plutus-data': 1.2.6(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)
       '@harmoniclabs/uplc': 1.4.1(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(@harmoniclabs/plutus-data@1.2.6(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6))
       '@lucid-evolution/core-types': 0.1.22
       '@lucid-evolution/core-utils': 0.1.16
       '@lucid-evolution/crc8': 0.1.8
       '@lucid-evolution/plutus': 0.1.29
-      '@lucid-evolution/uplc': 0.2.19
+      '@lucid-evolution/uplc': 0.2.20
       bip39: 3.1.0
       cbor-x: 1.6.0
-      effect: 3.15.2
+      effect: 3.16.12
     transitivePeerDependencies:
       - '@dcspark/cardano-multiplatform-lib-asmjs'
       - '@dcspark/cardano-multiplatform-lib-browser'
@@ -2870,14 +2889,14 @@ snapshots:
       - rxjs
       - utf-8-validate
 
-  '@lucid-evolution/wallet@0.1.71(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)':
+  '@lucid-evolution/wallet@0.1.72(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)':
     dependencies:
       '@anastasia-labs/cardano-multiplatform-lib-browser': 6.0.2-3
       '@anastasia-labs/cardano-multiplatform-lib-nodejs': 6.0.2-3
       '@lucid-evolution/core-types': 0.1.22
       '@lucid-evolution/core-utils': 0.1.16
       '@lucid-evolution/sign_data': 0.1.25
-      '@lucid-evolution/utils': 0.1.65(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
+      '@lucid-evolution/utils': 0.1.66(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)
       bip39: 3.1.0
     transitivePeerDependencies:
       - '@dcspark/cardano-multiplatform-lib-asmjs'
@@ -2922,14 +2941,15 @@ snapshots:
 
   '@multiformats/mafmt@12.1.6':
     dependencies:
-      '@multiformats/multiaddr': 12.4.0
+      '@multiformats/multiaddr': 12.5.1
 
-  '@multiformats/multiaddr@12.4.0':
+  '@multiformats/multiaddr@12.5.1':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/netmask': 2.0.0
       '@multiformats/dns': 1.0.6
-      multiformats: 13.3.4
+      abort-error: 1.0.1
+      multiformats: 13.3.7
       uint8-varint: 2.0.4
       uint8arrays: 5.1.0
 
@@ -2993,7 +3013,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.2
+      protobufjs: 7.5.3
 
   '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -3050,7 +3070,7 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
-  '@opentelemetry/semantic-conventions@1.33.0': {}
+  '@opentelemetry/semantic-conventions@1.34.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -3138,69 +3158,69 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@rollup/rollup-android-arm-eabi@4.41.0':
+  '@rollup/rollup-android-arm-eabi@4.44.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.41.0':
+  '@rollup/rollup-android-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.41.0':
+  '@rollup/rollup-darwin-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.41.0':
+  '@rollup/rollup-darwin-x64@4.44.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.41.0':
+  '@rollup/rollup-freebsd-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.41.0':
+  '@rollup/rollup-freebsd-x64@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.41.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.41.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.41.0':
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.41.0':
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.41.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.41.0':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.41.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.41.0':
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.41.0':
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.41.0':
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.41.0':
+  '@rollup/rollup-linux-x64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.41.0':
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.41.0':
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.41.0':
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
     optional: true
 
   '@scure/base@1.1.9': {}
 
-  '@scure/base@1.2.5': {}
+  '@scure/base@1.2.6': {}
 
   '@scure/bip32@1.4.0':
     dependencies:
@@ -3212,7 +3232,7 @@ snapshots:
     dependencies:
       '@noble/curves': 1.9.0
       '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.5
+      '@scure/base': 1.2.6
 
   '@scure/bip39@1.3.0':
     dependencies:
@@ -3222,7 +3242,7 @@ snapshots:
   '@scure/bip39@1.6.0':
     dependencies:
       '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.5
+      '@scure/base': 1.2.6
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -3230,35 +3250,41 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@types/body-parser@1.19.5':
+  '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
+
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/dns-packet@5.6.5':
     dependencies:
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
 
-  '@types/estree@1.0.7': {}
+  '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
-      '@types/send': 0.17.4
+      '@types/send': 0.17.5
 
-  '@types/express@5.0.2':
+  '@types/express@5.0.3':
     dependencies:
-      '@types/body-parser': 1.19.5
+      '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.0.6
-      '@types/serve-static': 1.15.7
+      '@types/serve-static': 1.15.8
 
-  '@types/http-errors@2.0.4': {}
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3279,7 +3305,7 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/node@22.15.19':
+  '@types/node@22.16.0':
     dependencies:
       undici-types: 6.21.0
 
@@ -3287,16 +3313,16 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/send@0.17.4':
+  '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
 
-  '@types/serve-static@1.15.7':
+  '@types/serve-static@1.15.8':
     dependencies:
-      '@types/http-errors': 2.0.4
-      '@types/node': 22.15.19
-      '@types/send': 0.17.4
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.16.0
+      '@types/send': 0.17.5
 
   '@types/stack-utils@2.0.3': {}
 
@@ -3306,48 +3332,52 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitest/expect@3.1.3':
+  '@vitest/expect@3.2.4':
     dependencies:
-      '@vitest/spy': 3.1.3
-      '@vitest/utils': 3.1.3
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.19))':
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.16.0))':
     dependencies:
-      '@vitest/spy': 3.1.3
+      '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.19)
+      vite: 6.3.5(@types/node@22.16.0)
 
-  '@vitest/pretty-format@3.1.3':
+  '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.1.3':
+  '@vitest/runner@3.2.4':
     dependencies:
-      '@vitest/utils': 3.1.3
+      '@vitest/utils': 3.2.4
       pathe: 2.0.3
+      strip-literal: 3.0.0
 
-  '@vitest/snapshot@3.1.3':
+  '@vitest/snapshot@3.2.4':
     dependencies:
-      '@vitest/pretty-format': 3.1.3
+      '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.1.3':
+  '@vitest/spy@3.2.4':
     dependencies:
-      tinyspy: 3.0.2
+      tinyspy: 4.0.3
 
-  '@vitest/utils@3.1.3':
+  '@vitest/utils@3.2.4':
     dependencies:
-      '@vitest/pretty-format': 3.1.3
-      loupe: 3.1.3
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.1.4
       tinyrainbow: 2.0.0
 
   '@zxing/text-encoding@0.9.0':
     optional: true
+
+  abort-error@1.0.1: {}
 
   abstract-level@1.0.4:
     dependencies:
@@ -3359,7 +3389,7 @@ snapshots:
       module-error: 1.0.2
       queue-microtask: 1.2.3
 
-  acorn@8.14.1: {}
+  acorn@8.15.0: {}
 
   ansi-regex@5.0.1: {}
 
@@ -3405,7 +3435,7 @@ snapshots:
       blake2b-wasm: 2.4.0
       nanoassert: 2.0.0
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -3425,9 +3455,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bundle-require@5.1.0(esbuild@0.25.4):
+  bundle-require@5.1.0(esbuild@0.25.5):
     dependencies:
-      esbuild: 0.25.4
+      esbuild: 0.25.5
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -3472,8 +3502,8 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.3
-      pathval: 2.0.0
+      loupe: 3.1.4
+      pathval: 2.0.1
 
   chalk@4.1.2:
     dependencies:
@@ -3517,22 +3547,21 @@ snapshots:
 
   consola@3.4.2: {}
 
-  create-hash@1.2.0:
+  create-hash@1.1.3:
     dependencies:
       cipher-base: 1.0.6
       inherits: 2.0.4
-      md5.js: 1.3.5
-      ripemd160: 2.0.2
-      sha.js: 2.4.11
+      ripemd160: 2.0.1
+      sha.js: 2.4.12
 
   create-hmac@1.1.7:
     dependencies:
       cipher-base: 1.0.6
-      create-hash: 1.2.0
+      create-hash: 1.1.3
       inherits: 2.0.4
-      ripemd160: 2.0.2
+      ripemd160: 2.0.1
       safe-buffer: 5.2.1
-      sha.js: 2.4.11
+      sha.js: 2.4.12
 
   cross-fetch@3.2.0:
     dependencies:
@@ -3569,7 +3598,7 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
-  dotenv@16.5.0: {}
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3579,7 +3608,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  effect@3.15.2:
+  effect@3.16.12:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
@@ -3598,39 +3627,39 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.25.4:
+  esbuild@0.25.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.4
-      '@esbuild/android-arm': 0.25.4
-      '@esbuild/android-arm64': 0.25.4
-      '@esbuild/android-x64': 0.25.4
-      '@esbuild/darwin-arm64': 0.25.4
-      '@esbuild/darwin-x64': 0.25.4
-      '@esbuild/freebsd-arm64': 0.25.4
-      '@esbuild/freebsd-x64': 0.25.4
-      '@esbuild/linux-arm': 0.25.4
-      '@esbuild/linux-arm64': 0.25.4
-      '@esbuild/linux-ia32': 0.25.4
-      '@esbuild/linux-loong64': 0.25.4
-      '@esbuild/linux-mips64el': 0.25.4
-      '@esbuild/linux-ppc64': 0.25.4
-      '@esbuild/linux-riscv64': 0.25.4
-      '@esbuild/linux-s390x': 0.25.4
-      '@esbuild/linux-x64': 0.25.4
-      '@esbuild/netbsd-arm64': 0.25.4
-      '@esbuild/netbsd-x64': 0.25.4
-      '@esbuild/openbsd-arm64': 0.25.4
-      '@esbuild/openbsd-x64': 0.25.4
-      '@esbuild/sunos-x64': 0.25.4
-      '@esbuild/win32-arm64': 0.25.4
-      '@esbuild/win32-ia32': 0.25.4
-      '@esbuild/win32-x64': 0.25.4
+      '@esbuild/aix-ppc64': 0.25.5
+      '@esbuild/android-arm': 0.25.5
+      '@esbuild/android-arm64': 0.25.5
+      '@esbuild/android-x64': 0.25.5
+      '@esbuild/darwin-arm64': 0.25.5
+      '@esbuild/darwin-x64': 0.25.5
+      '@esbuild/freebsd-arm64': 0.25.5
+      '@esbuild/freebsd-x64': 0.25.5
+      '@esbuild/linux-arm': 0.25.5
+      '@esbuild/linux-arm64': 0.25.5
+      '@esbuild/linux-ia32': 0.25.5
+      '@esbuild/linux-loong64': 0.25.5
+      '@esbuild/linux-mips64el': 0.25.5
+      '@esbuild/linux-ppc64': 0.25.5
+      '@esbuild/linux-riscv64': 0.25.5
+      '@esbuild/linux-s390x': 0.25.5
+      '@esbuild/linux-x64': 0.25.5
+      '@esbuild/netbsd-arm64': 0.25.5
+      '@esbuild/netbsd-x64': 0.25.5
+      '@esbuild/openbsd-arm64': 0.25.5
+      '@esbuild/openbsd-x64': 0.25.5
+      '@esbuild/sunos-x64': 0.25.5
+      '@esbuild/win32-arm64': 0.25.5
+      '@esbuild/win32-ia32': 0.25.5
+      '@esbuild/win32-x64': 0.25.5
 
   escape-string-regexp@2.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   ethereum-cryptography@2.2.1:
     dependencies:
@@ -3649,7 +3678,7 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
-  expect-type@1.2.1: {}
+  expect-type@1.2.2: {}
 
   expect@29.7.0:
     dependencies:
@@ -3667,7 +3696,7 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.4.4(picomatch@4.0.2):
+  fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -3681,7 +3710,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.17
       mlly: 1.7.4
-      rollup: 4.41.0
+      rollup: 4.44.2
 
   for-each@0.3.5:
     dependencies:
@@ -3726,11 +3755,11 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.2:
+  glob@11.0.3:
     dependencies:
       foreground-child: 3.3.1
-      jackspeak: 4.1.0
-      minimatch: 10.0.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
@@ -3751,11 +3780,9 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hash-base@3.1.0:
+  hash-base@2.0.2:
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.2
-      safe-buffer: 5.2.1
 
   hashlru@2.3.0: {}
 
@@ -3811,6 +3838,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.19
 
+  isarray@2.0.5: {}
+
   isexe@2.0.0: {}
 
   iso-url@1.2.1: {}
@@ -3825,7 +3854,7 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.0:
+  jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
@@ -3860,7 +3889,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3869,6 +3898,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   jsbn@1.1.0: {}
 
@@ -3903,7 +3934,7 @@ snapshots:
 
   long@5.3.2: {}
 
-  loupe@3.1.3: {}
+  loupe@3.1.4: {}
 
   lru-cache@10.1.0: {}
 
@@ -3913,15 +3944,9 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   math-intrinsics@1.1.0: {}
-
-  md5.js@1.3.5:
-    dependencies:
-      hash-base: 3.1.0
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
 
   micromatch@4.0.8:
     dependencies:
@@ -3930,19 +3955,19 @@ snapshots:
 
   mime@3.0.0: {}
 
-  minimatch@10.0.1:
+  minimatch@10.0.3:
     dependencies:
-      brace-expansion: 2.0.1
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minipass@7.1.2: {}
 
   mlly@1.7.4:
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
@@ -3967,7 +3992,7 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
-  multiformats@13.3.4: {}
+  multiformats@13.3.7: {}
 
   multipasta@0.2.5: {}
 
@@ -4028,15 +4053,16 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.0: {}
+  pathval@2.0.1: {}
 
-  pbkdf2@3.1.2:
+  pbkdf2@3.1.3:
     dependencies:
-      create-hash: 1.2.0
+      create-hash: 1.1.3
       create-hmac: 1.1.7
-      ripemd160: 2.0.2
+      ripemd160: 2.0.1
       safe-buffer: 5.2.1
-      sha.js: 2.4.11
+      sha.js: 2.4.12
+      to-buffer: 1.2.1
 
   picocolors@1.1.1: {}
 
@@ -4054,21 +4080,21 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(postcss@8.5.3):
+  postcss-load-config@6.0.1(postcss@8.5.6):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
 
-  postcss@8.5.3:
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres@3.4.5: {}
+  postgres@3.4.7: {}
 
-  prettier@3.5.3: {}
+  prettier@3.6.2: {}
 
   pretty-format@29.7.0:
     dependencies:
@@ -4078,7 +4104,7 @@ snapshots:
 
   progress-events@1.0.1: {}
 
-  protobufjs@7.5.2:
+  protobufjs@7.5.3:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -4090,7 +4116,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
       long: 5.3.2
 
   punycode@2.3.1: {}
@@ -4101,12 +4127,6 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
   readdirp@4.1.2: {}
 
   resolve-from@5.0.0: {}
@@ -4115,38 +4135,38 @@ snapshots:
 
   rimraf@6.0.1:
     dependencies:
-      glob: 11.0.2
+      glob: 11.0.3
       package-json-from-dist: 1.0.1
 
-  ripemd160@2.0.2:
+  ripemd160@2.0.1:
     dependencies:
-      hash-base: 3.1.0
+      hash-base: 2.0.2
       inherits: 2.0.4
 
-  rollup@4.41.0:
+  rollup@4.44.2:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.41.0
-      '@rollup/rollup-android-arm64': 4.41.0
-      '@rollup/rollup-darwin-arm64': 4.41.0
-      '@rollup/rollup-darwin-x64': 4.41.0
-      '@rollup/rollup-freebsd-arm64': 4.41.0
-      '@rollup/rollup-freebsd-x64': 4.41.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.41.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.41.0
-      '@rollup/rollup-linux-arm64-gnu': 4.41.0
-      '@rollup/rollup-linux-arm64-musl': 4.41.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.41.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.41.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.41.0
-      '@rollup/rollup-linux-riscv64-musl': 4.41.0
-      '@rollup/rollup-linux-s390x-gnu': 4.41.0
-      '@rollup/rollup-linux-x64-gnu': 4.41.0
-      '@rollup/rollup-linux-x64-musl': 4.41.0
-      '@rollup/rollup-win32-arm64-msvc': 4.41.0
-      '@rollup/rollup-win32-ia32-msvc': 4.41.0
-      '@rollup/rollup-win32-x64-msvc': 4.41.0
+      '@rollup/rollup-android-arm-eabi': 4.44.2
+      '@rollup/rollup-android-arm64': 4.44.2
+      '@rollup/rollup-darwin-arm64': 4.44.2
+      '@rollup/rollup-darwin-x64': 4.44.2
+      '@rollup/rollup-freebsd-arm64': 4.44.2
+      '@rollup/rollup-freebsd-x64': 4.44.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.44.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.44.2
+      '@rollup/rollup-linux-arm64-gnu': 4.44.2
+      '@rollup/rollup-linux-arm64-musl': 4.44.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.44.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-musl': 4.44.2
+      '@rollup/rollup-linux-s390x-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-musl': 4.44.2
+      '@rollup/rollup-win32-arm64-msvc': 4.44.2
+      '@rollup/rollup-win32-ia32-msvc': 4.44.2
+      '@rollup/rollup-win32-x64-msvc': 4.44.2
       fsevents: 2.3.3
 
   run-parallel-limit@1.1.0:
@@ -4176,10 +4196,11 @@ snapshots:
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
 
-  sha.js@2.4.11:
+  sha.js@2.4.12:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
+      to-buffer: 1.2.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -4221,10 +4242,6 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4233,9 +4250,13 @@ snapshots:
     dependencies:
       ansi-regex: 6.1.0
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   sucrase@3.35.0:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/gen-mapping': 0.3.12
       commander: 4.1.1
       glob: 10.4.5
       lines-and-columns: 1.2.4
@@ -4259,16 +4280,22 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.13:
+  tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.4(picomatch@4.0.2)
+      fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  tinypool@1.0.2: {}
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
-  tinyspy@3.0.2: {}
+  tinyspy@4.0.3: {}
+
+  to-buffer@1.2.1:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4288,27 +4315,27 @@ snapshots:
 
   ts-log@2.2.7: {}
 
-  tsup@8.5.0(postcss@8.5.3)(typescript@5.8.3):
+  tsup@8.5.0(postcss@8.5.6)(typescript@5.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.4)
+      bundle-require: 5.1.0(esbuild@0.25.5)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.1
-      esbuild: 0.25.4
+      esbuild: 0.25.5
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.3)
+      postcss-load-config: 6.0.1(postcss@8.5.6)
       resolve-from: 5.0.0
-      rollup: 4.41.0
+      rollup: 4.44.2
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
       typescript: 5.8.3
     transitivePeerDependencies:
       - jiti
@@ -4319,6 +4346,12 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@2.19.0: {}
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
 
   typescript@5.8.3: {}
 
@@ -4335,13 +4368,11 @@ snapshots:
 
   uint8arrays@5.1.0:
     dependencies:
-      multiformats: 13.3.4
+      multiformats: 13.3.7
 
   undici-types@6.21.0: {}
 
-  undici@7.9.0: {}
-
-  util-deprecate@1.0.2: {}
+  undici@7.11.0: {}
 
   util@0.12.5:
     dependencies:
@@ -4353,13 +4384,13 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  vite-node@3.1.3(@types/node@22.15.19):
+  vite-node@3.2.4(@types/node@22.16.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.19)
+      vite: 6.3.5(@types/node@22.16.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4374,43 +4405,45 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@22.15.19):
+  vite@6.3.5(@types/node@22.16.0):
     dependencies:
-      esbuild: 0.25.4
-      fdir: 6.4.4(picomatch@4.0.2)
+      esbuild: 0.25.5
+      fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
-      postcss: 8.5.3
-      rollup: 4.41.0
-      tinyglobby: 0.2.13
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
       fsevents: 2.3.3
 
-  vitest@3.1.3(@types/node@22.15.19):
+  vitest@3.2.4(@types/node@22.16.0):
     dependencies:
-      '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@22.15.19))
-      '@vitest/pretty-format': 3.1.3
-      '@vitest/runner': 3.1.3
-      '@vitest/snapshot': 3.1.3
-      '@vitest/spy': 3.1.3
-      '@vitest/utils': 3.1.3
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.16.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
       chai: 5.2.0
       debug: 4.4.1
-      expect-type: 1.2.1
+      expect-type: 1.2.2
       magic-string: 0.30.17
       pathe: 2.0.3
+      picomatch: 4.0.2
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
-      tinypool: 1.0.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.19)
-      vite-node: 3.1.3(@types/node@22.15.19)
+      vite: 6.3.5(@types/node@22.16.0)
+      vite-node: 3.2.4(@types/node@22.16.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.15.19
+      '@types/node': 22.16.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -4479,4 +4512,4 @@ snapshots:
 
   ws@7.5.10: {}
 
-  ws@8.18.2: {}
+  ws@8.18.3: {}

--- a/demo/midgard-node/pnpm-lock.yaml
+++ b/demo/midgard-node/pnpm-lock.yaml
@@ -115,7 +115,7 @@ packages:
     resolution: {integrity: sha512-yEie4HFRoQS+ShbEYGNcVEQKFvnClXHFEysYT7lqoL1FGVxwvWWTBsctsEXolUIvusslztzrnJyUG67KGljBKw==}
 
   '@al-ft/midgard-sdk@file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz':
-    resolution: {integrity: sha512-aJZOPsMAPBIRZy9Usi3Rn0kLQofhJ7c+RHnaDOv5HjGw6NTkEkJoeQaTIJbmKGoUV9QLtYnYXN4ZKiP1FhznlA==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
+    resolution: {integrity: sha512-WmeEuF0s3wgF1wDZqgZV+NqnY9mZl5WbiSfX0pBn2m3foS2ZILgHGwx/BAvvzw3cC2JeokNNv2YuB+q/U6oUSg==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
     version: 0.1.0
 
   '@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2':

--- a/demo/midgard-node/pnpm-lock.yaml
+++ b/demo/midgard-node/pnpm-lock.yaml
@@ -15,16 +15,16 @@ importers:
         specifier: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz
         version: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@effect/experimental':
-        specifier: ^0.46.8
+        specifier: ^0.46.0
         version: 0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
       '@effect/opentelemetry':
-        specifier: ^0.44.12
+        specifier: ^0.44.6
         version: 0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.12)
       '@effect/platform':
-        specifier: ^0.80.21
+        specifier: ^0.80.0
         version: 0.80.21(effect@3.16.12)
       '@effect/platform-node':
-        specifier: ^0.80.3
+        specifier: ^0.80.0
         version: 0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       '@effect/sql':
         specifier: ^0.34.1
@@ -39,7 +39,7 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0
       '@lucid-evolution/lucid':
-        specifier: ^0.4.29
+        specifier: ^0.4.23
         version: 0.4.29(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@opentelemetry/api':
         specifier: ^1.9.0
@@ -66,10 +66,10 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       dotenv:
-        specifier: ^16.6.1
+        specifier: ^16.4.7
         version: 16.6.1
       effect:
-        specifier: ^3.16.12
+        specifier: ^3.14.22
         version: 3.16.12
       lru-cache:
         specifier: ^11.1.0
@@ -78,32 +78,32 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       vitest:
-        specifier: ^3.2.4
+        specifier: ^3.0.7
         version: 3.2.4(@types/node@22.16.0)
     devDependencies:
       '@commander-js/extra-typings':
         specifier: ^13.1.0
         version: 13.1.0(commander@13.1.0)
       '@effect/vitest':
-        specifier: ^0.22.5
+        specifier: ^0.22.0
         version: 0.22.5(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))
       '@types/express':
-        specifier: ^5.0.3
+        specifier: ^5.0.0
         version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: ^22.16.0
+        specifier: ^22.13.5
         version: 22.16.0
       prettier:
-        specifier: ^3.6.2
+        specifier: ^3.5.2
         version: 3.6.2
       tsup:
-        specifier: ^8.5.0
+        specifier: ^8.4.0
         version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)
       typescript:
-        specifier: ^5.8.3
+        specifier: ^5.7.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
@@ -115,7 +115,7 @@ packages:
     resolution: {integrity: sha512-yEie4HFRoQS+ShbEYGNcVEQKFvnClXHFEysYT7lqoL1FGVxwvWWTBsctsEXolUIvusslztzrnJyUG67KGljBKw==}
 
   '@al-ft/midgard-sdk@file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz':
-    resolution: {integrity: sha512-WmeEuF0s3wgF1wDZqgZV+NqnY9mZl5WbiSfX0pBn2m3foS2ZILgHGwx/BAvvzw3cC2JeokNNv2YuB+q/U6oUSg==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
+    resolution: {integrity: sha512-G5v2MIBYmBsMsUYwRMr92rUqAwaQKJW6adxnylAxNzeWqTeVI/NVM4yp/FLzDfdNTMnb5LM1oTMpWfZdUd7MYw==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
     version: 0.1.0
 
   '@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2':

--- a/demo/midgard-node/pnpm-lock.yaml
+++ b/demo/midgard-node/pnpm-lock.yaml
@@ -15,16 +15,16 @@ importers:
         specifier: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz
         version: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@effect/experimental':
-        specifier: ^0.46.0
+        specifier: ^0.46.8
         version: 0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
       '@effect/opentelemetry':
-        specifier: ^0.44.6
+        specifier: ^0.44.12
         version: 0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.12)
       '@effect/platform':
-        specifier: ^0.80.0
+        specifier: ^0.80.21
         version: 0.80.21(effect@3.16.12)
       '@effect/platform-node':
-        specifier: ^0.80.0
+        specifier: ^0.80.3
         version: 0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       '@effect/sql':
         specifier: ^0.34.1
@@ -39,7 +39,7 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0
       '@lucid-evolution/lucid':
-        specifier: ^0.4.23
+        specifier: ^0.4.29
         version: 0.4.29(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@opentelemetry/api':
         specifier: ^1.9.0
@@ -66,10 +66,10 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       dotenv:
-        specifier: ^16.4.7
+        specifier: ^16.6.1
         version: 16.6.1
       effect:
-        specifier: ^3.14.22
+        specifier: ^3.16.12
         version: 3.16.12
       lru-cache:
         specifier: ^11.1.0
@@ -78,32 +78,32 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       vitest:
-        specifier: ^3.0.7
+        specifier: ^3.2.4
         version: 3.2.4(@types/node@22.16.0)
     devDependencies:
       '@commander-js/extra-typings':
         specifier: ^13.1.0
         version: 13.1.0(commander@13.1.0)
       '@effect/vitest':
-        specifier: ^0.22.0
+        specifier: ^0.22.5
         version: 0.22.5(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))
       '@types/express':
-        specifier: ^5.0.0
+        specifier: ^5.0.3
         version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: ^22.13.5
+        specifier: ^22.16.0
         version: 22.16.0
       prettier:
-        specifier: ^3.5.2
+        specifier: ^3.6.2
         version: 3.6.2
       tsup:
-        specifier: ^8.4.0
+        specifier: ^8.5.0
         version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
@@ -115,7 +115,7 @@ packages:
     resolution: {integrity: sha512-yEie4HFRoQS+ShbEYGNcVEQKFvnClXHFEysYT7lqoL1FGVxwvWWTBsctsEXolUIvusslztzrnJyUG67KGljBKw==}
 
   '@al-ft/midgard-sdk@file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz':
-    resolution: {integrity: sha512-G5v2MIBYmBsMsUYwRMr92rUqAwaQKJW6adxnylAxNzeWqTeVI/NVM4yp/FLzDfdNTMnb5LM1oTMpWfZdUd7MYw==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
+    resolution: {integrity: sha512-CHWdbxcXsmAtWQ8A2rmqz7jLqYGqx6IdNFBatVJOd2Z5+cAv1PScGtKX3f0QydC98dWfx78jr7m/yIYfd2mK2g==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
     version: 0.1.0
 
   '@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2':

--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -267,12 +267,9 @@ const getLogStateQueueHandler = Effect.gen(function* () {
     const isEnd = u.datum.next === "Empty";
     const emoji = isHead ? "🚢" : isEnd ? "⚓" : "⛓ ";
     if (!isHead) {
-      const header = yield* SDK.Utils.getHeaderFromStateQueueUTxO(u);
-      const headerHash = yield* SDK.Utils.hashHeader(header);
-      const icon = isEnd ? "   " : emoji;
+      const icon = isEnd ? "  " : emoji;
       info = isHead ? "" : `
-${icon}   ├─ header:     ${headerHash}
-${icon}   ╰─ asset name: ${u.assetName}`;
+${icon} ╰─ asset name: ${u.assetName}`;
     }
     drawn = `${drawn}
 ${emoji} ${u.utxo.txHash}#${u.utxo.outputIndex}${info}`;
@@ -311,6 +308,7 @@ ${bHex} -──▶ ${keyValues[bHex]} tx(s)
   drawn += `
 ---------------------------------------------------------------------
 `;
+  yield* Effect.logInfo(drawn);
   return yield* HttpServerResponse.json({
     message: `BlocksDB drawn in server logs!`,
   });

--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -248,7 +248,7 @@ const getResetHandler = Effect.gen(function* () {
 );
 
 const getLogStateQueueHandler = Effect.gen(function* () {
-  yield* Effect.logInfo(`\u270d Fetching state queue to draw...`);
+  // yield* Effect.logInfo(`✍  State queue draw request received...`);
   const { user: lucid } = yield* User;
 
   const alwaysSucceeds = yield* AlwaysSucceeds.AlwaysSucceedsContract;
@@ -258,18 +258,25 @@ const getLogStateQueueHandler = Effect.gen(function* () {
     stateQueueAddress: alwaysSucceeds.spendScriptAddress,
   };
 
+  yield* Effect.logInfo(`✍  Fetching state queue UTxOs...`);
   const sortedUTxOs = yield* SDK.Endpoints.fetchSortedStateQueueUTxOsProgram(
     lucid,
     fetchConfig,
   );
-  let drawn = "";
+  // yield* Effect.logInfo(`✍  ${sortedUTxOs.length} UTxO(s) found.`);
+  let drawn = `
+---------------------------- STATE QUEUE ----------------------------`;
   sortedUTxOs.map((u) => {
-    const emoji =
-      u.datum.key === "Empty" ? "👑" : u.datum.next === "Empty" ? "⚓" : "⛓";
+    const isHead = u.datum.key === "Empty";
+    const isEnd = u.datum.next === "Empty";
+    const emoji = isHead ? "🚢" : isEnd ? "⚓" : "⛓ ";
     drawn = `${drawn}
-${u.utxo.txHash}#${u.utxo.outputIndex}
-${emoji}${u.datum.key !== "Empty" ? "(" + u.assetName + ")" : ""}`;
+${emoji} ${u.utxo.txHash}#${u.utxo.outputIndex} ${!isHead ? "(" + u.assetName + ")" : ""}`;
   });
+  drawn += `
+---------------------------------------------------------------------
+`;
+  yield* Effect.logInfo(drawn);
   return yield* HttpServerResponse.json({
     message: `State queue drawn in server logs!`,
   });

--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -248,7 +248,8 @@ const getResetHandler = Effect.gen(function* () {
 );
 
 const getLogStateQueueHandler = Effect.gen(function* () {
-  // yield* Effect.logInfo(`✍  State queue draw request received...`);
+  yield* Effect.logInfo(`✍  Drawing state queue UTxOs...`);
+
   const { user: lucid } = yield* User;
 
   const alwaysSucceeds = yield* AlwaysSucceeds.AlwaysSucceedsContract;
@@ -258,14 +259,14 @@ const getLogStateQueueHandler = Effect.gen(function* () {
     stateQueueAddress: alwaysSucceeds.spendScriptAddress,
   };
 
-  yield* Effect.logInfo(`✍  Fetching state queue UTxOs...`);
   const sortedUTxOs = yield* SDK.Endpoints.fetchSortedStateQueueUTxOsProgram(
     lucid,
     fetchConfig,
   );
-  // yield* Effect.logInfo(`✍  ${sortedUTxOs.length} UTxO(s) found.`);
+
   let drawn = `
 ---------------------------- STATE QUEUE ----------------------------`;
+
   sortedUTxOs.map((u) => {
     const isHead = u.datum.key === "Empty";
     const isEnd = u.datum.next === "Empty";
@@ -273,10 +274,13 @@ const getLogStateQueueHandler = Effect.gen(function* () {
     drawn = `${drawn}
 ${emoji} ${u.utxo.txHash}#${u.utxo.outputIndex} ${!isHead ? "(" + u.assetName + ")" : ""}`;
   });
+
   drawn += `
 ---------------------------------------------------------------------
 `;
+
   yield* Effect.logInfo(drawn);
+
   return yield* HttpServerResponse.json({
     message: `State queue drawn in server logs!`,
   });

--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -302,8 +302,7 @@ const getLogBlocksDBHandler = Effect.gen(function* () {
 ------------------------------ BLOCKS DB ----------------------------`;
   for (const bHex in keyValues) {
     drawn = `${drawn}
-${bHex} -──▶ ${keyValues[bHex]} tx(s)
-`;
+${bHex} -──▶ ${keyValues[bHex]} tx(s)`;
   }
   drawn += `
 ---------------------------------------------------------------------

--- a/demo/midgard-node/src/database/blocks.ts
+++ b/demo/midgard-node/src/database/blocks.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { clearTable, mapSqlError } from "./utils.js";
 import { SqlClient } from "@effect/sql";
 import { Database } from "@/services/database.js";
+import { toHex } from "@lucid-evolution/lucid";
 
 export const tableName = "blocks";
 
@@ -119,7 +120,7 @@ export const clearBlock = (
       yield* sql`DELETE FROM ${sql(tableName)} WHERE header_hash = ${Buffer.from(blockHash)}`;
 
     yield* Effect.logInfo(
-      `${tableName} db: cleared ${result.length} rows for block ${blockHash}`,
+      `${tableName} db: cleared ${result.length} rows for block ${toHex(blockHash)}`,
     );
     return Effect.void;
   }).pipe(
@@ -138,7 +139,7 @@ interface BlockRow {
 }
 
 export const retrieve = (): Effect.Effect<
-  [Uint8Array, Uint8Array][],
+  (readonly [Uint8Array, Uint8Array])[],
   Error,
   Database
 > =>
@@ -146,7 +147,7 @@ export const retrieve = (): Effect.Effect<
     yield* Effect.logInfo(`${tableName} db: attempt to retrieve blocks`);
     const sql = yield* SqlClient.SqlClient;
     const rows = yield* sql<BlockRow>`SELECT * FROM ${sql(tableName)}`;
-    const result: [Uint8Array, Uint8Array][] = rows.map(
+    const result: (readonly [Uint8Array, Uint8Array])[] = rows.map(
       (row: BlockRow) =>
         [
           Uint8Array.from(row.header_hash),

--- a/demo/midgard-node/src/database/blocks.ts
+++ b/demo/midgard-node/src/database/blocks.ts
@@ -100,11 +100,11 @@ export const retrieveBlockHashByTxHash = (
     return result;
   }).pipe(
     Effect.withLogSpan(`retrieveBlockHashByTxHash ${tableName}`),
-    Effect.tapErrorTag("SqlError", (e) =>
-      Effect.logError(
-        `${tableName} db: retrieving block_hash error: ${JSON.stringify(e)}`,
-      ),
-    ),
+    // Effect.tapErrorTag("SqlError", (e) =>
+    //   Effect.logError(
+    //     `${tableName} db: retrieving block_hash error: ${JSON.stringify(e)}`,
+    //   ),
+    // ),
     mapSqlError,
   );
 

--- a/demo/midgard-node/src/database/blocks.ts
+++ b/demo/midgard-node/src/database/blocks.ts
@@ -101,11 +101,11 @@ export const retrieveBlockHashByTxHash = (
     return result;
   }).pipe(
     Effect.withLogSpan(`retrieveBlockHashByTxHash ${tableName}`),
-    // Effect.tapErrorTag("SqlError", (e) =>
-    //   Effect.logError(
-    //     `${tableName} db: retrieving block_hash error: ${JSON.stringify(e)}`,
-    //   ),
-    // ),
+    Effect.tapErrorTag("SqlError", (e) =>
+      Effect.logError(
+        `${tableName} db: retrieving block_hash error: ${JSON.stringify(e)}`,
+      ),
+    ),
     mapSqlError,
   );
 
@@ -118,6 +118,8 @@ export const clearBlock = (
 
     const result =
       yield* sql`DELETE FROM ${sql(tableName)} WHERE header_hash = ${Buffer.from(blockHash)}`;
+
+    result
 
     yield* Effect.logInfo(
       `${tableName} db: cleared ${result.length} rows for block ${toHex(blockHash)}`,

--- a/demo/midgard-node/src/database/blocks.ts
+++ b/demo/midgard-node/src/database/blocks.ts
@@ -115,15 +115,10 @@ export const clearBlock = (
   Effect.gen(function* () {
     yield* Effect.logDebug(`${tableName} db: attempt clear block ${blockHash}`);
     const sql = yield* SqlClient.SqlClient;
-
-    const result =
-      yield* sql`DELETE FROM ${sql(tableName)} WHERE header_hash = ${Buffer.from(blockHash)}`;
-
-    result
-
-    yield* Effect.logInfo(
-      `${tableName} db: cleared ${result.length} rows for block ${toHex(blockHash)}`,
-    );
+    yield* sql`DELETE FROM ${sql(tableName)} WHERE header_hash = ${Buffer.from(blockHash)}`;
+    // yield* Effect.logInfo(
+    //   `${tableName} db: cleared ${result.entries()} rows for block ${toHex(blockHash)}`,
+    // );
     return Effect.void;
   }).pipe(
     Effect.withLogSpan(`clearBlock ${tableName}`),

--- a/demo/midgard-node/src/database/blocks.ts
+++ b/demo/midgard-node/src/database/blocks.ts
@@ -19,7 +19,7 @@ export const insert = (
   txHashes: Uint8Array[],
 ): Effect.Effect<void, Error, Database> =>
   Effect.gen(function* () {
-    yield* Effect.logInfo(`${tableName} db: attempt to insert blocks`);
+    // yield* Effect.logInfo(`${tableName} db: attempt to insert blocks`);
     const sql = yield* SqlClient.SqlClient;
 
     if (!txHashes.length) {
@@ -34,9 +34,9 @@ export const insert = (
 
     yield* sql`INSERT INTO ${sql(tableName)} ${sql.insert(rowsToInsert)}`;
 
-    yield* Effect.logInfo(
-      `${tableName} db: ${rowsToInsert.length} block rows inserted.`,
-    );
+    // yield* Effect.logInfo(
+    //   `${tableName} db: ${rowsToInsert.length} block rows inserted.`,
+    // );
   }).pipe(
     Effect.tapErrorTag("SqlError", (e) =>
       Effect.logError(`${tableName} db: inserting error: ${e}`),

--- a/demo/midgard-node/src/globals.d.ts
+++ b/demo/midgard-node/src/globals.d.ts
@@ -4,3 +4,7 @@ declare var BLOCKS_IN_QUEUE: number;
 // Latest moment the in-memory state queue length was synchronized with
 // on-chain state.
 declare var LATEST_SYNC_OF_STATE_QUEUE_LENGTH: number;
+
+// Needed for development to prevent other actions triggering while spending all
+// UTxOs at state queue.
+declare var RESET_IN_PROGRESS: boolean;

--- a/demo/midgard-node/src/index.ts
+++ b/demo/midgard-node/src/index.ts
@@ -13,6 +13,7 @@ import { NodeRuntime } from "@effect/platform-node";
 // Initialize global flags:
 global.BLOCKS_IN_QUEUE = 0;
 global.LATEST_SYNC_OF_STATE_QUEUE_LENGTH = 0;
+global.RESET_IN_PROGRESS = false;
 
 dotenv.config();
 const VERSION = packageJson.version;

--- a/demo/midgard-node/src/index.ts
+++ b/demo/midgard-node/src/index.ts
@@ -12,7 +12,7 @@ import { NodeRuntime } from "@effect/platform-node";
 
 // Initialize global flags:
 global.BLOCKS_IN_QUEUE = 0;
-global.LATEST_SYNC_OF_STATE_QUEUE_LENGTH = 0;
+global.LATEST_SYNC_OF_STATE_QUEUE_LENGTH = Date.now();
 global.RESET_IN_PROGRESS = false;
 
 dotenv.config();

--- a/demo/midgard-node/src/transactions/state-queue/commit-block-header.ts
+++ b/demo/midgard-node/src/transactions/state-queue/commit-block-header.ts
@@ -44,6 +44,9 @@ const commitBlockTxSizeGauge = Metric.gauge("commit_block_tx_size", {
 
 export const buildAndSubmitCommitmentBlock = () =>
   Effect.gen(function* () {
+    if (global.RESET_IN_PROGRESS) {
+      return yield* Effect.logInfo("🔹 Reset in progress...");
+    }
     const worker = Effect.async<WorkerOutput, Error, never>((resume) => {
       Effect.runSync(Effect.logInfo(`👷 Starting worker...`));
       const worker = new Worker(

--- a/demo/midgard-node/src/transactions/state-queue/merge-to-confirm-state.ts
+++ b/demo/midgard-node/src/transactions/state-queue/merge-to-confirm-state.ts
@@ -84,7 +84,7 @@ export const buildAndSubmitMergeTx = (
     );
     // Avoid a merge tx if the queue is too short (performing a merge with such
     // conditions has a chance of wasting the work done for root computaions).
-    if (currentStateQueueLength < 4) {
+    if (currentStateQueueLength < 4 || global.RESET_IN_PROGRESS) {
       // yield* Effect.logInfo(
       //   "🔸 There are too few blocks in queue.
       // );
@@ -103,7 +103,7 @@ export const buildAndSubmitMergeTx = (
       );
     if (firstBlockUTxO) {
       yield* Effect.logInfo(
-        `🔸 First block found: ${firstBlockUTxO.txHash}#${firstBlockUTxO.outputIndex}`,
+        `🔸 First block found: ${firstBlockUTxO.utxo.txHash}#${firstBlockUTxO.utxo.outputIndex}`,
       );
       // Fetch transactions from the first block
       yield* Effect.logInfo("🔸 Looking up its transactions from BlocksDB...");

--- a/demo/midgard-node/src/transactions/state-queue/reset.ts
+++ b/demo/midgard-node/src/transactions/state-queue/reset.ts
@@ -19,6 +19,7 @@ const collectAndBurnStateQueueNodesProgram = (
   stateQueueUTxOs: SDK.TxBuilder.StateQueue.StateQueueUTxO[],
 ): Effect.Effect<void, Error> =>
   Effect.gen(function* () {
+    global.RESET_IN_PROGRESS = true;
     const tx = lucid.newTx();
     const assetsToBurn: Assets = {};
     stateQueueUTxOs.map(({ utxo, assetName }) => {
@@ -41,12 +42,14 @@ const collectAndBurnStateQueueNodesProgram = (
       });
     const onConfirmFailure = (err: ConfirmError) =>
       Effect.logError(`Confirm tx error: ${err}`);
-    return yield* handleSignSubmit(
+    const txHash = yield* handleSignSubmit(
       lucid,
       completed,
       onSubmitFailure,
       onConfirmFailure,
     );
+    global.RESET_IN_PROGRESS = false;
+    return txHash;
   });
 
 export const resetStateQueue = Effect.gen(function* () {

--- a/demo/midgard-node/src/transactions/state-queue/reset.ts
+++ b/demo/midgard-node/src/transactions/state-queue/reset.ts
@@ -16,7 +16,7 @@ const collectAndBurnStateQueueNodesProgram = (
   fetchConfig: SDK.TxBuilder.StateQueue.FetchConfig,
   stateQueueSpendingScript: Script,
   stateQueueMintingScript: Script,
-  stateQueueUTxOs: SDK.Utils.StateQueueUTxO[],
+  stateQueueUTxOs: SDK.TxBuilder.StateQueue.StateQueueUTxO[],
 ): Effect.Effect<void, Error> =>
   Effect.gen(function* () {
     const tx = lucid.newTx();

--- a/demo/midgard-node/src/transactions/state-queue/reset.ts
+++ b/demo/midgard-node/src/transactions/state-queue/reset.ts
@@ -4,7 +4,6 @@ import {
   Data,
   LucidEvolution,
   Script,
-  UTxO,
   toUnit,
 } from "@lucid-evolution/lucid";
 import { AlwaysSucceeds } from "@/services/index.js";
@@ -17,12 +16,12 @@ const collectAndBurnStateQueueNodesProgram = (
   fetchConfig: SDK.TxBuilder.StateQueue.FetchConfig,
   stateQueueSpendingScript: Script,
   stateQueueMintingScript: Script,
-  utxosAndAssetNames: StateQueueUTxO[],
+  stateQueueUTxOs: SDK.Utils.StateQueueUTxO[],
 ): Effect.Effect<void, Error> =>
   Effect.gen(function* () {
     const tx = lucid.newTx();
     const assetsToBurn: Assets = {};
-    utxosAndAssetNames.map(({ utxo, assetName }) => {
+    stateQueueUTxOs.map(({ utxo, assetName }) => {
       const unit = toUnit(fetchConfig.stateQueuePolicyId, assetName);
       if (assetsToBurn[unit] !== undefined) {
         assetsToBurn[unit] -= 1n;
@@ -59,7 +58,7 @@ export const resetStateQueue = Effect.gen(function* () {
   };
 
   const allStateQueueUTxOs =
-    yield* SDK.Endpoints.fetchSortedStateQueueUTxOsProgram(lucid, fetchConfig.stateQueuePolicyId);
+    yield* SDK.Endpoints.fetchSortedStateQueueUTxOsProgram(lucid, fetchConfig);
 
   // Collect and burn 10 UTxOs and asset names at a time:
   const batchSize = 40;

--- a/demo/midgard-node/src/transactions/state-queue/reset.ts
+++ b/demo/midgard-node/src/transactions/state-queue/reset.ts
@@ -73,4 +73,6 @@ export const resetStateQueue = Effect.gen(function* () {
       batch,
     );
   }
+  global.LATEST_SYNC_OF_STATE_QUEUE_LENGTH = Date.now();
+  global.BLOCKS_IN_QUEUE = 0;
 });

--- a/demo/midgard-node/src/transactions/state-queue/reset.ts
+++ b/demo/midgard-node/src/transactions/state-queue/reset.ts
@@ -17,7 +17,7 @@ const collectAndBurnStateQueueNodesProgram = (
   fetchConfig: SDK.TxBuilder.StateQueue.FetchConfig,
   stateQueueSpendingScript: Script,
   stateQueueMintingScript: Script,
-  utxosAndAssetNames: { utxo: UTxO; assetName: string }[],
+  utxosAndAssetNames: StateQueueUTxO[],
 ): Effect.Effect<void, Error> =>
   Effect.gen(function* () {
     const tx = lucid.newTx();
@@ -58,13 +58,13 @@ export const resetStateQueue = Effect.gen(function* () {
     stateQueueAddress: alwaysSucceeds.spendScriptAddress,
   };
 
-  const allUTxOsAndAssetNames =
-    yield* SDK.Endpoints.fetchAllStateQueueUTxOsProgram(lucid, fetchConfig);
+  const allStateQueueUTxOs =
+    yield* SDK.Endpoints.fetchSortedStateQueueUTxOsProgram(lucid, fetchConfig.stateQueuePolicyId);
 
   // Collect and burn 10 UTxOs and asset names at a time:
   const batchSize = 40;
-  for (let i = 0; i < allUTxOsAndAssetNames.length; i += batchSize) {
-    const batch = allUTxOsAndAssetNames.slice(i, i + batchSize);
+  for (let i = 0; i < allStateQueueUTxOs.length; i += batchSize) {
+    const batch = allStateQueueUTxOs.slice(i, i + batchSize);
     yield* collectAndBurnStateQueueNodesProgram(
       lucid,
       fetchConfig,

--- a/demo/midgard-node/src/transactions/utils.ts
+++ b/demo/midgard-node/src/transactions/utils.ts
@@ -15,6 +15,8 @@ const RETRY_ATTEMPTS = 2;
 
 const INIT_RETRY_AFTER_MILLIS = 5_000;
 
+const PAUSE_DURATION = "5 seconds";
+
 /**
  * Handle the signing and submission of a transaction.
  *
@@ -50,8 +52,8 @@ export const handleSignSubmit = (
       catch: (err: any) => new ConfirmError({ err, txHash }),
     });
     yield* Effect.logInfo(`🎉 Transaction confirmed: ${txHash}`);
-    yield* Effect.logInfo("⌛ Pausing for 10 seconds...");
-    yield* Effect.sleep("10 seconds");
+    yield* Effect.logInfo(`⌛ Pausing for ${PAUSE_DURATION}...`);
+    yield* Effect.sleep(PAUSE_DURATION);
     yield* Effect.logInfo("✅ Pause ended.");
     return txHash;
   }).pipe(
@@ -130,10 +132,11 @@ export class ConfirmError extends Data.TaggedError("ConfirmError")<{
  * @returns An Effect that resolves to an array of transactions.
  */
 export const fetchFirstBlockTxs = (
-  firstBlockUTxO: UTxO,
+  firstBlockUTxO: SDK.TxBuilder.StateQueue.StateQueueUTxO,
 ): Effect.Effect<{ txs: Uint8Array[]; headerHash: string }, Error, Database> =>
   Effect.gen(function* () {
-    const blockHeader = yield* SDK.Utils.getHeaderFromBlockUTxO(firstBlockUTxO);
+    const blockHeader =
+      yield* SDK.Utils.getHeaderFromStateQueueUTxO(firstBlockUTxO);
     const headerHash = yield* SDK.Utils.hashHeader(blockHeader);
     const txHashes = yield* BlocksDB.retrieveTxHashesByBlockHash(
       fromHex(headerHash),

--- a/demo/midgard-node/src/workers/commit-block-header.ts
+++ b/demo/midgard-node/src/workers/commit-block-header.ts
@@ -24,9 +24,6 @@ const wrapper = (
   _input: WorkerInput,
 ): Effect.Effect<WorkerOutput, Error, NodeConfig | User | Database> =>
   Effect.gen(function* () {
-    if (global.RESET_IN_PROGRESS) {
-      return emptyOutput;
-    }
     const nodeConfig = yield* NodeConfig;
     const { user: lucid } = yield* User;
 

--- a/demo/midgard-node/src/workers/commit-block-header.ts
+++ b/demo/midgard-node/src/workers/commit-block-header.ts
@@ -24,6 +24,9 @@ const wrapper = (
   _input: WorkerInput,
 ): Effect.Effect<WorkerOutput, Error, NodeConfig | User | Database> =>
   Effect.gen(function* () {
+    if (global.RESET_IN_PROGRESS) {
+      return emptyOutput;
+    }
     const nodeConfig = yield* NodeConfig;
     const { user: lucid } = yield* User;
 

--- a/demo/midgard-node/src/workers/commit-block-header.ts
+++ b/demo/midgard-node/src/workers/commit-block-header.ts
@@ -13,7 +13,6 @@ import { fromHex } from "@lucid-evolution/lucid";
 import { makeMpts, processMpts, withTrieTransaction } from "./db.js";
 import { NodeConfig, User } from "@/config.js";
 import { Database } from "@/services/database.js";
-import { SqlClient } from "@effect/sql";
 
 const emptyOutput: WorkerOutput = {
   txSize: 0,

--- a/demo/midgard-node/src/workers/commit-block-header.ts
+++ b/demo/midgard-node/src/workers/commit-block-header.ts
@@ -70,6 +70,7 @@ const wrapper = (
         const { nodeDatum: updatedNodeDatum, header: newHeader } =
           yield* SDK.Utils.updateLatestBlocksDatumAndGetTheNewHeader(
             lucid,
+            policyId,
             latestBlock,
             utxoRoot,
             txRoot,

--- a/demo/midgard-node/src/workers/commit-block-header.ts
+++ b/demo/midgard-node/src/workers/commit-block-header.ts
@@ -69,7 +69,6 @@ const wrapper = (
         const { nodeDatum: updatedNodeDatum, header: newHeader } =
           yield* SDK.Utils.updateLatestBlocksDatumAndGetTheNewHeader(
             lucid,
-            policyId,
             latestBlock,
             utxoRoot,
             txRoot,

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
@@ -3,7 +3,8 @@ import { StateQueue } from "@/tx-builder/index.js";
 import { Effect } from "effect";
 import { utxosAtByNFTPolicyId } from "@/utils/common.js";
 import { makeReturn } from "@/core.js";
-import { StateQueueUTxO, sortStateQueueUTxOs, utxosToStateQueueUTxOs } from "@/utils/state-queue.js";
+import { sortStateQueueUTxOs, utxosToStateQueueUTxOs } from "@/utils/state-queue.js";
+import { StateQueueUTxO } from "@/tx-builder/state-queue/types.js";
 
 export const fetchSortedStateQueueUTxOsProgram = (
   lucid: LucidEvolution,

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
@@ -1,31 +1,22 @@
-import { LucidEvolution, UTxO } from "@lucid-evolution/lucid";
+import { LucidEvolution } from "@lucid-evolution/lucid";
 import { StateQueue } from "@/tx-builder/index.js";
 import { Effect } from "effect";
-import {
-  getSingleAssetApartFromAda,
-  utxosAtByNFTPolicyId,
-} from "@/utils/common.js";
+import { utxosAtByNFTPolicyId } from "@/utils/common.js";
 import { makeReturn } from "@/core.js";
+import { StateQueueUTxO, sortStateQueueUTxOs, utxosToStateQueueUTxOs } from "@/utils/state-queue.js";
 
-export const fetchAllStateQueueUTxOsProgram = (
+export const fetchSortedStateQueueUTxOsProgram = (
   lucid: LucidEvolution,
   config: StateQueue.FetchConfig,
-): Effect.Effect<{ utxo: UTxO; assetName: string }[], Error> =>
+): Effect.Effect<StateQueueUTxO[], Error> =>
   Effect.gen(function* () {
     const allUTxOs = yield* utxosAtByNFTPolicyId(
       lucid,
       config.stateQueueAddress,
       config.stateQueuePolicyId,
     );
-    return yield* Effect.allSuccesses(
-      allUTxOs.map((u: UTxO) => {
-        const singleAssetProgram = getSingleAssetApartFromAda(u.assets);
-        return Effect.map(singleAssetProgram, ([_sym, tn, _qty]) => {
-          // Quantity of 1 and policy ID are already checked.
-          return { utxo: u, assetName: tn };
-        });
-      }),
-    );
+    const unsorted = yield* utxosToStateQueueUTxOs(allUTxOs, config.stateQueuePolicyId);
+    return yield* sortStateQueueUTxOs(unsorted);
   });
 
 /**
@@ -35,7 +26,7 @@ export const fetchAllStateQueueUTxOsProgram = (
  * @param config - Configuration values required to know where to look for which NFT.
  * @returns {UTxO[]} - All the authentic node UTxOs.
  */
-export const fetchAllStateQueueUTxOs = (
+export const fetchSortedStateQueueUTxOs = (
   lucid: LucidEvolution,
   config: StateQueue.FetchConfig,
-) => makeReturn(fetchAllStateQueueUTxOsProgram(lucid, config)).unsafeRun();
+) => makeReturn(fetchSortedStateQueueUTxOsProgram(lucid, config)).unsafeRun();

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
@@ -3,7 +3,10 @@ import { StateQueue } from "@/tx-builder/index.js";
 import { Effect } from "effect";
 import { utxosAtByNFTPolicyId } from "@/utils/common.js";
 import { makeReturn } from "@/core.js";
-import { sortStateQueueUTxOs, utxosToStateQueueUTxOs } from "@/utils/state-queue.js";
+import {
+  sortStateQueueUTxOs,
+  utxosToStateQueueUTxOs,
+} from "@/utils/state-queue.js";
 import { StateQueueUTxO } from "@/tx-builder/state-queue/types.js";
 
 export const fetchSortedStateQueueUTxOsProgram = (
@@ -16,7 +19,10 @@ export const fetchSortedStateQueueUTxOsProgram = (
       config.stateQueueAddress,
       config.stateQueuePolicyId,
     );
-    const unsorted = yield* utxosToStateQueueUTxOs(allUTxOs, config.stateQueuePolicyId);
+    const unsorted = yield* utxosToStateQueueUTxOs(
+      allUTxOs,
+      config.stateQueuePolicyId,
+    );
     return yield* sortStateQueueUTxOs(unsorted);
   });
 

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-confirmed-state-and-its-link.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-confirmed-state-and-its-link.ts
@@ -19,7 +19,7 @@ export const fetchConfirmedStateAndItsLinkProgram = (
       config.stateQueueAddress,
       config.stateQueuePolicyId
     );
-    const allUTxOs = yield* utxosToStateQueueUTxOs(initUTxOs);
+    const allUTxOs = yield* utxosToStateQueueUTxOs(initUTxOs, config.stateQueuePolicyId);
     const filteredForConfirmedState = yield* Effect.allSuccesses(
       allUTxOs.map(getConfirmedStateFromStateQueueUTxO)
     );

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-confirmed-state-and-its-link.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-confirmed-state-and-its-link.ts
@@ -2,7 +2,6 @@ import { Effect } from "effect";
 import { LucidEvolution, UTxO } from "@lucid-evolution/lucid";
 import { makeReturn } from "../../core.js";
 import {
-  StateQueueUTxO,
   getConfirmedStateFromStateQueueUTxO,
   utxosToStateQueueUTxOs,
   findLinkStateQueueUTxO,

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
@@ -1,17 +1,17 @@
 import { Effect } from "effect";
 import { LucidEvolution, UTxO } from "@lucid-evolution/lucid";
 import {
-  StateQueueUTxO,
   utxosAtByNFTPolicyId,
   utxoToStateQueueUTxO,
 } from "../../utils/index.js";
 import { makeReturn } from "../../core.js";
 import { StateQueue } from "../../tx-builder/index.js";
+import { StateQueueUTxO } from "@/tx-builder/state-queue/types.js";
 
 export const fetchLatestCommittedBlockProgram = (
   lucid: LucidEvolution,
   config: StateQueue.FetchConfig,
-): Effect.Effect<UTxO, Error> =>
+): Effect.Effect<StateQueueUTxO, Error> =>
   Effect.gen(function* () {
     const allBlocks = yield* utxosAtByNFTPolicyId(
       lucid,
@@ -24,7 +24,7 @@ export const fetchLatestCommittedBlockProgram = (
         const stateQueueUTxOEffect = utxoToStateQueueUTxO(u, config.stateQueuePolicyId);
         return Effect.andThen(stateQueueUTxOEffect, (squ: StateQueueUTxO) =>
           squ.datum.next === "Empty"
-            ? Effect.succeed(u)
+            ? Effect.succeed(squ)
             : Effect.fail(new Error("Not a tail node")),
         );
       }),

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
@@ -21,7 +21,10 @@ export const fetchLatestCommittedBlockProgram = (
     yield* Effect.logInfo("allBlocks", allBlocks.length);
     const filtered = yield* Effect.allSuccesses(
       allBlocks.map((u: UTxO) => {
-        const stateQueueUTxOEffect = utxoToStateQueueUTxO(u, config.stateQueuePolicyId);
+        const stateQueueUTxOEffect = utxoToStateQueueUTxO(
+          u,
+          config.stateQueuePolicyId,
+        );
         return Effect.andThen(stateQueueUTxOEffect, (squ: StateQueueUTxO) =>
           squ.datum.next === "Empty"
             ? Effect.succeed(squ)

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
@@ -1,8 +1,9 @@
 import { Effect } from "effect";
 import { LucidEvolution, UTxO } from "@lucid-evolution/lucid";
 import {
+  StateQueueUTxO,
   utxosAtByNFTPolicyId,
-  getLinkFromBlockUTxO,
+  utxoToStateQueueUTxO,
 } from "../../utils/index.js";
 import { makeReturn } from "../../core.js";
 import { StateQueue } from "../../tx-builder/index.js";
@@ -20,9 +21,9 @@ export const fetchLatestCommittedBlockProgram = (
     yield* Effect.logInfo("allBlocks", allBlocks.length);
     const filtered = yield* Effect.allSuccesses(
       allBlocks.map((u: UTxO) => {
-        const nodeKeyEffect = getLinkFromBlockUTxO(u);
-        return Effect.andThen(nodeKeyEffect, (nodeKey) =>
-          nodeKey === "Empty"
+        const stateQueueUTxOEffect = utxoToStateQueueUTxO(u);
+        return Effect.andThen(stateQueueUTxOEffect, (squ: StateQueueUTxO) =>
+          squ.datum.next === "Empty"
             ? Effect.succeed(u)
             : Effect.fail(new Error("Not a tail node")),
         );

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-latest-block.ts
@@ -21,7 +21,7 @@ export const fetchLatestCommittedBlockProgram = (
     yield* Effect.logInfo("allBlocks", allBlocks.length);
     const filtered = yield* Effect.allSuccesses(
       allBlocks.map((u: UTxO) => {
-        const stateQueueUTxOEffect = utxoToStateQueueUTxO(u);
+        const stateQueueUTxOEffect = utxoToStateQueueUTxO(u, config.stateQueuePolicyId);
         return Effect.andThen(stateQueueUTxOEffect, (squ: StateQueueUTxO) =>
           squ.datum.next === "Empty"
             ? Effect.succeed(u)

--- a/demo/midgard-sdk/src/tx-builder/state-queue/commit-block-header.ts
+++ b/demo/midgard-sdk/src/tx-builder/state-queue/commit-block-header.ts
@@ -49,7 +49,7 @@ export const commitTxBuilder = (
       .newTx()
       // .validFrom(Number(newHeader.startTime))
       // .validTo(Number(endTime))
-      .collectFrom([latestBlock], Data.void())
+      .collectFrom([latestBlock.utxo], Data.void())
       .pay.ToContract(
         config.stateQueueAddress,
         { kind: "inline", value: Data.to(newNodeDatum, Datum) },
@@ -58,7 +58,7 @@ export const commitTxBuilder = (
       .pay.ToContract(
         config.stateQueueAddress,
         { kind: "inline", value: Data.to(updatedNodeDatum, Datum) },
-        latestBlock.assets,
+        latestBlock.utxo.assets,
       )
       .mintAssets(assets, Data.void())
       .attach.Script(stateQueueSpendingScript)

--- a/demo/midgard-sdk/src/tx-builder/state-queue/merge-to-confirmed-state.ts
+++ b/demo/midgard-sdk/src/tx-builder/state-queue/merge-to-confirmed-state.ts
@@ -6,15 +6,14 @@ import {
   TxBuilder,
   toUnit,
 } from "@lucid-evolution/lucid";
-import { getSingleAssetApartFromAda } from "../../utils/common.js";
 import { ConfirmedState, Header } from "../ledger-state.js";
-import { getNodeDatumFromUTxO } from "../../utils/linked-list.js";
 import {
-  getHeaderFromBlockUTxO,
+  getHeaderFromStateQueueUTxO,
   hashHeader,
 } from "../../utils/ledger-state.js";
 import { NodeDatum } from "../linked-list.js";
 import { Redeemer, FetchConfig, MergeParams } from "./types.js";
+import { getConfirmedStateFromStateQueueUTxO } from "@/utils/state-queue.js";
 
 /**
  * Merge
@@ -34,14 +33,9 @@ export const mergeTxBuilder = (
   }: MergeParams,
 ): Effect.Effect<TxBuilder, Error> =>
   Effect.gen(function* () {
-    const confirmedNode = yield* getNodeDatumFromUTxO(confirmedUTxO);
-    const currentConfirmedNodeDatum = confirmedNode;
-    const currentConfirmedState: ConfirmedState = yield* Effect.try({
-      try: () => Data.castFrom(currentConfirmedNodeDatum.data, ConfirmedState),
-      catch: (e) => new Error(`${e}`),
-    });
-    const blockNode: NodeDatum = yield* getNodeDatumFromUTxO(firstBlockUTxO);
-    const blockHeader: Header = yield* getHeaderFromBlockUTxO(firstBlockUTxO);
+    const { data: currentConfirmedState } =
+      yield* getConfirmedStateFromStateQueueUTxO(confirmedUTxO);
+    const blockHeader: Header = yield* getHeaderFromStateQueueUTxO(firstBlockUTxO);
     const headerHash = yield* hashHeader(blockHeader);
     const newConfirmedState = {
       ...currentConfirmedState,
@@ -52,20 +46,17 @@ export const mergeTxBuilder = (
       endTime: blockHeader.endTime,
     };
     const newConfirmedNodeDatum: NodeDatum = {
-      ...currentConfirmedNodeDatum,
+      ...confirmedUTxO.datum,
       data: Data.castTo(newConfirmedState, ConfirmedState),
-      next: blockNode.next,
+      next: firstBlockUTxO.datum.next,
     };
-    const [nftSym, nftName, _nftQty] = yield* getSingleAssetApartFromAda(
-      firstBlockUTxO.assets,
-    );
     const assetsToBurn: Assets = {
-      [toUnit(nftSym, nftName)]: -1n,
+      [toUnit(fetchConfig.stateQueuePolicyId, firstBlockUTxO.assetName)]: -1n,
     };
     const tx = lucid
       .newTx()
       .collectFrom(
-        [confirmedUTxO, firstBlockUTxO],
+        [confirmedUTxO.utxo, firstBlockUTxO.utxo],
         Data.to("MergeToConfirmedState", Redeemer),
       )
       .pay.ToContract(
@@ -74,7 +65,7 @@ export const mergeTxBuilder = (
           kind: "inline",
           value: Data.to(newConfirmedNodeDatum, NodeDatum),
         },
-        confirmedUTxO.assets,
+        confirmedUTxO.utxo.assets,
       )
       .mintAssets(assetsToBurn, Data.void())
       .attach.Script(stateQueueSpendingScript)

--- a/demo/midgard-sdk/src/tx-builder/state-queue/merge-to-confirmed-state.ts
+++ b/demo/midgard-sdk/src/tx-builder/state-queue/merge-to-confirmed-state.ts
@@ -35,7 +35,8 @@ export const mergeTxBuilder = (
   Effect.gen(function* () {
     const { data: currentConfirmedState } =
       yield* getConfirmedStateFromStateQueueUTxO(confirmedUTxO);
-    const blockHeader: Header = yield* getHeaderFromStateQueueUTxO(firstBlockUTxO);
+    const blockHeader: Header =
+      yield* getHeaderFromStateQueueUTxO(firstBlockUTxO);
     const headerHash = yield* hashHeader(blockHeader);
     const newConfirmedState = {
       ...currentConfirmedState,

--- a/demo/midgard-sdk/src/tx-builder/state-queue/types.ts
+++ b/demo/midgard-sdk/src/tx-builder/state-queue/types.ts
@@ -32,13 +32,19 @@ export const Redeemer = RedeemerSchema as unknown as Redeemer;
 export type Datum = Data.Static<typeof NodeDatumSchema>;
 export const Datum = NodeDatumSchema as unknown as Datum;
 
+export type StateQueueUTxO = {
+  utxo: UTxO;
+  datum: Datum;
+  assetName: string;
+};
+
 export type FetchConfig = {
   stateQueueAddress: Address;
   stateQueuePolicyId: PolicyId;
 };
 
 export type CommitBlockParams = {
-  anchorUTxO: UTxO;
+  anchorUTxO: StateQueueUTxO;
   updatedAnchorDatum: Datum;
   newHeader: Header;
   stateQueueSpendingScript: Script;
@@ -47,8 +53,8 @@ export type CommitBlockParams = {
 };
 
 export type MergeParams = {
-  confirmedUTxO: UTxO;
-  firstBlockUTxO: UTxO;
+  confirmedUTxO: StateQueueUTxO;
+  firstBlockUTxO: StateQueueUTxO;
   stateQueueSpendingScript: Script;
   stateQueueMintingScript: Script;
 };

--- a/demo/midgard-sdk/src/tx-builder/state-queue/types.ts
+++ b/demo/midgard-sdk/src/tx-builder/state-queue/types.ts
@@ -1,8 +1,5 @@
 import { Address, PolicyId, Script, Data, UTxO } from "@lucid-evolution/lucid";
-import {
-  OutputReferenceSchema,
-  POSIXTimeSchema,
-} from "../common.js";
+import { OutputReferenceSchema, POSIXTimeSchema } from "../common.js";
 import { NodeDatumSchema } from "../linked-list.js";
 import { Header } from "../ledger-state.js";
 

--- a/demo/midgard-sdk/src/tx-builder/state-queue/types.ts
+++ b/demo/midgard-sdk/src/tx-builder/state-queue/types.ts
@@ -1,8 +1,6 @@
 import { Address, PolicyId, Script, Data, UTxO } from "@lucid-evolution/lucid";
 import {
-  MerkleRoot,
   OutputReferenceSchema,
-  POSIXTime,
   POSIXTimeSchema,
 } from "../common.js";
 import { NodeDatumSchema } from "../linked-list.js";

--- a/demo/midgard-sdk/src/utils/ledger-state.ts
+++ b/demo/midgard-sdk/src/utils/ledger-state.ts
@@ -5,7 +5,7 @@ import { hashHexWithBlake2b224 } from "./common.js";
 import { StateQueueUTxO } from "@/tx-builder/state-queue/types.js";
 
 export const getHeaderFromStateQueueUTxO = (
-  utxo: StateQueueUTxO
+  utxo: StateQueueUTxO,
 ): Effect.Effect<Header, Error> =>
   Effect.gen(function* () {
     const nodeDatum = utxo.datum;

--- a/demo/midgard-sdk/src/utils/ledger-state.ts
+++ b/demo/midgard-sdk/src/utils/ledger-state.ts
@@ -1,17 +1,18 @@
-import { Data, UTxO } from "@lucid-evolution/lucid";
+import { Data } from "@lucid-evolution/lucid";
 import { Effect } from "effect";
 import { Header } from "../tx-builder/ledger-state.js";
 import { hashHexWithBlake2b224 } from "./common.js";
-import { getNodeDatumFromUTxO } from "./linked-list.js";
+import { StateQueueUTxO } from "@/tx-builder/state-queue/types.js";
 
-export const getHeaderFromBlockUTxO = (
-  blockUTxO: UTxO,
+export const getHeaderFromStateQueueUTxO = (
+  utxo: StateQueueUTxO
 ): Effect.Effect<Header, Error> =>
   Effect.gen(function* () {
-    const nodeDatum = yield* getNodeDatumFromUTxO(blockUTxO);
+    const nodeDatum = utxo.datum;
     const header = yield* Effect.try({
       try: () => Data.castFrom(nodeDatum.data, Header),
-      catch: (e) => new Error(`Failed coercing latest block's datum: ${e}`),
+      catch: (e) =>
+        new Error(`Failed coercing block's datum data to Header: ${e}`),
     });
     return header;
   });

--- a/demo/midgard-sdk/src/utils/state-queue.ts
+++ b/demo/midgard-sdk/src/utils/state-queue.ts
@@ -11,38 +11,51 @@ import { StateQueue } from "../tx-builder/index.js";
 import { getNodeDatumFromUTxO } from "./linked-list.js";
 import { MerkleRoot, POSIXTime } from "../tx-builder/common.js";
 import { Datum } from "@/tx-builder/state-queue/types.js";
-import { getHeaderFromBlockUTxO, hashHeader } from "./ledger-state.js";
 
-export const getLinkFromBlockUTxO = (
-  blockUTxO: UTxO,
-): Effect.Effect<NodeKey, Error> => {
-  const nodeDatum = getNodeDatumFromUTxO(blockUTxO);
-  return Effect.map(nodeDatum, (nd) => nd.next);
+export type StateQueueUTxO = {
+  utxo: UTxO;
+  datum: StateQueue.Datum;
+};
+
+export const utxoToStateQueueUTxO = (
+  utxo: UTxO,
+): Effect.Effect<StateQueueUTxO, Error> => Effect.gen(function* () {
+  const datum = yield* getNodeDatumFromUTxO(utxo);
+  return { utxo, datum };
+});
+
+export const utxosToStateQueueUTxOs = (
+  utxos: UTxO[],
+): Effect.Effect<StateQueueUTxO[], Error> => {
+  const effects = utxos.map(utxoToStateQueueUTxO);
+  return Effect.allSuccesses(effects);
 };
 
 /**
- * Given a block UTxO, this function confirmes the node is root (i.e. no keys
- * in its datum), and attempts to coerce its underlying data into a
+ * Given a StateQueueUTxO, this function confirmes the node is root (i.e. no
+ * keys in its datum), and attempts to coerce its underlying data into a
  * `ConfirmedState`.
  */
-export const getConfirmedStateFromUTxO = (
-  blockUTxO: UTxO,
-): Effect.Effect<{ data: ConfirmedState; link: NodeKey }, Error> => {
-  const datumCBOR = blockUTxO.datum;
-  if (datumCBOR) {
-    try {
-      const nodeDatum = Data.from(datumCBOR, StateQueue.Datum);
-      if (nodeDatum.key === "Empty") {
-        const confirmedState = Data.castFrom(nodeDatum.data, ConfirmedState);
-        return Effect.succeed({ data: confirmedState, link: nodeDatum.next });
-      } else {
-        return Effect.fail(new Error("Given UTxO is not root"));
-      }
-    } catch {
-      return Effect.fail(new Error("Could not coerce to a node datum"));
+export const getConfirmedStateFromStateQueueUTxO = (
+  utxo: StateQueueUTxO
+): Effect.Effect<
+  { utxo: StateQueueUTxO; data: ConfirmedState; link: NodeKey },
+  Error
+> => {
+  try {
+    const nodeDatum = utxo.datum;
+    if (nodeDatum.key === "Empty") {
+      const confirmedState = Data.castFrom(nodeDatum.data, ConfirmedState);
+      return Effect.succeed({
+        utxo,
+        data: confirmedState,
+        link: nodeDatum.next,
+      });
+    } else {
+      return Effect.fail(new Error("Given UTxO is not root"));
     }
-  } else {
-    return Effect.fail(new Error("No datum found"));
+  } catch {
+    return Effect.fail(new Error("Could not coerce to a node datum"));
   }
 };
 
@@ -62,10 +75,9 @@ export const updateLatestBlocksDatumAndGetTheNewHeader = (
   latestBlock: UTxO,
   newUTxOsRoot: MerkleRoot,
   transactionsRoot: MerkleRoot,
-  endTime: POSIXTime,
+  endTime: POSIXTime
 ): Effect.Effect<{ nodeDatum: Datum; header: Header }, Error> =>
   Effect.gen(function* () {
-    // const latestBlock = yield* fetchLatestCommittedBlockProgram(lucid, config);
     const walletAddress = yield* Effect.tryPromise({
       try: () => lucid.wallet().address(),
       catch: (e) => new Error(`Failed to find the wallet: ${e}`),
@@ -73,60 +85,66 @@ export const updateLatestBlocksDatumAndGetTheNewHeader = (
 
     const pubKeyHash = paymentCredentialOf(walletAddress).hash;
 
-    const latestNodeDatum = yield* getNodeDatumFromUTxO(latestBlock);
-
-    if (latestNodeDatum.key === "Empty") {
-      const confirmedState = yield* getConfirmedStateFromUTxO(latestBlock);
-      return {
-        nodeDatum: {
-          ...latestNodeDatum,
-          next: { Key: { key: confirmedState.data.headerHash } },
-        },
-        header: {
-          prevUtxosRoot: confirmedState.data.utxoRoot,
-          utxosRoot: newUTxOsRoot,
-          transactionsRoot,
-          depositsRoot: "00".repeat(32),
-          withdrawalsRoot: "00".repeat(32),
-          startTime: confirmedState.data.endTime,
-          endTime,
-          prevHeaderHash: confirmedState.data.headerHash,
-          operatorVkey: pubKeyHash,
-          protocolVersion: confirmedState.data.protocolVersion,
-        },
-      };
-    } else {
-      const latestHeader = yield* getHeaderFromBlockUTxO(latestBlock);
-      const prevHeaderHash = yield* hashHeader(latestHeader);
-      return {
-        nodeDatum: {
-          ...latestNodeDatum,
-          next: { Key: { key: prevHeaderHash } },
-        },
-        header: {
-          ...latestHeader,
-          prevUtxosRoot: latestHeader.utxosRoot,
-          utxosRoot: newUTxOsRoot,
-          transactionsRoot,
-          startTime: latestHeader.endTime,
-          endTime,
-          prevHeaderHash,
-          operatorVkey: pubKeyHash,
-        },
-      };
-    }
+    const stateQueueUTxO = yield* utxoToStateQueueUTxO(latestBlock);
+    const { data: confirmedState } = yield* getConfirmedStateFromStateQueueUTxO(stateQueueUTxO);
+    return {
+      nodeDatum: {
+        ...stateQueueUTxO.datum,
+        next: { Key: { key: confirmedState.headerHash } },
+      },
+      header: {
+        prevUtxosRoot: confirmedState.utxoRoot,
+        utxosRoot: newUTxOsRoot,
+        transactionsRoot,
+        depositsRoot: "00".repeat(32),
+        withdrawalsRoot: "00".repeat(32),
+        startTime: confirmedState.endTime,
+        endTime,
+        prevHeaderHash: confirmedState.headerHash,
+        operatorVkey: pubKeyHash,
+        protocolVersion: confirmedState.protocolVersion,
+      },
+    };
   });
 
-export const getLatestBlocksUtxosRoot = (
-  latestBlock: UTxO,
-): Effect.Effect<string, Error> =>
-  Effect.gen(function* () {
-    const latestNodeDatum = yield* getNodeDatumFromUTxO(latestBlock);
-    if (latestNodeDatum.key === "Empty") {
-      const confirmedState = yield* getConfirmedStateFromUTxO(latestBlock);
-      return confirmedState.data.utxoRoot;
+export const findLinkStateQueueUTxO = (
+  link: NodeKey,
+  utxos: StateQueueUTxO[],
+): Effect.Effect<StateQueueUTxO, Error> => {
+  if (link === "Empty") {
+    return Effect.fail(new Error("Given link is \"Empty\""));
+  } else {
+    const foundLink = utxos.find(
+      (u: StateQueueUTxO) => (u.datum.key !== "Empty" && u.datum.key.Key.key === link.Key.key));
+    if (foundLink) {
+      return Effect.succeed(foundLink);
     } else {
-      const latestHeader = yield* getHeaderFromBlockUTxO(latestBlock);
-      return latestHeader.utxosRoot;
+      return Effect.fail(new Error("Link not found"));
     }
-  });
+  }
+};
+
+export const sortStateQueueUTxOs = (
+  stateQueueUTxOs: StateQueueUTxO[],
+): Effect.Effect<StateQueueUTxO[], Error> => Effect.gen(function* () {
+  const filteredForConfirmedState = yield* Effect.allSuccesses(
+    stateQueueUTxOs.map(getConfirmedStateFromStateQueueUTxO),
+  );
+  if (filteredForConfirmedState.length === 1) {
+    const { utxo: confirmedStateUTxO, link: linkToOldestBlock } = filteredForConfirmedState[0];
+    const sorted: StateQueueUTxO[] = [confirmedStateUTxO];
+    let link = linkToOldestBlock;
+    while (link !== "Empty") {
+      const linkUTxO = yield* findLinkStateQueueUTxO(
+        link,
+        stateQueueUTxOs,
+      );
+      sorted.push(linkUTxO);
+      link = linkUTxO.datum.next;
+    }
+    return sorted;
+  } else {
+    yield* Effect.fail(new Error("Confirmed state not found among state queue UTxOs."));
+    return [];
+  }
+});

--- a/demo/midgard-sdk/src/utils/state-queue.ts
+++ b/demo/midgard-sdk/src/utils/state-queue.ts
@@ -21,16 +21,16 @@ type StateQueueUTxO = StateQueue.StateQueueUTxO;
  */
 export const utxoToStateQueueUTxO = (
   utxo: UTxO,
-  nftPolicy: string
+  nftPolicy: string,
 ): Effect.Effect<StateQueueUTxO, Error> =>
   Effect.gen(function* () {
     const datum = yield* getNodeDatumFromUTxO(utxo);
     const [sym, assetName, _qty] = yield* getSingleAssetApartFromAda(
-      utxo.assets
+      utxo.assets,
     );
     if (sym !== nftPolicy) {
       yield* Effect.fail(
-        new Error("UTxO's NFT policy ID is not the same as the state queue's")
+        new Error("UTxO's NFT policy ID is not the same as the state queue's"),
       );
     }
     return { utxo, datum, assetName };
@@ -41,7 +41,7 @@ export const utxoToStateQueueUTxO = (
  */
 export const utxosToStateQueueUTxOs = (
   utxos: UTxO[],
-  nftPolicy: string
+  nftPolicy: string,
 ): Effect.Effect<StateQueueUTxO[], Error> => {
   const effects = utxos.map((u) => utxoToStateQueueUTxO(u, nftPolicy));
   return Effect.allSuccesses(effects);
@@ -53,7 +53,7 @@ export const utxosToStateQueueUTxOs = (
  * `ConfirmedState`.
  */
 export const getConfirmedStateFromStateQueueUTxO = (
-  utxo: StateQueueUTxO
+  utxo: StateQueueUTxO,
 ): Effect.Effect<
   { utxo: StateQueueUTxO; data: ConfirmedState; link: NodeKey },
   Error
@@ -91,7 +91,7 @@ export const updateLatestBlocksDatumAndGetTheNewHeader = (
   latestBlock: StateQueueUTxO,
   newUTxOsRoot: MerkleRoot,
   transactionsRoot: MerkleRoot,
-  endTime: POSIXTime
+  endTime: POSIXTime,
 ): Effect.Effect<{ nodeDatum: Datum; header: Header }, Error> =>
   Effect.gen(function* () {
     const walletAddress = yield* Effect.tryPromise({
@@ -146,14 +146,14 @@ export const updateLatestBlocksDatumAndGetTheNewHeader = (
 
 export const findLinkStateQueueUTxO = (
   link: NodeKey,
-  utxos: StateQueueUTxO[]
+  utxos: StateQueueUTxO[],
 ): Effect.Effect<StateQueueUTxO, Error> => {
   if (link === "Empty") {
     return Effect.fail(new Error('Given link is "Empty"'));
   } else {
     const foundLink = utxos.find(
       (u: StateQueueUTxO) =>
-        u.datum.key !== "Empty" && u.datum.key.Key.key === link.Key.key
+        u.datum.key !== "Empty" && u.datum.key.Key.key === link.Key.key,
     );
     if (foundLink) {
       return Effect.succeed(foundLink);
@@ -174,11 +174,11 @@ export const findLinkStateQueueUTxO = (
  *       become cheaper.
  */
 export const sortStateQueueUTxOs = (
-  stateQueueUTxOs: StateQueueUTxO[]
+  stateQueueUTxOs: StateQueueUTxO[],
 ): Effect.Effect<StateQueueUTxO[], Error> =>
   Effect.gen(function* () {
     const filteredForConfirmedState = yield* Effect.allSuccesses(
-      stateQueueUTxOs.map(getConfirmedStateFromStateQueueUTxO)
+      stateQueueUTxOs.map(getConfirmedStateFromStateQueueUTxO),
     );
     if (filteredForConfirmedState.length === 1) {
       const { utxo: confirmedStateUTxO, link: linkToOldestBlock } =
@@ -193,7 +193,7 @@ export const sortStateQueueUTxOs = (
       return sorted;
     } else {
       yield* Effect.fail(
-        new Error("Confirmed state not found among state queue UTxOs.")
+        new Error("Confirmed state not found among state queue UTxOs."),
       );
       return [];
     }

--- a/demo/midgard-sdk/src/utils/state-queue.ts
+++ b/demo/midgard-sdk/src/utils/state-queue.ts
@@ -122,7 +122,7 @@ export const updateLatestBlocksDatumAndGetTheNewHeader = (
     };
   });
 
-const findLinkStateQueueUTxO = (
+export const findLinkStateQueueUTxO = (
   link: NodeKey,
   utxos: StateQueueUTxO[],
 ): Effect.Effect<StateQueueUTxO, Error> => {


### PR DESCRIPTION
- [ ] Merge transaction is often failing (for spending an already spent UTxO). ~The logic of finding confirmed state's link seems to be flawed. This PR attempts to address this.~ The issue is with wallet UTxOs. We can either use tx chaining to submit a merge tx along a block commitment, or implement a cache for spent UTxOs to prevent them from getting repicked.
- [x] The semaphores didn't seem very effective and/or were very restrictive. Instead of keeping track of on-going block submissions, we now only store the length of state queue, and when was the last time it was synced with on-chain state (resyncs after 30 minutes).
- [x] Add more validation on state queue UTxOs by ensuring they all have 1 NFT with the intended policy ID.
- [x] Add a GET endpoint for "drawing" what the state queue looks like in server logs.
- [x] ~After completing a merge transaction, none of the transactions from the merged block seem to be getting removed from BlocksDB. This PR fixes that.~ After adding a logging endpoint, it showed the log from BlocksDB was incorrect—The table is correctly updated.