### PR TITLE
Modify getLogStateQueueHandler so it also returns the list of header_hashes

### DIFF
--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -77,6 +77,7 @@ const INIT_ENDPOINT: string = "init";
 const COMMIT_ENDPOINT: string = "commit";
 const RESET_ENDPOINT: string = "reset";
 const SUBMIT_ENDPOINT: string = "submit";
+const STATE_QUEUE_ENDPOINT: string = "stateQueue";
 
 const txCounter = Metric.counter("tx_count", {
   description: "A counter for tracking submit transactions",
@@ -416,7 +417,7 @@ const getTxsOfAddressHandler = Effect.gen(function* () {
   ),
 );
 
-const getLogStateQueueHandler = Effect.gen(function* () {
+const getStateQueueHandler = Effect.gen(function* () {
   yield* Effect.logInfo(`✍  Drawing state queue UTxOs...`);
   const lucid = yield* Lucid;
   const alwaysSucceeds = yield* AlwaysSucceedsContract;
@@ -456,7 +457,6 @@ ${emoji} ${u.utxo.txHash}#${u.utxo.outputIndex}${info}`;
 `;
   yield* Effect.logInfo(drawn);
   return yield* HttpServerResponse.json({
-    message: `State queue drawn in server logs!`,
     headers,
   });
 }).pipe(
@@ -587,7 +587,7 @@ const router = (
       HttpRouter.get(`/${COMMIT_ENDPOINT}`, getCommitEndpoint),
       HttpRouter.get(`/${MERGE_ENDPOINT}`, getMergeHandler),
       HttpRouter.get(`/${RESET_ENDPOINT}`, getResetHandler),
-      HttpRouter.get(`/logStateQueue`, getLogStateQueueHandler),
+      HttpRouter.get(`/${STATE_QUEUE_ENDPOINT}`, getStateQueueHandler),
       HttpRouter.get(`/logBlocksDB`, getLogBlocksDBHandler),
       HttpRouter.get(`/logGlobals`, getLogGlobalsHandler),
       HttpRouter.post(`/${SUBMIT_ENDPOINT}`, postSubmitHandler(txQueue)),


### PR DESCRIPTION
getLogStateQueueHandler can also return the sorted header_hashes easily, so there is not need for code duplication (in case we wanted an endpoint that returns the header_hashes)

Before: 
```
{
    "message": "State queue drawn in server logs!",
}
```

After:
```
{
    "message": "State queue drawn in server logs!",
    "headers": [
        "1200ffb3c86a9a9caa7019a84fbac82e3e69fade7d7e9e0d627609c9",
        "13b90a480316d91b6700ee02621cf40edc10868a959c3a62f7759325",
        "ccdb82bf6fc712efd6a800c3a2ad5896779edc425930874ef7d0f845"
    ]
}
```