### PR TITLE
Use Unsorted UTxOs for `reset` Endpoint

### DIFF
--- a/demo/midgard-node/pnpm-lock.yaml
+++ b/demo/midgard-node/pnpm-lock.yaml
@@ -15,16 +15,16 @@ importers:
         specifier: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz
         version: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@effect/experimental':
-        specifier: ^0.46.8
+        specifier: ^0.46.0
         version: 0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12)
       '@effect/opentelemetry':
-        specifier: ^0.44.12
+        specifier: ^0.44.6
         version: 0.44.12(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)(effect@3.16.12)
       '@effect/platform':
-        specifier: ^0.80.21
+        specifier: ^0.80.0
         version: 0.80.21(effect@3.16.12)
       '@effect/platform-node':
-        specifier: ^0.80.3
+        specifier: ^0.80.0
         version: 0.80.3(@effect/cluster@0.31.1(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(@effect/rpc@0.57.1(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.34.1(@effect/experimental@0.46.8(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.80.21(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       '@effect/sql':
         specifier: ^0.34.1
@@ -39,7 +39,7 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0
       '@lucid-evolution/lucid':
-        specifier: ^0.4.29
+        specifier: ^0.4.23
         version: 0.4.29(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/cbor@1.6.6)(@harmoniclabs/crypto@0.2.5)(@harmoniclabs/pair@1.0.0)(fast-check@3.23.2)
       '@opentelemetry/api':
         specifier: ^1.9.0
@@ -66,10 +66,10 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       dotenv:
-        specifier: ^16.6.1
+        specifier: ^16.4.7
         version: 16.6.1
       effect:
-        specifier: ^3.16.12
+        specifier: ^3.14.22
         version: 3.16.12
       lru-cache:
         specifier: ^11.1.0
@@ -78,32 +78,32 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       vitest:
-        specifier: ^3.2.4
+        specifier: ^3.0.7
         version: 3.2.4(@types/node@22.16.0)
     devDependencies:
       '@commander-js/extra-typings':
         specifier: ^13.1.0
         version: 13.1.0(commander@13.1.0)
       '@effect/vitest':
-        specifier: ^0.22.5
+        specifier: ^0.22.0
         version: 0.22.5(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))
       '@types/express':
-        specifier: ^5.0.3
+        specifier: ^5.0.0
         version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: ^22.16.0
+        specifier: ^22.13.5
         version: 22.16.0
       prettier:
-        specifier: ^3.6.2
+        specifier: ^3.5.2
         version: 3.6.2
       tsup:
-        specifier: ^8.5.0
+        specifier: ^8.4.0
         version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)
       typescript:
-        specifier: ^5.8.3
+        specifier: ^5.7.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
@@ -115,7 +115,7 @@ packages:
     resolution: {integrity: sha512-yEie4HFRoQS+ShbEYGNcVEQKFvnClXHFEysYT7lqoL1FGVxwvWWTBsctsEXolUIvusslztzrnJyUG67KGljBKw==}
 
   '@al-ft/midgard-sdk@file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz':
-    resolution: {integrity: sha512-CHWdbxcXsmAtWQ8A2rmqz7jLqYGqx6IdNFBatVJOd2Z5+cAv1PScGtKX3f0QydC98dWfx78jr7m/yIYfd2mK2g==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
+    resolution: {integrity: sha512-5dpJX6yYbwaCcuhqdUU7sKPh1UvzbhebhctQisvIWoNLLB4mMBQBYnegqk+bpYPkKTjtuEF6wSOFqT+pES9c4A==, tarball: file:../midgard-sdk/al-ft-midgard-sdk-0.1.0.tgz}
     version: 0.1.0
 
   '@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2':

--- a/demo/midgard-node/src/transactions/state-queue/reset.ts
+++ b/demo/midgard-node/src/transactions/state-queue/reset.ts
@@ -62,7 +62,7 @@ export const resetStateQueue = Effect.gen(function* () {
   };
 
   const allStateQueueUTxOs =
-    yield* SDK.Endpoints.fetchSortedStateQueueUTxOsProgram(lucid, fetchConfig);
+    yield* SDK.Endpoints.fetchUnsortedStateQueueUTxOsProgram(lucid, fetchConfig);
 
   lucid.selectWallet.fromSeed(nodeConfig.L1_OPERATOR_SEED_PHRASE);
 

--- a/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
+++ b/demo/midgard-sdk/src/endpoints/state-queue/fetch-all-utxos.ts
@@ -26,6 +26,22 @@ export const fetchSortedStateQueueUTxOsProgram = (
     return yield* sortStateQueueUTxOs(unsorted);
   });
 
+export const fetchUnsortedStateQueueUTxOsProgram = (
+  lucid: LucidEvolution,
+  config: StateQueue.FetchConfig,
+): Effect.Effect<StateQueueUTxO[], Error> =>
+  Effect.gen(function* () {
+    const allUTxOs = yield* utxosAtByNFTPolicyId(
+      lucid,
+      config.stateQueueAddress,
+      config.stateQueuePolicyId,
+    );
+    return yield* utxosToStateQueueUTxOs(
+      allUTxOs,
+      config.stateQueuePolicyId,
+    );
+  });
+
 /**
  * Attempts fetching the whole state queue linked list.
  *
@@ -37,3 +53,8 @@ export const fetchSortedStateQueueUTxOs = (
   lucid: LucidEvolution,
   config: StateQueue.FetchConfig,
 ) => makeReturn(fetchSortedStateQueueUTxOsProgram(lucid, config)).unsafeRun();
+
+export const fetchUnsortedStateQueueUTxOs = (
+  lucid: LucidEvolution,
+  config: StateQueue.FetchConfig,
+) => makeReturn(fetchUnsortedStateQueueUTxOsProgram(lucid, config)).unsafeRun();


### PR DESCRIPTION
Using sorted UTxOs had led to failures in cases of interrupted, multi-transaction reset processes (as the head got spent in the very first transaction, which is needed for sorting the linked list).