### PR TITLE
fix: mempool tx counter

### DIFF
--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -413,9 +413,8 @@ const mergeAction = Effect.gen(function* () {
 });
 
 const mempoolAction = Effect.gen(function* () {
-  const txList = yield* MempoolDB.retrieve();
-  const numTx = BigInt(txList.length);
-  yield* mempoolTxGauge(Effect.succeed(numTx));
+  const numTx = yield* MempoolDB.retrieveNumberOfEntries();
+  yield* mempoolTxGauge(Effect.succeed(BigInt(numTx)));
 });
 
 const blockCommitmentFork = (rerunDelay: number) =>

--- a/demo/midgard-node/src/database/mempool.ts
+++ b/demo/midgard-node/src/database/mempool.ts
@@ -6,6 +6,7 @@ import {
   retrieveValues,
   retrieveKeyValues,
 } from "./utils.js";
+import * as Utils from "./utils.js";
 
 export const tableName = "mempool";
 
@@ -19,6 +20,9 @@ export const retrieveTxCborsByHashes = (txHashes: Uint8Array[]) =>
   retrieveValues(tableName, txHashes);
 
 export const retrieve = () => retrieveKeyValues(tableName);
+
+export const retrieveNumberOfEntries = () =>
+  Utils.retrieveNumberOfEntries(tableName);
 
 export const clearTxs = (txHashes: Uint8Array[]) =>
   delMultiple(tableName, txHashes);

--- a/demo/midgard-node/src/database/utils.ts
+++ b/demo/midgard-node/src/database/utils.ts
@@ -167,6 +167,26 @@ export const retrieveKeyValues = (
     mapSqlError,
   );
 
+export const retrieveNumberOfEntries = (
+  tableName: string,
+): Effect.Effect<number, Error, Database> =>
+  Effect.gen(function* () {
+    yield* Effect.logDebug(`${tableName} db: attempt to get number of entries`);
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<{
+      count: number;
+    }>`SELECT COUNT(*) FROM ${sql(tableName)}`;
+    return rows[0].count ?? 0;
+  }).pipe(
+    Effect.withLogSpan(`get number of entries ${tableName}`),
+    Effect.tapErrorTag("SqlError", (e) =>
+      Effect.logError(
+        `${tableName} db: insert keyValues: ${JSON.stringify(e)}`,
+      ),
+    ),
+    mapSqlError,
+  );
+
 export const mapSqlError = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, Exclude<E, SqlError.SqlError> | Error, R> =>


### PR DESCRIPTION
Currently, to determine the number of transactions in the mempool database, the node retrieves all transaction entries. This approach negatively impacts performance, especially as the transaction volume grows.
This PR improves efficiency by replacing the full retrieval of transaction records with a simple query that fetches only the count of transactions from the database. 