### PR TITLE
fix: similar txHash and outputIndex running tx-generator

### DIFF
--- a/demo/midgard-manager/packages/tx-generator/src/lib/generators/one-to-one.ts
+++ b/demo/midgard-manager/packages/tx-generator/src/lib/generators/one-to-one.ts
@@ -140,7 +140,7 @@ const generateOneToOneTransactions = async (
     // Use the output of initial transaction for subsequent transactions
     const firstUtxo = {
       txHash: initialTxSigned.toHash(),
-      outputIndex: 0,
+      outputIndex: initialUTxO.outputIndex,
       address: initialUTxO.address,
       assets: initialUTxO.assets,
     };

--- a/demo/midgard-manager/packages/tx-generator/src/lib/scheduler/scheduler.ts
+++ b/demo/midgard-manager/packages/tx-generator/src/lib/scheduler/scheduler.ts
@@ -147,7 +147,7 @@ const generateUniqueUTxOs = (baseUTxO: UTxO, count: number) =>
   Array.from({ length: count }, () => ({
     ...baseUTxO,
     txHash: randomBytes(32).toString('hex').toUpperCase(),
-    outputIndex: Math.floor(Math.random() * 10), // Random outputIndex 0 -> 9
+    outputIndex: Math.floor(Math.random() * 1001), // Random outputIndex 0 -> 1000
   }));
 
     


### PR DESCRIPTION
Running the Tx-generator produces similar TxHash and outputIndex, this update generates random txHashes and outputIndexes to alleviate this challenge.