### PR TITLE
Bump `aiken-design-patterns`

### DIFF
--- a/.github/workflows/aiken-ci.yml
+++ b/.github/workflows/aiken-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aiken-lang/setup-aiken@v1.0.3
         with:
-          version: v1.1.19
+          version: v1.1.21
       - name: Run Aiken auto-formatter
         run: aiken fmt --check
       - name: Compile Aiken code and run test suite

--- a/.github/workflows/midgard-node-ci.yml
+++ b/.github/workflows/midgard-node-ci.yml
@@ -9,6 +9,7 @@ on:
       - "demo/midgard-sdk/**"
       - "demo/midgard-core/**"
       - "demo/midgard-validation/**"
+      - "onchain/aiken/**"
       - "demo/pnpm-lock.yaml"
       - "demo/pnpm-workspace.yaml"
       - ".github/workflows/midgard-node-ci.yml"
@@ -19,6 +20,7 @@ on:
       - "demo/midgard-sdk/**"
       - "demo/midgard-core/**"
       - "demo/midgard-validation/**"
+      - "onchain/aiken/**"
       - "demo/pnpm-lock.yaml"
       - "demo/pnpm-workspace.yaml"
       - ".github/workflows/midgard-node-ci.yml"
@@ -59,6 +61,9 @@ jobs:
       TESTNET_GENESIS_WALLET_SEED_PHRASE_C: "cactus chalk grit reopen true slight whale sand law sibling silver fringe cement twist process bracket history leopard churn federal coral three hockey fossil"
     steps:
       - uses: actions/checkout@v4
+      - uses: aiken-lang/setup-aiken@v1.0.3
+        with:
+          version: v1.1.21
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -69,11 +74,16 @@ jobs:
           cache-dependency-path: demo/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm --dir demo install --frozen-lockfile
-      - name: Build lucid-midgard workspace deps
-        run: pnpm --dir demo/midgard-validation run build
+      - name: Build testnet Aiken blueprint
+        working-directory: onchain/aiken
+        run: aiken build --env testnet
+      - name: Build lucid-midgard
+        run: pnpm --dir demo/lucid-midgard run build
       - name: Typecheck lucid-midgard
         run: pnpm --dir demo/lucid-midgard run typecheck
       - name: Test lucid-midgard
         run: pnpm --dir demo/lucid-midgard test
+      - name: Build midgard-sdk
+        run: pnpm --dir demo/midgard-sdk run build
       - name: Test Midgard node
         run: pnpm --dir demo/midgard-node test

--- a/.github/workflows/midgard-node-ci.yml
+++ b/.github/workflows/midgard-node-ci.yml
@@ -69,6 +69,8 @@ jobs:
           cache-dependency-path: demo/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm --dir demo install --frozen-lockfile
+      - name: Build lucid-midgard workspace deps
+        run: pnpm --dir demo/midgard-validation run build
       - name: Typecheck lucid-midgard
         run: pnpm --dir demo/lucid-midgard run typecheck
       - name: Test lucid-midgard

--- a/.github/workflows/midgard-node-ci.yml
+++ b/.github/workflows/midgard-node-ci.yml
@@ -53,6 +53,7 @@ jobs:
       NETWORK: Preprod
       RUN_GENESIS_ON_STARTUP: "false"
       POSTGRES_HOST: 127.0.0.1
+      POSTGRES_PORT: 5432
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: midgard

--- a/demo/midgard-fault-proofs/src/remove-fraudulent-block.ts
+++ b/demo/midgard-fault-proofs/src/remove-fraudulent-block.ts
@@ -14,7 +14,9 @@ import {
   HUB_ORACLE_ASSET_NAME,
   incompleteRemoveFraudulentBlocksLinkTxProgram,
   incompleteRemoveLastFraudulentBlockHeaderTxProgram,
+  outputReferenceFromUTxO,
   type LinkedListNodeView,
+  type OutputReference,
   parseFaultProofBlueprint,
   REGISTERED_OPERATORS_ROOT_ASSET_NAME,
   RETIRED_OPERATOR_NODE_ASSET_NAME_PREFIX,
@@ -124,16 +126,13 @@ type RemoveFraudulentBlockContracts = {
 };
 
 type RemoveFraudulentBlockLayout = {
-  readonly fraudulentNodeInputIndex: bigint;
   readonly fraudProofRefInputIndex: bigint;
   readonly stateQueueRedeemerTxInfoIndex: bigint;
   readonly activeOperatorsRedeemerTxInfoIndex?: bigint;
   readonly retiredOperatorsRedeemerTxInfoIndex?: bigint;
   readonly activeOperatorsElementRefInputIndex?: bigint;
   readonly retiredOperatorsElementRefInputIndex?: bigint;
-  readonly anchorElementInputIndex?: bigint;
   readonly anchorElementOutputIndex?: bigint;
-  readonly removedBlockInputIndex?: bigint;
   readonly fraudulentNodeOutputIndex?: bigint;
 };
 
@@ -141,8 +140,7 @@ type OperatorSlashingLayout = {
   readonly activeOperatorsRedeemerTxInfoIndex?: bigint;
   readonly retiredOperatorsRedeemerTxInfoIndex?: bigint;
   readonly stateQueueRedeemerTxInfoIndex: bigint;
-  readonly operatorDirectoryAnchorInputIndex: bigint;
-  readonly operatorDirectoryNodeInputIndex: bigint;
+  readonly operatorDirectoryAnchorInputOutRef: OutputReference;
   readonly operatorDirectoryAnchorOutputIndex: bigint;
   readonly schedulerRefInputIndex?: bigint;
   readonly schedulerInputIndex?: bigint;
@@ -154,16 +152,13 @@ type OperatorSlashingLayout = {
 };
 
 const REMOVE_LAYOUT_KEYS = [
-  "fraudulentNodeInputIndex",
   "fraudProofRefInputIndex",
   "stateQueueRedeemerTxInfoIndex",
   "activeOperatorsRedeemerTxInfoIndex",
   "retiredOperatorsRedeemerTxInfoIndex",
   "activeOperatorsElementRefInputIndex",
   "retiredOperatorsElementRefInputIndex",
-  "anchorElementInputIndex",
   "anchorElementOutputIndex",
-  "removedBlockInputIndex",
   "fraudulentNodeOutputIndex",
 ] as const satisfies readonly (keyof RemoveFraudulentBlockLayout)[];
 
@@ -1211,10 +1206,8 @@ const makeActiveOperatorsMintRedeemerFromPlan =
         slashing_arguments: {
           slashed_operator: operator,
           hub_oracle_ref_input_index: layout.hubOracleRefInputIndex,
-          slashed_operator_anchor_element_input_index:
-            layout.operatorDirectoryAnchorInputIndex,
-          slashed_operator_node_input_index:
-            layout.operatorDirectoryNodeInputIndex,
+          slashed_operator_anchor_element_input_outref:
+            layout.operatorDirectoryAnchorInputOutRef,
           slashed_operator_anchor_element_output_index:
             layout.operatorDirectoryAnchorOutputIndex,
           slashing_reason: {
@@ -1236,10 +1229,8 @@ const makeRetiredOperatorsMintRedeemerFromPlan =
         {
           slashed_operator: operator,
           hub_oracle_ref_input_index: layout.hubOracleRefInputIndex,
-          slashed_operator_anchor_element_input_index:
-            layout.operatorDirectoryAnchorInputIndex,
-          slashed_operator_node_input_index:
-            layout.operatorDirectoryNodeInputIndex,
+          slashed_operator_anchor_element_input_outref:
+            layout.operatorDirectoryAnchorInputOutRef,
           slashed_operator_anchor_element_output_index:
             layout.operatorDirectoryAnchorOutputIndex,
           slashing_reason: {
@@ -1683,7 +1674,6 @@ const deriveOperatorSlashingLayoutFromRedeemerContext = ({
 }): OperatorSlashingLayout => {
   const {
     operatorDirectoryAnchor,
-    operatorDirectoryNode,
     hubOracle,
     operatorDirectoryAnchorUnit,
     slashedOperatorDirectory,
@@ -1711,15 +1701,8 @@ const deriveOperatorSlashingLayoutFromRedeemerContext = ({
       contracts.stateQueuePolicyId,
       "state-queue remove fraudulent block",
     ),
-    operatorDirectoryAnchorInputIndex: requireInputIndex(
-      ctx,
+    operatorDirectoryAnchorInputOutRef: outputReferenceFromUTxO(
       operatorDirectoryAnchor,
-      `${slashingDirectoryLabel} anchor input`,
-    ),
-    operatorDirectoryNodeInputIndex: requireInputIndex(
-      ctx,
-      operatorDirectoryNode,
-      `${slashingDirectoryLabel} node input`,
     ),
     operatorDirectoryAnchorOutputIndex: requireOutputIndexByUnit({
       outputs: ctx.outputs,
@@ -1908,11 +1891,6 @@ const makeStateQueueRemoveMintRedeemer = ({
     const { slashingApproach, layout: slashingLayout } =
       resolveStateQueueSlashingApproach({ ctx, slashing, contracts });
     const fraudulentNodeInput = kind === "remove-successor" ? anchor : removed;
-    const fraudulentNodeInputIndex = requireInputIndex(
-      ctx,
-      fraudulentNodeInput.utxo,
-      "remove-fraudulent-block fraudulent state-queue node",
-    );
     const fraudProofRefInputIndex = requireReferenceInputIndex(
       ctx,
       fraudProofRefInput,
@@ -1923,7 +1901,6 @@ const makeStateQueueRemoveMintRedeemer = ({
       anchor.assetName,
     );
     const commonLayout = {
-      fraudulentNodeInputIndex,
       fraudProofRefInputIndex,
       stateQueueRedeemerTxInfoIndex,
       ...slashingLayout,
@@ -1932,16 +1909,10 @@ const makeStateQueueRemoveMintRedeemer = ({
       fraudulent_operator: fraudulentOperator,
       fraudulent_blocks_header_hash: fraudulentBlocksHeaderHash,
       slashing_approach: slashingApproach,
-      fraudulent_node_input_index: fraudulentNodeInputIndex,
       fraud_proof_ref_input_index: fraudProofRefInputIndex,
     };
 
     if (kind === "remove-successor") {
-      const removedBlockInputIndex = requireInputIndex(
-        ctx,
-        removed.utxo,
-        "remove-fraudulent-block removed successor",
-      );
       const fraudulentNodeOutputIndex = requireOutputIndexByUnit({
         outputs: ctx.outputs,
         address: contracts.stateQueueAddress,
@@ -1950,7 +1921,6 @@ const makeStateQueueRemoveMintRedeemer = ({
       });
       onLayout({
         ...commonLayout,
-        removedBlockInputIndex,
         fraudulentNodeOutputIndex,
       });
       return Data.to(
@@ -1959,8 +1929,10 @@ const makeStateQueueRemoveMintRedeemer = ({
             ...commonRedeemer,
             block_removal_approach: {
               RemoveFraudulentBlocksLink: {
+                fraudulent_node_input_outref: outputReferenceFromUTxO(
+                  fraudulentNodeInput.utxo,
+                ),
                 fraudulent_node_output_index: fraudulentNodeOutputIndex,
-                removed_block_input_index: removedBlockInputIndex,
               },
             },
           },
@@ -1969,11 +1941,6 @@ const makeStateQueueRemoveMintRedeemer = ({
       );
     }
 
-    const anchorElementInputIndex = requireInputIndex(
-      ctx,
-      anchor.utxo,
-      "remove-fraudulent-block predecessor anchor",
-    );
     const anchorElementOutputIndex = requireOutputIndexByUnit({
       outputs: ctx.outputs,
       address: contracts.stateQueueAddress,
@@ -1982,7 +1949,6 @@ const makeStateQueueRemoveMintRedeemer = ({
     });
     onLayout({
       ...commonLayout,
-      anchorElementInputIndex,
       anchorElementOutputIndex,
     });
     return Data.to(
@@ -1991,7 +1957,7 @@ const makeStateQueueRemoveMintRedeemer = ({
           ...commonRedeemer,
           block_removal_approach: {
             RemoveLastFraudulentBlock: {
-              anchor_element_input_index: anchorElementInputIndex,
+              anchor_element_input_outref: outputReferenceFromUTxO(anchor.utxo),
               anchor_element_output_index: anchorElementOutputIndex,
             },
           },

--- a/demo/midgard-fault-proofs/tests/submit-init-emulator.test.ts
+++ b/demo/midgard-fault-proofs/tests/submit-init-emulator.test.ts
@@ -52,6 +52,7 @@ import {
   HubOracleDatum,
   incompleteEmulatorCommitBlockHeaderTxProgram,
   makeHubOracleDatum,
+  outputReferenceFromUTxO,
   type MidgardValidators,
   type MintingValidator,
   parseFaultProofBlueprint,
@@ -63,7 +64,6 @@ import {
   requireReferenceInputIndex,
   requireMintRedeemerIndex,
   requireOwnMintPurpose,
-  requireSpendRedeemerIndex,
   requireUniqueOutputIndex,
   SCHEDULER_ASSET_NAME,
   SchedulerDatum,
@@ -131,7 +131,7 @@ const alwaysSucceedsBlueprintPath = resolve(
 const network: Network = "Preprod";
 const EMULATOR_PROTOCOL_PARAMETERS = {
   ...PROTOCOL_PARAMETERS_DEFAULT,
-  maxTxSize: 65_536,
+  maxTxSize: 131_072,
   maxCollateralInputs: 3,
 } as const;
 
@@ -1085,7 +1085,6 @@ const submitSetupTx = async ({
         ActivateOperator: {
           new_active_operator_key: header.operatorVkey,
           new_active_operator_bond_unlock_time: null,
-          active_operator_anchor_element_input_index: 0n,
           active_operator_anchor_element_output_index:
             ACTIVE_OPERATOR_ACTIVATION_OUTPUT_INDEX.root,
           active_operator_inserted_node_output_index:
@@ -1110,8 +1109,9 @@ const submitSetupTx = async ({
       {
         ActivateOperator: {
           activating_operator: header.operatorVkey,
-          anchor_element_input_index: 0n,
-          removed_node_input_index: 0n,
+          anchor_element_input_outref: outputReferenceFromUTxO(
+            initialActiveOperatorsRoot,
+          ),
           anchor_element_output_index:
             ACTIVE_OPERATOR_ACTIVATION_OUTPUT_INDEX.root,
           hub_oracle_ref_input_index: 0n,
@@ -1326,10 +1326,10 @@ const submitSetupTx = async ({
             stateQueueRoot.utxo,
             "commit state-queue root input",
           ),
-          state_queue_redeemer_index: requireSpendRedeemerIndex(
+          state_queue_redeemer_index: requireMintRedeemerIndex(
             ctx,
-            stateQueueRoot.utxo,
-            "commit state-queue spend redeemer",
+            contracts.stateQueue.policyId,
+            "commit state-queue mint redeemer",
           ),
         },
       } satisfies ActiveOperatorSpendRedeemer,
@@ -1501,10 +1501,10 @@ const submitSuccessorBlockTx = async ({
             anchorBlock.utxo,
             "successor commit state-queue anchor input",
           ),
-          state_queue_redeemer_index: requireSpendRedeemerIndex(
+          state_queue_redeemer_index: requireMintRedeemerIndex(
             ctx,
-            anchorBlock.utxo,
-            "successor commit state-queue spend redeemer",
+            contracts.stateQueue.policyId,
+            "successor commit state-queue mint redeemer",
           ),
         },
       } satisfies ActiveOperatorSpendRedeemer,

--- a/demo/midgard-fault-proofs/tests/submit-init-emulator.test.ts
+++ b/demo/midgard-fault-proofs/tests/submit-init-emulator.test.ts
@@ -131,7 +131,7 @@ const alwaysSucceedsBlueprintPath = resolve(
 const network: Network = "Preprod";
 const EMULATOR_PROTOCOL_PARAMETERS = {
   ...PROTOCOL_PARAMETERS_DEFAULT,
-  maxTxSize: 131_072,
+  maxTxSize: 65_536,
   maxCollateralInputs: 3,
 } as const;
 

--- a/demo/midgard-node/tests/sdk-abi-fixtures.test.ts
+++ b/demo/midgard-node/tests/sdk-abi-fixtures.test.ts
@@ -55,6 +55,10 @@ const fields = (ctor: BlueprintConstructor): readonly string[] =>
 const h28 = "11".repeat(28);
 const h32 = "22".repeat(32);
 const h64 = "33".repeat(64);
+const outputReference: SDK.OutputReference = {
+  transactionId: h32,
+  outputIndex: 0n,
+};
 const address: SDK.AddressData = {
   paymentCredential: { PublicKeyCredential: [h28] },
   stakeCredential: null,
@@ -88,8 +92,7 @@ describe("SDK canonical ABI fixtures", () => {
       ),
     ).toEqual([
       "header_node_key",
-      "header_node_input_index",
-      "confirmed_state_input_index",
+      "confirmed_state_input_outref",
       "confirmed_state_output_index",
       "m_settlement_redeemer_index",
       "merged_block_transactions_root",
@@ -238,11 +241,11 @@ describe("SDK canonical ABI fixtures", () => {
     ]);
 
     expectRoundTrip({ Init: { output_index: 2n } }, SDK.StateQueueRedeemer);
+    expectRoundTrip("LinkedListMutation", SDK.StateQueueSpendRedeemer);
     expect(
       roundTrip(
         {
           CommitBlockHeader: {
-            latest_block_input_index: 0n,
             new_block_output_index: 1n,
             continued_latest_block_output_index: 2n,
             operator: h28,
@@ -259,8 +262,7 @@ describe("SDK canonical ABI fixtures", () => {
         {
           MergeToConfirmedState: {
             header_node_key: h28,
-            header_node_input_index: 1n,
-            confirmed_state_input_index: 0n,
+            confirmed_state_input_outref: outputReference,
             confirmed_state_output_index: 0n,
             m_settlement_redeemer_index: 2n,
             merged_block_transactions_root: h32,
@@ -277,7 +279,6 @@ describe("SDK canonical ABI fixtures", () => {
         {
           RegisterOperator: {
             registering_operator: h28,
-            root_input_index: 0n,
             root_output_index: 0n,
             registered_node_output_index: 1n,
             hub_oracle_ref_input_index: 0n,
@@ -296,7 +297,6 @@ describe("SDK canonical ABI fixtures", () => {
           ActivateOperator: {
             new_active_operator_key: h28,
             new_active_operator_bond_unlock_time: null,
-            active_operator_anchor_element_input_index: 0n,
             active_operator_anchor_element_output_index: 0n,
             active_operator_inserted_node_output_index: 1n,
             registered_operators_redeemer_index: 2n,

--- a/demo/midgard-sdk/src/active-operators.ts
+++ b/demo/midgard-sdk/src/active-operators.ts
@@ -9,6 +9,7 @@ import { Effect } from "effect";
 import {
   AuthenticatedValidator,
   LucidError,
+  OutputReferenceSchema,
   POSIXTimeSchema,
 } from "@/common.js";
 import { authenticateUTxOs, AuthenticUTxO } from "@/internals.js";
@@ -41,8 +42,7 @@ export const SlashingReason = SlashingReasonSchema as unknown as SlashingReason;
 export const SlashingArgumentsSchema = Data.Object({
   slashed_operator: Data.Bytes({ minLength: 28, maxLength: 28 }),
   hub_oracle_ref_input_index: Data.Integer(),
-  slashed_operator_anchor_element_input_index: Data.Integer(),
-  slashed_operator_node_input_index: Data.Integer(),
+  slashed_operator_anchor_element_input_outref: OutputReferenceSchema,
   slashed_operator_anchor_element_output_index: Data.Integer(),
   slashing_reason: SlashingReasonSchema,
 });
@@ -118,16 +118,11 @@ export const ActiveOperatorMintRedeemerSchema = Data.Enum([
       output_index: Data.Integer(),
     }),
   }),
-  Data.Object({
-    Deinit: Data.Object({
-      input_index: Data.Integer(),
-    }),
-  }),
+  Data.Literal("Deinit"),
   Data.Object({
     ActivateOperator: Data.Object({
       new_active_operator_key: Data.Bytes({ minLength: 28, maxLength: 28 }),
       new_active_operator_bond_unlock_time: Data.Nullable(POSIXTimeSchema),
-      active_operator_anchor_element_input_index: Data.Integer(),
       active_operator_anchor_element_output_index: Data.Integer(),
       active_operator_inserted_node_output_index: Data.Integer(),
       registered_operators_redeemer_index: Data.Integer(),
@@ -137,8 +132,7 @@ export const ActiveOperatorMintRedeemerSchema = Data.Enum([
     RetireOperator: Data.Object({
       active_operator_key: Data.Bytes({ minLength: 28, maxLength: 28 }),
       hub_oracle_ref_input_index: Data.Integer(),
-      active_operator_anchor_element_input_index: Data.Integer(),
-      active_operator_removed_node_input_index: Data.Integer(),
+      active_operator_anchor_element_input_outref: OutputReferenceSchema,
       active_operator_anchor_element_output_index: Data.Integer(),
       retired_operators_redeemer_index: Data.Integer(),
       penalize_for_inactivity: Data.Boolean(),

--- a/demo/midgard-sdk/src/active-operators.ts
+++ b/demo/midgard-sdk/src/active-operators.ts
@@ -79,7 +79,6 @@ export const ActiveOperatorSpendRedeemerSchema = Data.Enum([
       active_node_input_index: Data.Integer(),
       active_node_output_index: Data.Integer(),
       hub_oracle_ref_input_index: Data.Integer(),
-      state_queue_input_index: Data.Integer(),
       state_queue_redeemer_index: Data.Integer(),
     }),
   }),

--- a/demo/midgard-sdk/src/common.ts
+++ b/demo/midgard-sdk/src/common.ts
@@ -189,6 +189,13 @@ export type OutputReference = Data.Static<typeof OutputReferenceSchema>;
 export const OutputReference =
   OutputReferenceSchema as unknown as OutputReference;
 
+export const outputReferenceFromUTxO = (
+  utxo: Pick<UTxO, "txHash" | "outputIndex">,
+): OutputReference => ({
+  transactionId: utxo.txHash,
+  outputIndex: BigInt(utxo.outputIndex),
+});
+
 export const AssetsSchema = Data.Object({
   policyId: Data.Bytes(),
   assetName: Data.Bytes(),

--- a/demo/midgard-sdk/src/ledger-state.ts
+++ b/demo/midgard-sdk/src/ledger-state.ts
@@ -32,17 +32,27 @@ export const HeaderSchema = Data.Object({
 });
 export type Header = Data.Static<typeof HeaderSchema>;
 export const Header = HeaderSchema as unknown as Header;
-export const castHeaderToData = (header: Header): unknown =>
-  Data.castTo(header, Header);
+
+export const NO_DA_ATTESTATION = "";
+
+export const StateQueueNodeSchema = Data.Object({
+  header: HeaderSchema,
+  da_attestation: Data.Bytes(),
+});
+export type StateQueueNode = Data.Static<typeof StateQueueNodeSchema>;
+export const StateQueueNode = StateQueueNodeSchema as unknown as StateQueueNode;
+export const castStateQueueNodeToData = (
+  node: StateQueueNode,
+): unknown => Data.castTo(node, StateQueueNode);
 
 export const getHeaderFromStateQueueDatum = (nodeDatum: {
   readonly data: Parameters<typeof Data.castFrom>[0];
 }): Effect.Effect<Header, DataCoercionError> =>
   Effect.try({
-    try: () => Data.castFrom(nodeDatum.data, Header),
+    try: () => Data.castFrom(nodeDatum.data, StateQueueNode).header,
     catch: (cause) =>
       new DataCoercionError({
-        message: "Failed coercing block's datum data to `Header`",
+        message: "Failed coercing block's datum data to `StateQueueNode`",
         cause,
       }),
   });

--- a/demo/midgard-sdk/src/operator-lifecycle.ts
+++ b/demo/midgard-sdk/src/operator-lifecycle.ts
@@ -10,6 +10,7 @@ import {
 import { canonicalPlutusDataCbor } from "@al-ft/midgard-core/plutus-data-cbor";
 
 import * as SDK from "@/operator-lifecycle/primitives.js";
+import { outputReferenceFromUTxO } from "@/common.js";
 import {
   type ActivateRedeemerLayout,
   type NodeWithDatum,
@@ -17,7 +18,6 @@ import {
   type RegisterRedeemerLayout,
 } from "@/operator-lifecycle/layout.js";
 import {
-  requireInputIndex,
   requireMintRedeemerIndex,
   requireOwnMintPurpose,
   requireReferenceInputIndex,
@@ -102,10 +102,8 @@ const registeredActivateRedeemer = ({
     {
       ActivateOperator: {
         activating_operator: operatorKeyHash,
-        anchor_element_input_index:
-          layout.registeredOperatorsAnchorNodeInputIndex,
-        removed_node_input_index:
-          layout.registeredOperatorsRemovedNodeInputIndex,
+        anchor_element_input_outref:
+          layout.registeredOperatorsAnchorNodeInputOutRef,
         anchor_element_output_index:
           layout.registeredOperatorsAnchorNodeOutputIndex,
         hub_oracle_ref_input_index: layout.hubOracleRefInputIndex,
@@ -145,11 +143,6 @@ const deriveRegisterLayoutFromContext = ({
   readonly prependedNodeDatumCbor: string;
   readonly updatedRegisteredRootDatumCbor: string;
 }): RegisterRedeemerLayout => ({
-  rootInputIndex: requireInputIndex(
-    ctx,
-    config.registeredRootNode.utxo,
-    "registered-operator register root",
-  ),
   hubOracleRefInputIndex: requireReferenceInputIndex(
     ctx,
     config.hubOracleRefInput,
@@ -223,7 +216,6 @@ export const buildRegisterOperatorTx = (
       {
         RegisterOperator: {
           registering_operator: config.operatorKeyHash,
-          root_input_index: layout.rootInputIndex,
           root_output_index: layout.anchorNodeOutputIndex,
           registered_node_output_index: layout.prependedNodeOutputIndex,
           hub_oracle_ref_input_index: layout.hubOracleRefInputIndex,
@@ -324,15 +316,8 @@ const deriveActivateLayoutFromContext = ({
     config.contracts.activeOperators.policyId,
     "operator activation active mint",
   ),
-  registeredOperatorsRemovedNodeInputIndex: requireInputIndex(
-    ctx,
-    config.registeredNode.utxo,
-    "operator activation registered node",
-  ),
-  registeredOperatorsAnchorNodeInputIndex: requireInputIndex(
-    ctx,
+  registeredOperatorsAnchorNodeInputOutRef: outputReferenceFromUTxO(
     config.registeredAnchor.utxo,
-    "operator activation registered anchor",
   ),
   registeredOperatorsAnchorNodeOutputIndex: requireUniqueOutputIndex(
     ctx.outputs,
@@ -348,11 +333,6 @@ const deriveActivateLayoutFromContext = ({
         ),
       }),
     "operator activation updated registered anchor",
-  ),
-  activeOperatorsAnchorNodeInputIndex: requireInputIndex(
-    ctx,
-    config.activeAppendAnchor.utxo,
-    "operator activation active anchor",
   ),
   activeOperatorsInsertedNodeOutputIndex: requireUniqueOutputIndex(
     ctx.outputs,
@@ -439,8 +419,6 @@ export const buildActivateOperatorTx = (
         ActivateOperator: {
           new_active_operator_key: config.operatorKeyHash,
           new_active_operator_bond_unlock_time: null,
-          active_operator_anchor_element_input_index:
-            layout.activeOperatorsAnchorNodeInputIndex,
           active_operator_anchor_element_output_index:
             layout.activeOperatorsAnchorNodeOutputIndex,
           active_operator_inserted_node_output_index:
@@ -537,15 +515,8 @@ export const buildDeregisterRegisteredOperatorTx = (
       {
         DeregisterOperator: {
           deregistering_operator: config.operatorKeyHash,
-          removed_node_input_index: requireInputIndex(
-            ctx,
-            config.registeredNode.utxo,
-            "deregister registered node",
-          ),
-          anchor_element_input_index: requireInputIndex(
-            ctx,
+          anchor_element_input_outref: outputReferenceFromUTxO(
             config.registeredAnchor.utxo,
-            "deregister registered anchor",
           ),
           anchor_element_output_index: requireUniqueOutputIndex(
             ctx.outputs,

--- a/demo/midgard-sdk/src/operator-lifecycle/layout.ts
+++ b/demo/midgard-sdk/src/operator-lifecycle/layout.ts
@@ -3,6 +3,7 @@
  */
 import { compareHex } from "@al-ft/midgard-core/hex";
 import * as SDK from "@/operator-lifecycle/primitives.js";
+import type { OutputReference } from "@/common.js";
 import { type UTxO } from "@lucid-evolution/lucid";
 
 export type ReferenceScriptPublication = {
@@ -17,7 +18,6 @@ export type NodeWithDatum = {
 };
 
 export type RegisterRedeemerLayout = {
-  readonly rootInputIndex: bigint;
   readonly hubOracleRefInputIndex: bigint;
   readonly activeOperatorRefInputIndex: bigint;
   readonly retiredOperatorRefInputIndex: bigint;
@@ -30,10 +30,8 @@ export type ActivateRedeemerLayout = {
   readonly retiredOperatorRefInputIndex: bigint;
   readonly registeredOperatorsRedeemerIndex: bigint;
   readonly activeOperatorsRedeemerIndex: bigint;
-  readonly registeredOperatorsRemovedNodeInputIndex: bigint;
-  readonly registeredOperatorsAnchorNodeInputIndex: bigint;
+  readonly registeredOperatorsAnchorNodeInputOutRef: OutputReference;
   readonly registeredOperatorsAnchorNodeOutputIndex: bigint;
-  readonly activeOperatorsAnchorNodeInputIndex: bigint;
   readonly activeOperatorsInsertedNodeOutputIndex: bigint;
   readonly activeOperatorsAnchorNodeOutputIndex: bigint;
 };
@@ -57,7 +55,7 @@ const isPolicyAsset = (unit: string, quantity: bigint, policyId: string) =>
 export const registerLayoutToLogString = (
   layout: RegisterRedeemerLayout,
 ): string =>
-  `root_in=${layout.rootInputIndex.toString()},hub_ref=${layout.hubOracleRefInputIndex.toString()},active_ref=${layout.activeOperatorRefInputIndex.toString()},retired_ref=${layout.retiredOperatorRefInputIndex.toString()},prepended_out=${layout.prependedNodeOutputIndex.toString()},anchor_out=${layout.anchorNodeOutputIndex.toString()}`;
+  `hub_ref=${layout.hubOracleRefInputIndex.toString()},active_ref=${layout.activeOperatorRefInputIndex.toString()},retired_ref=${layout.retiredOperatorRefInputIndex.toString()},prepended_out=${layout.prependedNodeOutputIndex.toString()},anchor_out=${layout.anchorNodeOutputIndex.toString()}`;
 
 /**
  * Formats an activate-layout derivation for logs.
@@ -70,10 +68,8 @@ export const activateLayoutToLogString = (
     `retired_ref=${layout.retiredOperatorRefInputIndex.toString()}`,
     `registered_redeemer=${layout.registeredOperatorsRedeemerIndex.toString()}`,
     `active_redeemer=${layout.activeOperatorsRedeemerIndex.toString()}`,
-    `registered_removed_in=${layout.registeredOperatorsRemovedNodeInputIndex.toString()}`,
-    `registered_anchor_in=${layout.registeredOperatorsAnchorNodeInputIndex.toString()}`,
+    `registered_anchor_outref=${layout.registeredOperatorsAnchorNodeInputOutRef.transactionId}#${layout.registeredOperatorsAnchorNodeInputOutRef.outputIndex.toString()}`,
     `registered_anchor_out=${layout.registeredOperatorsAnchorNodeOutputIndex.toString()}`,
-    `active_anchor_in=${layout.activeOperatorsAnchorNodeInputIndex.toString()}`,
     `active_inserted_out=${layout.activeOperatorsInsertedNodeOutputIndex.toString()}`,
     `active_anchor_out=${layout.activeOperatorsAnchorNodeOutputIndex.toString()}`,
   ].join(",");

--- a/demo/midgard-sdk/src/registered-operators.ts
+++ b/demo/midgard-sdk/src/registered-operators.ts
@@ -6,7 +6,11 @@ import {
 } from "@lucid-evolution/lucid";
 import { Effect } from "effect";
 
-import { AuthenticatedValidator, POSIXTimeSchema } from "@/common.js";
+import {
+  AuthenticatedValidator,
+  OutputReferenceSchema,
+  POSIXTimeSchema,
+} from "@/common.js";
 
 import { incompleteInitLinkedListTxProgram } from "./linked-list.js";
 
@@ -63,15 +67,10 @@ export const RegisteredOperatorMintRedeemerSchema = Data.Enum([
       output_index: Data.Integer(),
     }),
   }),
-  Data.Object({
-    Deinit: Data.Object({
-      input_index: Data.Integer(),
-    }),
-  }),
+  Data.Literal("Deinit"),
   Data.Object({
     RegisterOperator: Data.Object({
       registering_operator: Data.Bytes({ minLength: 28, maxLength: 28 }),
-      root_input_index: Data.Integer(),
       root_output_index: Data.Integer(),
       registered_node_output_index: Data.Integer(),
       hub_oracle_ref_input_index: Data.Integer(),
@@ -82,8 +81,7 @@ export const RegisteredOperatorMintRedeemerSchema = Data.Enum([
   Data.Object({
     ActivateOperator: Data.Object({
       activating_operator: Data.Bytes({ minLength: 28, maxLength: 28 }),
-      anchor_element_input_index: Data.Integer(),
-      removed_node_input_index: Data.Integer(),
+      anchor_element_input_outref: OutputReferenceSchema,
       anchor_element_output_index: Data.Integer(),
       hub_oracle_ref_input_index: Data.Integer(),
       retired_operators_element_ref_input_index: Data.Integer(),
@@ -93,16 +91,14 @@ export const RegisteredOperatorMintRedeemerSchema = Data.Enum([
   Data.Object({
     DeregisterOperator: Data.Object({
       deregistering_operator: Data.Bytes({ minLength: 28, maxLength: 28 }),
-      anchor_element_input_index: Data.Integer(),
-      removed_node_input_index: Data.Integer(),
+      anchor_element_input_outref: OutputReferenceSchema,
       anchor_element_output_index: Data.Integer(),
     }),
   }),
   Data.Object({
     SlashDuplicateOperator: Data.Object({
       duplicate_operator: Data.Bytes({ minLength: 28, maxLength: 28 }),
-      anchor_element_input_index: Data.Integer(),
-      removed_node_input_index: Data.Integer(),
+      anchor_element_input_outref: OutputReferenceSchema,
       anchor_element_output_index: Data.Integer(),
       duplicate_node_ref_input_index: Data.Integer(),
       duplicate_operator_status: DuplicateOperatorStatusSchema,

--- a/demo/midgard-sdk/src/retired-operators.ts
+++ b/demo/midgard-sdk/src/retired-operators.ts
@@ -9,6 +9,7 @@ import { Effect } from "effect";
 import {
   AuthenticatedValidator,
   LucidError,
+  OutputReferenceSchema,
   POSIXTimeSchema,
 } from "@/common.js";
 import { authenticateUTxOs, AuthenticUTxO } from "@/internals.js";
@@ -37,17 +38,12 @@ export const RetiredOperatorMintRedeemerSchema = Data.Enum([
       output_index: Data.Integer(),
     }),
   }),
-  Data.Object({
-    Deinit: Data.Object({
-      input_index: Data.Integer(),
-    }),
-  }),
+  Data.Literal("Deinit"),
   Data.Object({
     RetireOperator: Data.Object({
       new_retired_operator_key: Data.Bytes({ minLength: 28, maxLength: 28 }),
       bond_unlock_time: Data.Nullable(POSIXTimeSchema),
       hub_oracle_ref_input_index: Data.Integer(),
-      retired_operator_anchor_element_input_index: Data.Integer(),
       retired_operator_anchor_element_output_index: Data.Integer(),
       retired_operator_inserted_node_output_index: Data.Integer(),
       active_operators_redeemer_index: Data.Integer(),
@@ -58,8 +54,7 @@ export const RetiredOperatorMintRedeemerSchema = Data.Enum([
       retired_operator_key: Data.Bytes({ minLength: 28, maxLength: 28 }),
       retired_operator_bond_unlock_time: Data.Nullable(POSIXTimeSchema),
       hub_oracle_ref_input_index: Data.Integer(),
-      retired_operator_anchor_element_input_index: Data.Integer(),
-      retired_operator_removed_node_input_index: Data.Integer(),
+      retired_operator_anchor_element_input_outref: OutputReferenceSchema,
       retired_operator_anchor_element_output_index: Data.Integer(),
       registered_operators_redeemer_index: Data.Integer(),
     }),
@@ -67,8 +62,7 @@ export const RetiredOperatorMintRedeemerSchema = Data.Enum([
   Data.Object({
     RecoverOperatorBond: Data.Object({
       retired_operator_key: Data.Bytes({ minLength: 28, maxLength: 28 }),
-      retired_operator_anchor_element_input_index: Data.Integer(),
-      retired_operator_removed_node_input_index: Data.Integer(),
+      retired_operator_anchor_element_input_outref: OutputReferenceSchema,
       retired_operator_anchor_element_output_index: Data.Integer(),
     }),
   }),

--- a/demo/midgard-sdk/src/state-queue-production.ts
+++ b/demo/midgard-sdk/src/state-queue-production.ts
@@ -90,7 +90,6 @@ export type StateQueueCommitWitnessContext = {
 
 type StateQueueCommitLayout = {
   readonly schedulerRefInputIndex: bigint;
-  readonly latestBlockInputIndex: bigint;
   readonly newBlockOutputIndex: bigint;
   readonly continuedLatestBlockOutputIndex: bigint;
   readonly activeOperatorsInputIndex: bigint;
@@ -117,7 +116,6 @@ type ActiveOperatorCommitRedeemer = {
     readonly active_node_input_index: bigint;
     readonly active_node_output_index: bigint;
     readonly hub_oracle_ref_input_index: bigint;
-    readonly state_queue_input_index: bigint;
     readonly state_queue_redeemer_index: bigint;
   };
 };
@@ -203,7 +201,6 @@ const makeActiveOperatorCommitRedeemer = (
     active_node_input_index: layout.activeOperatorsInputIndex,
     active_node_output_index: layout.activeOperatorOutputIndex,
     hub_oracle_ref_input_index: layout.hubOracleRefInputIndex,
-    state_queue_input_index: layout.latestBlockInputIndex,
     state_queue_redeemer_index: layout.stateQueueMintRedeemerIndex,
   },
 });
@@ -231,7 +228,6 @@ const encodeStateQueueLinkedListMutationSpendRedeemer = (): string =>
 
 type CommitLayoutLike = {
   readonly schedulerRefInputIndex: bigint;
-  readonly latestBlockInputIndex: bigint;
   readonly activeOperatorsInputIndex: bigint;
   readonly activeOperatorsRedeemerIndex: bigint;
   readonly stateQueueMintRedeemerIndex: bigint;
@@ -243,7 +239,6 @@ type CommitLayoutLike = {
 
 const COMMIT_LAYOUT_FIELDS = [
   { key: "schedulerRefInputIndex", label: "scheduler_ref_input_index" },
-  { key: "latestBlockInputIndex", label: "latest_block_input" },
   { key: "activeOperatorsInputIndex", label: "active_operators_input_index" },
   {
     key: "activeOperatorsRedeemerIndex",
@@ -300,7 +295,6 @@ const requireUniqueContextOutputIndex = (
 
 const deriveCommitLayoutFromRedeemerContext = ({
   ctx,
-  latestBlockInput,
   schedulerRefInput,
   hubOracleRefInput,
   activeOperatorInput,
@@ -311,7 +305,6 @@ const deriveCommitLayoutFromRedeemerContext = ({
   previousHeaderNodeDatum,
 }: {
   readonly ctx: Parameters<BuildTxWithRedeemer>[0];
-  readonly latestBlockInput: UTxO;
   readonly schedulerRefInput: UTxO;
   readonly hubOracleRefInput: UTxO;
   readonly activeOperatorInput: UTxO;
@@ -321,11 +314,6 @@ const deriveCommitLayoutFromRedeemerContext = ({
   readonly headerNodeDatum: string;
   readonly previousHeaderNodeDatum: string;
 }): StateQueueCommitLayout => {
-  const latestBlockInputIndex = requireContextInputIndex(
-    ctx,
-    latestBlockInput,
-    "state-queue commit latest block",
-  );
   const activeOperatorsInputIndex = requireContextInputIndex(
     ctx,
     activeOperatorInput,
@@ -337,7 +325,6 @@ const deriveCommitLayoutFromRedeemerContext = ({
       schedulerRefInput,
       "state-queue commit scheduler",
     ),
-    latestBlockInputIndex,
     newBlockOutputIndex: requireUniqueContextOutputIndex(
       ctx.outputs,
       (output) =>
@@ -381,7 +368,6 @@ const deriveCommitLayoutFromRedeemerContext = ({
 
 export type DeterministicCommitTxBuilderInput = {
   readonly contracts: MidgardValidators;
-  readonly latestBlockInput: UTxO;
   readonly witness: StateQueueCommitWitnessContext;
   readonly headerNodeUnit: string;
   readonly appendedNodeDatumCbor: string;
@@ -395,7 +381,6 @@ export type DeterministicCommitTxBuilderInput = {
 
 export const buildDeterministicCommitTxBuilder = ({
   contracts,
-  latestBlockInput,
   witness,
   headerNodeUnit,
   appendedNodeDatumCbor,
@@ -435,7 +420,6 @@ export const buildDeterministicCommitTxBuilder = ({
     ): StateQueueCommitLayout => {
       const layout = deriveCommitLayoutFromRedeemerContext({
         ctx,
-        latestBlockInput,
         schedulerRefInput: witness.schedulerRefInput,
         hubOracleRefInput: witness.hubOracleRefInput,
         activeOperatorInput: witness.activeOperatorInput,
@@ -628,7 +612,6 @@ export const buildProductionCommitBlockHeaderTxProgram = ({
 
     const tx = yield* buildDeterministicCommitTxBuilder({
       contracts,
-      latestBlockInput: latestBlock.utxo,
       witness,
       headerNodeUnit,
       appendedNodeDatumCbor,
@@ -748,7 +731,6 @@ const makeSettlementSpawnRedeemer = ({
 const deriveMergeLayoutFromRedeemerContext = ({
   ctx,
   confirmedUTxO,
-  firstBlockUTxO: _firstBlockUTxO,
   hubOracleRefInput,
   stateQueuePolicyId,
   stateQueueAddress,
@@ -760,7 +742,6 @@ const deriveMergeLayoutFromRedeemerContext = ({
 }: {
   readonly ctx: Parameters<BuildTxWithRedeemer>[0];
   readonly confirmedUTxO: StateQueueUTxO;
-  readonly firstBlockUTxO: StateQueueUTxO;
   readonly hubOracleRefInput: UTxO;
   readonly stateQueuePolicyId: string;
   readonly stateQueueAddress: string;
@@ -1072,7 +1053,6 @@ export const buildProductionMergeToConfirmedStateTxProgram = ({
       const layout = deriveMergeLayoutFromRedeemerContext({
         ctx,
         confirmedUTxO,
-        firstBlockUTxO,
         hubOracleRefInput,
         stateQueuePolicyId: fetchConfig.stateQueuePolicyId,
         stateQueueAddress: fetchConfig.stateQueueAddress,

--- a/demo/midgard-sdk/src/state-queue-production.ts
+++ b/demo/midgard-sdk/src/state-queue-production.ts
@@ -24,14 +24,17 @@ import type {
   DataCoercionError,
   HashingError,
   MidgardValidators,
+  OutputReference,
 } from "@/common.js";
+import { outputReferenceFromUTxO } from "@/common.js";
 import {
   castConfirmedStateToData,
-  castHeaderToData,
+  castStateQueueNodeToData,
   type ConfirmedState,
   getHeaderFromStateQueueDatum,
   type Header,
   hashBlockHeader,
+  NO_DA_ATTESTATION,
 } from "@/ledger-state.js";
 import {
   encodeLinkedListNodeView,
@@ -52,6 +55,7 @@ import {
   StateQueueRedeemer,
   type StateQueueFetchConfig,
   type StateQueueRedeemer as StateQueueRedeemerType,
+  StateQueueSpendRedeemer,
   type StateQueueUTxO,
 } from "@/state-queue.js";
 import {
@@ -93,12 +97,11 @@ type StateQueueCommitLayout = {
   readonly activeOperatorsRedeemerIndex: bigint;
   readonly activeOperatorOutputIndex: bigint;
   readonly hubOracleRefInputIndex: bigint;
-  readonly stateQueueSpendRedeemerIndex: bigint;
+  readonly stateQueueMintRedeemerIndex: bigint;
 };
 
 type StateQueueCommitRedeemer = {
   readonly CommitBlockHeader: {
-    readonly latest_block_input_index: bigint;
     readonly new_block_output_index: bigint;
     readonly continued_latest_block_output_index: bigint;
     readonly operator: string;
@@ -182,7 +185,6 @@ const makeStateQueueCommitRedeemer = (
   layout: StateQueueCommitLayout,
 ): StateQueueCommitRedeemer => ({
   CommitBlockHeader: {
-    latest_block_input_index: layout.latestBlockInputIndex,
     new_block_output_index: layout.newBlockOutputIndex,
     continued_latest_block_output_index: layout.continuedLatestBlockOutputIndex,
     operator: operatorKeyHash,
@@ -202,7 +204,7 @@ const makeActiveOperatorCommitRedeemer = (
     active_node_output_index: layout.activeOperatorOutputIndex,
     hub_oracle_ref_input_index: layout.hubOracleRefInputIndex,
     state_queue_input_index: layout.latestBlockInputIndex,
-    state_queue_redeemer_index: layout.stateQueueSpendRedeemerIndex,
+    state_queue_redeemer_index: layout.stateQueueMintRedeemerIndex,
   },
 });
 
@@ -224,12 +226,15 @@ const encodeActiveOperatorCommitRedeemer = (
     ActiveOperatorSpendRedeemer as never,
   );
 
+const encodeStateQueueLinkedListMutationSpendRedeemer = (): string =>
+  Data.to("LinkedListMutation" as never, StateQueueSpendRedeemer as never);
+
 type CommitLayoutLike = {
   readonly schedulerRefInputIndex: bigint;
   readonly latestBlockInputIndex: bigint;
   readonly activeOperatorsInputIndex: bigint;
   readonly activeOperatorsRedeemerIndex: bigint;
-  readonly stateQueueSpendRedeemerIndex: bigint;
+  readonly stateQueueMintRedeemerIndex: bigint;
   readonly newBlockOutputIndex: bigint;
   readonly continuedLatestBlockOutputIndex: bigint;
   readonly activeOperatorOutputIndex: bigint;
@@ -238,15 +243,15 @@ type CommitLayoutLike = {
 
 const COMMIT_LAYOUT_FIELDS = [
   { key: "schedulerRefInputIndex", label: "scheduler_ref_input_index" },
-  { key: "latestBlockInputIndex", label: "latest_block_input_index" },
+  { key: "latestBlockInputIndex", label: "latest_block_input" },
   { key: "activeOperatorsInputIndex", label: "active_operators_input_index" },
   {
     key: "activeOperatorsRedeemerIndex",
     label: "active_operators_redeemer_index",
   },
   {
-    key: "stateQueueSpendRedeemerIndex",
-    label: "state_queue_spend_redeemer_index",
+    key: "stateQueueMintRedeemerIndex",
+    label: "state_queue_mint_redeemer_index",
   },
   { key: "newBlockOutputIndex", label: "new_block_output_index" },
   {
@@ -300,6 +305,7 @@ const deriveCommitLayoutFromRedeemerContext = ({
   hubOracleRefInput,
   activeOperatorInput,
   stateQueueAddress,
+  stateQueuePolicyId,
   headerNodeUnit,
   headerNodeDatum,
   previousHeaderNodeDatum,
@@ -310,6 +316,7 @@ const deriveCommitLayoutFromRedeemerContext = ({
   readonly hubOracleRefInput: UTxO;
   readonly activeOperatorInput: UTxO;
   readonly stateQueueAddress: string;
+  readonly stateQueuePolicyId: string;
   readonly headerNodeUnit: string;
   readonly headerNodeDatum: string;
   readonly previousHeaderNodeDatum: string;
@@ -364,10 +371,10 @@ const deriveCommitLayoutFromRedeemerContext = ({
       hubOracleRefInput,
       "state-queue commit hub oracle",
     ),
-    stateQueueSpendRedeemerIndex: requireContextSpendRedeemerIndex(
+    stateQueueMintRedeemerIndex: requireContextMintRedeemerIndex(
       ctx,
-      latestBlockInput,
-      "state-queue commit latest block",
+      stateQueuePolicyId,
+      "state-queue commit mint",
     ),
   };
 };
@@ -433,6 +440,7 @@ export const buildDeterministicCommitTxBuilder = ({
         hubOracleRefInput: witness.hubOracleRefInput,
         activeOperatorInput: witness.activeOperatorInput,
         stateQueueAddress: contracts.stateQueue.spendingScriptAddress,
+        stateQueuePolicyId: contracts.stateQueue.policyId,
         headerNodeUnit,
         headerNodeDatum: appendedNodeDatumCbor,
         previousHeaderNodeDatum: previousHeaderNodeDatumCbor,
@@ -440,11 +448,8 @@ export const buildDeterministicCommitTxBuilder = ({
       commitLayout = layout;
       return layout;
     };
-    const stateQueueCommitSpendRedeemer = ((ctx) =>
-      encodeStateQueueCommitRedeemer(
-        witness.operatorKeyHash,
-        layoutFromContext(ctx),
-      )) satisfies BuildTxWithRedeemer;
+    const stateQueueCommitSpendRedeemer = (() =>
+      encodeStateQueueLinkedListMutationSpendRedeemer()) satisfies BuildTxWithRedeemer;
     const stateQueueCommitMintRedeemer = ((ctx) =>
       encodeStateQueueCommitRedeemer(
         witness.operatorKeyHash,
@@ -562,7 +567,10 @@ export const buildProductionCommitBlockHeaderTxProgram = ({
     const appendedNodeDatum: LinkedListNodeView = {
       key: updatedNodeDatum.next,
       next: "Empty",
-      data: castHeaderToData(newHeader) as LinkedListNodeView["data"],
+      data: castStateQueueNodeToData({
+        header: newHeader,
+        da_attestation: NO_DA_ATTESTATION,
+      }) as LinkedListNodeView["data"],
     };
     const appendedNodeDatumCbor = encodeLinkedListNodeView(appendedNodeDatum);
     const updatedNodeDatumCbor = encodeLinkedListNodeView(updatedNodeDatum);
@@ -653,8 +661,6 @@ export type ProductionMergeToConfirmedStateParams = {
 };
 
 export type MergeRedeemerLayout = {
-  readonly headerNodeInputIndex: number;
-  readonly confirmedStateInputIndex: number;
   readonly confirmedStateOutputIndex: number;
   readonly settlementOutputIndex: number;
   readonly stateQueueRedeemerIndex: number;
@@ -706,15 +712,16 @@ const makeStateQueueMergeRedeemer = ({
   layout,
   headerNodeKey,
   blockHeader,
+  confirmedStateInputOutRef,
 }: {
   readonly layout: MergeRedeemerLayout;
   readonly headerNodeKey: string;
   readonly blockHeader: Header;
+  readonly confirmedStateInputOutRef: OutputReference;
 }): StateQueueRedeemerType => ({
   MergeToConfirmedState: {
     header_node_key: headerNodeKey,
-    header_node_input_index: BigInt(layout.headerNodeInputIndex),
-    confirmed_state_input_index: BigInt(layout.confirmedStateInputIndex),
+    confirmed_state_input_outref: confirmedStateInputOutRef,
     confirmed_state_output_index: BigInt(layout.confirmedStateOutputIndex),
     m_settlement_redeemer_index: BigInt(layout.settlementRedeemerIndex),
     merged_block_transactions_root: blockHeader.transactionsRoot,
@@ -741,7 +748,7 @@ const makeSettlementSpawnRedeemer = ({
 const deriveMergeLayoutFromRedeemerContext = ({
   ctx,
   confirmedUTxO,
-  firstBlockUTxO,
+  firstBlockUTxO: _firstBlockUTxO,
   hubOracleRefInput,
   stateQueuePolicyId,
   stateQueueAddress,
@@ -763,20 +770,6 @@ const deriveMergeLayoutFromRedeemerContext = ({
   readonly encodedSettlementDatum: string;
   readonly settlementOutputAssets: Assets;
 }): MergeRedeemerLayout => ({
-  headerNodeInputIndex: Number(
-    requireContextInputIndex(
-      ctx,
-      firstBlockUTxO.utxo,
-      "state-queue merge header node",
-    ),
-  ),
-  confirmedStateInputIndex: Number(
-    requireContextInputIndex(
-      ctx,
-      confirmedUTxO.utxo,
-      "state-queue merge confirmed state",
-    ),
-  ),
   confirmedStateOutputIndex: Number(
     requireUniqueContextOutputIndex(
       ctx.outputs,
@@ -824,12 +817,14 @@ const assertMergeRedeemerInvariants = ({
   layout,
   headerNodeKey,
   blockHeader,
+  confirmedStateInputOutRef,
   encodedStateQueueMergeRedeemer,
   encodedSettlementSpawnRedeemer,
 }: {
   readonly layout: MergeRedeemerLayout;
   readonly headerNodeKey: string;
   readonly blockHeader: Header;
+  readonly confirmedStateInputOutRef: OutputReference;
   readonly encodedStateQueueMergeRedeemer: string;
   readonly encodedSettlementSpawnRedeemer: string;
 }): void => {
@@ -843,7 +838,11 @@ const assertMergeRedeemerInvariants = ({
   ) as SettlementMintRedeemerType;
   const mismatches: string[] = [];
 
-  if (!("MergeToConfirmedState" in decodedStateQueue)) {
+  if (
+    typeof decodedStateQueue !== "object" ||
+    decodedStateQueue === null ||
+    !("MergeToConfirmedState" in decodedStateQueue)
+  ) {
     mismatches.push("state_queue variant mismatch");
   } else {
     const stateQueueMerge = decodedStateQueue.MergeToConfirmedState;
@@ -851,16 +850,18 @@ const assertMergeRedeemerInvariants = ({
       mismatches.push("state_queue.header_node_key mismatch");
     }
     if (
-      stateQueueMerge.header_node_input_index !==
-      BigInt(layout.headerNodeInputIndex)
+      stateQueueMerge.confirmed_state_input_outref.transactionId !==
+      confirmedStateInputOutRef.transactionId
     ) {
-      mismatches.push("state_queue.header_node_input_index mismatch");
+      mismatches.push("state_queue.confirmed_state_input_outref tx mismatch");
     }
     if (
-      stateQueueMerge.confirmed_state_input_index !==
-      BigInt(layout.confirmedStateInputIndex)
+      stateQueueMerge.confirmed_state_input_outref.outputIndex !==
+      confirmedStateInputOutRef.outputIndex
     ) {
-      mismatches.push("state_queue.confirmed_state_input_index mismatch");
+      mismatches.push(
+        "state_queue.confirmed_state_input_outref index mismatch",
+      );
     }
     if (
       stateQueueMerge.confirmed_state_output_index !==
@@ -1018,7 +1019,10 @@ export const buildProductionMergeToConfirmedStateTxProgram = ({
       lucid
         .newTx()
         .validFrom(validFrom)
-        .collectFrom([confirmedUTxO.utxo, firstBlockUTxO.utxo], Data.void())
+        .collectFrom(
+          [confirmedUTxO.utxo, firstBlockUTxO.utxo],
+          encodeStateQueueLinkedListMutationSpendRedeemer(),
+        )
         .collectFrom([feeInput])
         .readFrom(mergeReferenceInputs)
         .pay.ToContract(
@@ -1092,6 +1096,9 @@ export const buildProductionMergeToConfirmedStateTxProgram = ({
           layout: layoutFromContext(ctx),
           headerNodeKey,
           blockHeader,
+          confirmedStateInputOutRef: outputReferenceFromUTxO(
+            confirmedUTxO.utxo,
+          ),
         }),
         StateQueueRedeemer,
       );
@@ -1157,7 +1164,7 @@ export const buildProductionMergeToConfirmedStateTxProgram = ({
       settlementRedeemerCbor: resolvedSettlementRedeemerCbor,
     };
     yield* Effect.logInfo(
-      `🔸 Merge redeemer layout: header_input=${resolvedMergeLayout.headerNodeInputIndex},confirmed_input=${resolvedMergeLayout.confirmedStateInputIndex},confirmed_output=${resolvedMergeLayout.confirmedStateOutputIndex},settlement_output=${resolvedMergeLayout.settlementOutputIndex},hub_ref_input=${resolvedMergeLayout.hubOracleRefInputIndex},state_queue_redeemer_index=${resolvedMergeLayout.stateQueueRedeemerIndex},settlement_redeemer_index=${resolvedMergeLayout.settlementRedeemerIndex}`,
+      `🔸 Merge redeemer layout: confirmed_output=${resolvedMergeLayout.confirmedStateOutputIndex},settlement_output=${resolvedMergeLayout.settlementOutputIndex},hub_ref_input=${resolvedMergeLayout.hubOracleRefInputIndex},state_queue_redeemer_index=${resolvedMergeLayout.stateQueueRedeemerIndex},settlement_redeemer_index=${resolvedMergeLayout.settlementRedeemerIndex}`,
     );
     yield* Effect.try({
       try: () =>
@@ -1165,6 +1172,9 @@ export const buildProductionMergeToConfirmedStateTxProgram = ({
           layout: resolvedMergeLayout,
           headerNodeKey,
           blockHeader,
+          confirmedStateInputOutRef: outputReferenceFromUTxO(
+            confirmedUTxO.utxo,
+          ),
           encodedStateQueueMergeRedeemer: resolvedStateQueueRedeemerCbor,
           encodedSettlementSpawnRedeemer: resolvedSettlementRedeemerCbor,
         }),

--- a/demo/midgard-sdk/src/state-queue.ts
+++ b/demo/midgard-sdk/src/state-queue.ts
@@ -26,6 +26,8 @@ import {
   MerkleRoot,
   MerkleRootSchema,
   MissingDatumError,
+  OutputReferenceSchema,
+  outputReferenceFromUTxO,
   POSIXTime,
   UnauthenticUtxoError,
   utxosAtByNFTPolicyId,
@@ -38,11 +40,13 @@ import {
   GENESIS_PROTOCOL_VERSION,
 } from "@/ledger-constants.js";
 import {
+  castStateQueueNodeToData,
   ConfirmedState,
   getHeaderFromStateQueueDatum,
   hashBlockHeader,
   Header,
   HeaderHashSchema,
+  NO_DA_ATTESTATION,
 } from "@/ledger-state.js";
 import {
   encodeLinkedListNodeView,
@@ -102,14 +106,14 @@ export const SlashingApproach =
 export const BlockRemovalApproachSchema = Data.Enum([
   Data.Object({
     RemoveLastFraudulentBlock: Data.Object({
-      anchor_element_input_index: Data.Integer(),
+      anchor_element_input_outref: OutputReferenceSchema,
       anchor_element_output_index: Data.Integer(),
     }),
   }),
   Data.Object({
     RemoveFraudulentBlocksLink: Data.Object({
+      fraudulent_node_input_outref: OutputReferenceSchema,
       fraudulent_node_output_index: Data.Integer(),
-      removed_block_input_index: Data.Integer(),
     }),
   }),
 ]);
@@ -125,14 +129,9 @@ export const StateQueueRedeemerSchema = Data.Enum([
       output_index: Data.Integer(),
     }),
   }),
-  Data.Object({
-    Deinit: Data.Object({
-      input_index: Data.Integer(),
-    }),
-  }),
+  Data.Literal("Deinit"),
   Data.Object({
     CommitBlockHeader: Data.Object({
-      latest_block_input_index: Data.Integer(),
       new_block_output_index: Data.Integer(),
       continued_latest_block_output_index: Data.Integer(),
       operator: Data.Bytes({ minLength: 28, maxLength: 28 }),
@@ -144,8 +143,7 @@ export const StateQueueRedeemerSchema = Data.Enum([
   Data.Object({
     MergeToConfirmedState: Data.Object({
       header_node_key: Data.Bytes(),
-      header_node_input_index: Data.Integer(),
-      confirmed_state_input_index: Data.Integer(),
+      confirmed_state_input_outref: OutputReferenceSchema,
       confirmed_state_output_index: Data.Integer(),
       m_settlement_redeemer_index: Data.Nullable(Data.Integer()),
       merged_block_transactions_root: MerkleRootSchema,
@@ -158,7 +156,6 @@ export const StateQueueRedeemerSchema = Data.Enum([
       fraudulent_operator: Data.Bytes({ minLength: 28, maxLength: 28 }),
       fraudulent_blocks_header_hash: HeaderHashSchema,
       slashing_approach: SlashingApproachSchema,
-      fraudulent_node_input_index: Data.Integer(),
       fraud_proof_ref_input_index: Data.Integer(),
       block_removal_approach: BlockRemovalApproachSchema,
     }),
@@ -167,6 +164,26 @@ export const StateQueueRedeemerSchema = Data.Enum([
 export type StateQueueRedeemer = Data.Static<typeof StateQueueRedeemerSchema>;
 export const StateQueueRedeemer =
   StateQueueRedeemerSchema as unknown as StateQueueRedeemer;
+
+export const StateQueueSpendRedeemerSchema = Data.Enum([
+  Data.Literal("LinkedListMutation"),
+  Data.Object({
+    AttachDaAttestation: Data.Object({
+      state_queue_input_index: Data.Integer(),
+      da_attestation_mint_redeemer_index: Data.Integer(),
+    }),
+  }),
+]);
+export type StateQueueSpendRedeemer = Data.Static<
+  typeof StateQueueSpendRedeemerSchema
+>;
+export const StateQueueSpendRedeemer =
+  StateQueueSpendRedeemerSchema as unknown as StateQueueSpendRedeemer;
+
+const STATE_QUEUE_LINKED_LIST_MUTATION_REDEEMER = Data.to(
+  "LinkedListMutation" as never,
+  StateQueueSpendRedeemer as never,
+);
 
 export type StateQueueUTxO = {
   utxo: UTxO;
@@ -712,7 +729,10 @@ const buildStateQueueRemovalTx = (
     tx = tx.collectFrom([...additionalInputs]);
   }
   tx = tx
-    .collectFrom([...params.collectedStateQueueInputs], Data.void())
+    .collectFrom(
+      [...params.collectedStateQueueInputs],
+      STATE_QUEUE_LINKED_LIST_MUTATION_REDEEMER,
+    )
     .readFrom(referenceInputs)
     .pay.ToContract(
       stateQueueAddress,
@@ -754,7 +774,10 @@ export const incompleteEmulatorCommitBlockHeaderTxProgram = (
     const newBlockDatum: LinkedListNodeView = {
       key: { Key: { key: newHeaderHash } },
       next: "Empty",
-      data: Data.castTo(params.newHeader, Header),
+      data: castStateQueueNodeToData({
+        header: params.newHeader,
+        da_attestation: NO_DA_ATTESTATION,
+      }) as LinkedListNodeView["data"],
     };
     const newBlockDatumCbor = encodeLinkedListNodeView(newBlockDatum);
     const continuedAnchorDatumCbor =
@@ -767,11 +790,6 @@ export const incompleteEmulatorCommitBlockHeaderTxProgram = (
       Data.to(
         {
           CommitBlockHeader: {
-            latest_block_input_index: requireInputIndex(
-              ctx,
-              params.anchorUTxO.utxo,
-              "emulator state-queue commit latest block",
-            ),
             new_block_output_index: requireUniqueOutputIndex(
               ctx.outputs,
               (output) =>
@@ -817,7 +835,10 @@ export const incompleteEmulatorCommitBlockHeaderTxProgram = (
       tx = tx.collectFrom([...additionalInputs]);
     }
     tx = tx
-      .collectFrom([params.anchorUTxO.utxo], stateQueueCommitRedeemer)
+      .collectFrom(
+        [params.anchorUTxO.utxo],
+        STATE_QUEUE_LINKED_LIST_MUTATION_REDEEMER,
+      )
       .collectFrom(
         [params.activeOperatorInput],
         encodeActiveOperatorSpendRedeemer(params.activeOperatorSpendRedeemer),
@@ -909,11 +930,6 @@ export const incompleteRemoveLastFraudulentBlockHeaderTxProgram = (
             ctx,
             params.slashing,
           ),
-          fraudulent_node_input_index: requireInputIndex(
-            ctx,
-            params.fraudulentBlockUTxO.utxo,
-            "emulator state-queue remove fraudulent block",
-          ),
           fraud_proof_ref_input_index: requireReferenceInputIndex(
             ctx,
             params.fraudProofRefInput,
@@ -921,10 +937,8 @@ export const incompleteRemoveLastFraudulentBlockHeaderTxProgram = (
           ),
           block_removal_approach: {
             RemoveLastFraudulentBlock: {
-              anchor_element_input_index: requireInputIndex(
-                ctx,
+              anchor_element_input_outref: outputReferenceFromUTxO(
                 params.anchorUTxO.utxo,
-                "emulator state-queue remove anchor",
               ),
               anchor_element_output_index: requireUniqueOutputIndex(
                 ctx.outputs,
@@ -1018,11 +1032,6 @@ export const incompleteRemoveFraudulentBlocksLinkTxProgram = (
             ctx,
             params.slashing,
           ),
-          fraudulent_node_input_index: requireInputIndex(
-            ctx,
-            params.fraudulentBlockUTxO.utxo,
-            "state-queue remove fraud-proved block",
-          ),
           fraud_proof_ref_input_index: requireReferenceInputIndex(
             ctx,
             params.fraudProofRefInput,
@@ -1030,6 +1039,9 @@ export const incompleteRemoveFraudulentBlocksLinkTxProgram = (
           ),
           block_removal_approach: {
             RemoveFraudulentBlocksLink: {
+              fraudulent_node_input_outref: outputReferenceFromUTxO(
+                params.fraudulentBlockUTxO.utxo,
+              ),
               fraudulent_node_output_index: requireUniqueOutputIndex(
                 ctx.outputs,
                 (output) =>
@@ -1040,11 +1052,6 @@ export const incompleteRemoveFraudulentBlocksLinkTxProgram = (
                   ) &&
                   (output.assets[continuedFraudulentNodeUnit] ?? 0n) === 1n,
                 "state-queue remove continued fraud-proved block",
-              ),
-              removed_block_input_index: requireInputIndex(
-                ctx,
-                params.removedBlockUTxO.utxo,
-                "state-queue remove successor block",
               ),
             },
           },

--- a/demo/midgard-sdk/tests/state-queue.test.ts
+++ b/demo/midgard-sdk/tests/state-queue.test.ts
@@ -62,8 +62,8 @@ import {
   incompleteRemoveLastFraudulentBlockHeaderTxProgram,
   RETIRED_OPERATORS_ROOT_ASSET_NAME,
   requireInputIndex,
+  requireMintRedeemerIndex,
   requireReferenceInputIndex,
-  requireSpendRedeemerIndex,
   requireUniqueOutputIndex,
   SCHEDULER_ASSET_NAME,
   SchedulerDatum,
@@ -71,6 +71,7 @@ import {
   STATE_QUEUE_NODE_ASSET_NAME_PREFIX,
   STATE_QUEUE_ROOT_ASSET_NAME,
   StateQueueRedeemer,
+  StateQueueSpendRedeemer,
   type StateQueueUTxO,
   utxoToStateQueueUTxO,
 } from "../src/index.js";
@@ -83,6 +84,10 @@ const alwaysSucceedsBlueprintPath = resolve(
   "demo/midgard-node/blueprints/always-succeeds/plutus.json",
 );
 const network: Network = "Preprod";
+const outputReference = {
+  transactionId: "44".repeat(32),
+  outputIndex: 0n,
+};
 const EMULATOR_PROTOCOL_PARAMETERS = {
   ...PROTOCOL_PARAMETERS_DEFAULT,
   maxTxSize: 65_536,
@@ -543,10 +548,10 @@ const makeCommitActiveOperatorRedeemer = ({
             stateQueueInput,
             "emulator commit state queue",
           ),
-          state_queue_redeemer_index: requireSpendRedeemerIndex(
+          state_queue_redeemer_index: requireMintRedeemerIndex(
             ctx,
-            stateQueueInput,
-            "emulator commit state queue",
+            contracts.stateQueue.policyId,
+            "emulator commit state queue mint",
           ),
         },
       } satisfies ActiveOperatorSpendRedeemer,
@@ -641,7 +646,6 @@ describe("state-queue ABI", () => {
       roundTrip(
         {
           CommitBlockHeader: {
-            latest_block_input_index: 0n,
             new_block_output_index: 1n,
             continued_latest_block_output_index: 2n,
             operator: "11".repeat(28),
@@ -655,6 +659,9 @@ describe("state-queue ABI", () => {
     ).toMatchObject({
       CommitBlockHeader: { active_operators_redeemer_index: 5n },
     });
+    expect(roundTrip("LinkedListMutation", StateQueueSpendRedeemer)).toBe(
+      "LinkedListMutation",
+    );
 
     const removeRedeemer = {
       RemoveFraudulentBlockHeader: {
@@ -666,11 +673,10 @@ describe("state-queue ABI", () => {
             retired_operators_element_ref_input_index: 1n,
           },
         },
-        fraudulent_node_input_index: 2n,
         fraud_proof_ref_input_index: 3n,
         block_removal_approach: {
           RemoveLastFraudulentBlock: {
-            anchor_element_input_index: 4n,
+            anchor_element_input_outref: outputReference,
             anchor_element_output_index: 5n,
           },
         },
@@ -692,8 +698,8 @@ describe("state-queue ABI", () => {
             },
             block_removal_approach: {
               RemoveFraudulentBlocksLink: {
+                fraudulent_node_input_outref: outputReference,
                 fraudulent_node_output_index: 7n,
-                removed_block_input_index: 8n,
               },
             },
           },

--- a/demo/midgard-sdk/tests/state-queue.test.ts
+++ b/demo/midgard-sdk/tests/state-queue.test.ts
@@ -509,14 +509,12 @@ const makeCommitActiveOperatorRedeemer = ({
   contracts,
   operator,
   activeOperatorInput,
-  stateQueueInput,
   hubOracle,
   continuedActiveOperatorDatum,
 }: {
   readonly contracts: StateQueueTestContracts;
   readonly operator: string;
   readonly activeOperatorInput: UTxO;
-  readonly stateQueueInput: UTxO;
   readonly hubOracle: UTxO;
   readonly continuedActiveOperatorDatum: string;
 }): BuildTxWithRedeemer =>
@@ -542,11 +540,6 @@ const makeCommitActiveOperatorRedeemer = ({
             ctx,
             hubOracle,
             "emulator commit hub oracle",
-          ),
-          state_queue_input_index: requireInputIndex(
-            ctx,
-            stateQueueInput,
-            "emulator commit state queue",
           ),
           state_queue_redeemer_index: requireMintRedeemerIndex(
             ctx,
@@ -598,7 +591,6 @@ const submitCommitHeaderTx = async ({
           contracts,
           operator,
           activeOperatorInput,
-          stateQueueInput: anchor.utxo,
           hubOracle,
           continuedActiveOperatorDatum,
         }),

--- a/onchain/aiken/aiken.lock
+++ b/onchain/aiken/aiken.lock
@@ -13,7 +13,7 @@ source = "github"
 
 [[requirements]]
 name = "anastasia-labs/aiken-design-patterns"
-version = "v1.6.3"
+version = "v1.7.0"
 source = "github"
 
 [[requirements]]
@@ -40,7 +40,7 @@ source = "github"
 
 [[packages]]
 name = "anastasia-labs/aiken-design-patterns"
-version = "v1.6.3"
+version = "v1.7.0"
 requirements = []
 source = "github"
 

--- a/onchain/aiken/aiken.toml
+++ b/onchain/aiken/aiken.toml
@@ -22,7 +22,7 @@ source = "github"
 
 [[dependencies]]
 name = "anastasia-labs/aiken-design-patterns"
-version = "v1.6.3"
+version = "v1.7.0"
 source = "github"
 
 [[dependencies]]

--- a/onchain/aiken/env/testnet.ak
+++ b/onchain/aiken/env/testnet.ak
@@ -60,7 +60,7 @@ pub const l2_outbox_policy_id: PolicyId =
 pub const l2_outbox_asset_name: AssetName = #""
 
 pub const plutarch_phas_validator_hash: ScriptHash =
-  #"02f693d26e167df0b3e8d80ce1bd6fd63cd3e54a37728f67e9f6685c"
+  #"46df0027fc0af07197924dc07f1c27ac6b15eb2bd6efc7a73b0dbb4d"
 
 pub const plutarch_pexcludes_validator_hash: ScriptHash = #""
 

--- a/onchain/aiken/env/testnet.ak
+++ b/onchain/aiken/env/testnet.ak
@@ -60,7 +60,7 @@ pub const l2_outbox_policy_id: PolicyId =
 pub const l2_outbox_asset_name: AssetName = #""
 
 pub const plutarch_phas_validator_hash: ScriptHash =
-  #"46df0027fc0af07197924dc07f1c27ac6b15eb2bd6efc7a73b0dbb4d"
+  #"02f693d26e167df0b3e8d80ce1bd6fd63cd3e54a37728f67e9f6685c"
 
 pub const plutarch_pexcludes_validator_hash: ScriptHash = #""
 

--- a/onchain/aiken/lib/midgard/fraud-proofs/native-tx/components.ak
+++ b/onchain/aiken/lib/midgard/fraud-proofs/native-tx/components.ak
@@ -5,7 +5,7 @@ use aiken/primitive/bytearray
 use midgard/fraud_proofs/native_tx/codec.{
   byte_at, decode_definite_bytes_at, decode_definite_map_header_at,
   decode_uint_at, encode_definite_bytes, encode_definite_map_header, expect_byte,
-  expect_deserialise, expect_h28, expect_h32, slice_len,
+  expect_h28, expect_h32, slice_len,
 }
 use midgard/fraud_proofs/native_tx/types.{
   CertRedeemer, MidgardAddress, MidgardAddressWitness, MidgardCredential,
@@ -213,7 +213,7 @@ fn expect_asset_unit(unit: ByteArray) -> ByteArray {
   unit
 }
 
-fn asset_unit_from_policy_asset(
+pub fn asset_unit_from_policy_asset(
   policy_id: ByteArray,
   asset_name: ByteArray,
 ) -> ByteArray {
@@ -586,7 +586,7 @@ pub fn encode_midgard_tx_output(output: MidgardTxOutput) -> ByteArray {
   }
 }
 
-fn decode_midgard_tx_output_data(data: Data) -> MidgardTxOutput {
+pub fn decode_midgard_tx_output_data(data: Data) -> MidgardTxOutput {
   let entries = builtin.un_map_data(data)
   let output =
     when entries is {

--- a/onchain/aiken/lib/midgard/fraud-proofs/native-tx/preimages.ak
+++ b/onchain/aiken/lib/midgard/fraud-proofs/native-tx/preimages.ak
@@ -10,9 +10,8 @@ use midgard/fraud_proofs/native_tx/codec.{
 }
 use midgard/fraud_proofs/native_tx/components.{
   decode_midgard_address_witness_cbor, decode_midgard_redeemer_witness_at,
-  decode_midgard_redeemer_witness_data, decode_midgard_tx_input_cbor,
-  decode_midgard_tx_output_cbor, decode_midgard_versioned_script_at,
-  decode_midgard_versioned_script_data, encode_midgard_address_witness,
+  decode_midgard_tx_input_cbor, decode_midgard_tx_output_cbor,
+  decode_midgard_versioned_script_at, encode_midgard_address_witness,
   encode_midgard_redeemer_witness, encode_midgard_tx_input,
   encode_midgard_tx_output, encode_midgard_versioned_script,
 }

--- a/onchain/aiken/lib/midgard/fraud-proofs/native-tx/transaction.ak
+++ b/onchain/aiken/lib/midgard/fraud-proofs/native-tx/transaction.ak
@@ -5,7 +5,7 @@ use aiken/primitive/bytearray
 use midgard/fraud_proofs/native_tx/codec.{
   decode_definite_array_header_at, decode_definite_bytes_at, decode_int_at,
   decode_uint_at, encode_definite_bytes, encode_native_byte_list,
-  expect_deserialise, expect_preimage_hash, validity_from_code, validity_to_code,
+  expect_preimage_hash, validity_from_code, validity_to_code,
 }
 use midgard/fraud_proofs/native_tx/compact.{
   encode_native_tx_body_compact, encode_native_tx_compact,
@@ -202,7 +202,9 @@ pub fn encode_midgard_transaction(tx: MidgardTransaction) -> ByteArray {
     |> bytearray.concat(cbor.serialise(tx.validity |> validity_to_code))
 }
 
-fn decode_midgard_transaction_body_data(data: Data) -> MidgardTransactionBody {
+pub fn decode_midgard_transaction_body_data(
+  data: Data,
+) -> MidgardTransactionBody {
   expect [
     inputs_preimage_cbor_data, reference_inputs_preimage_cbor_data,
     outputs_preimage_cbor_data, fee_data, validity_interval_start_data,
@@ -239,7 +241,7 @@ fn decode_midgard_transaction_body_data(data: Data) -> MidgardTransactionBody {
   }
 }
 
-fn decode_midgard_transaction_witness_set_data(
+pub fn decode_midgard_transaction_witness_set_data(
   data: Data,
 ) -> MidgardTransactionWitnessSet {
   expect [

--- a/onchain/aiken/lib/midgard/operator-directory.ak
+++ b/onchain/aiken/lib/midgard/operator-directory.ak
@@ -4,7 +4,7 @@ use aiken/primitive/bytearray
 use aiken_design_patterns/linked_list
 use cardano/assets.{AssetName, PolicyId, Value}
 use cardano/transaction.{
-  Input, Mint, Output, Redeemer, ScriptPurpose, Transaction,
+  Input, Mint, Output, OutputReference, Redeemer, ScriptPurpose, Transaction,
 }
 use midgard/common/constants.{empty_data}
 use midgard/common/types.{Empty}
@@ -27,8 +27,7 @@ pub type SlashingReason {
 pub type SlashingArguments {
   slashed_operator: VerificationKeyHash,
   hub_oracle_ref_input_index: Int,
-  slashed_operator_anchor_element_input_index: Int,
-  slashed_operator_node_input_index: Int,
+  slashed_operator_anchor_element_input_outref: OutputReference,
   slashed_operator_anchor_element_output_index: Int,
   slashing_reason: SlashingReason,
 }
@@ -58,7 +57,9 @@ pub fn init(
     ) == 1,
     produced_element_output: root_output,
     tx_mint: mint,
-    root_validator: fn(_, root_data: Data) -> Bool { root_data == empty_data },
+    root_validator: fn(_, _, root_data: Data) -> Bool {
+      root_data == empty_data
+    },
   )
     |> linked_list.run_root_with(directory_policy_id, root_asset_name)
 }
@@ -67,23 +68,19 @@ pub fn deinit(
   hub_oracle_script_hash: PolicyId,
   directory_policy_id: PolicyId,
   root_asset_name: AssetName,
-  input_index: Int,
   tx: Transaction,
 ) -> Bool {
   let Transaction { inputs, mint, .. } = tx
 
-  // 1. An input must exist at specified index.
-  expect Some(own_input) = inputs |> list.at(input_index)
-
-  // 2. Hub oracle NFT must be getting burnt.
+  // 1. Hub oracle NFT must be getting burnt.
   expect assets.quantity_of(mint, hub_oracle_script_hash, hub.asset_name) == -1
 
-  // 3. Linked list de-initialization must be valid. No other validations
+  // 2. Linked list de-initialization must be valid. No other validations
   //    required.
   linked_list.deinit(
-    root_input: own_input,
+    inputs: inputs,
     tx_mint: mint,
-    root_validator: fn(_, _) -> Bool { True },
+    root_validator: fn(_, _, _) -> Bool { True },
   )
     |> linked_list.run_root_with(directory_policy_id, root_asset_name)
 }
@@ -94,10 +91,11 @@ pub fn operator_is_not_a_member(
   operator: VerificationKeyHash,
   reference_inputs: List<Input>,
   element_ref_input_index: Int,
-) -> linked_list.Eval {
+) -> linked_list.ElementEval<Bool> {
   expect Some(element_input) =
     reference_inputs |> list.at(element_ref_input_index)
   let
+    _element_address,
     _element_lovelace,
     m_smaller_key,
     _element_data,
@@ -127,7 +125,6 @@ pub fn validate_operator_transfer_and_get_inserted_data(
   origin_list_redeemer_index: Int,
   origin_list_redeemer_to_operator_and_penalty_flag: fn(Data) ->
     (VerificationKeyHash, Bool),
-  target_list_anchor_element_input_index: Int,
   target_list_anchor_element_output_index: Int,
   target_list_inserted_node_output_index: Int,
   inputs: List<Input>,
@@ -135,7 +132,7 @@ pub fn validate_operator_transfer_and_get_inserted_data(
   mint: Value,
   redeemers: Pairs<ScriptPurpose, Redeemer>,
   validate_inserted_node_data: fn(Data) -> Bool,
-) -> linked_list.Eval {
+) -> linked_list.ElementEval<Bool> {
   // 1. The minting redeemer of the origin operators list must be invoked.
   let origin_list_redeemer_data =
     redeemers
@@ -151,9 +148,7 @@ pub fn validate_operator_transfer_and_get_inserted_data(
   //    extracted from the origin list's redeemer.
   expect operator == operator_from_origin_list_redeemer
 
-  // 3. Specified input and outpus related to the linked list must exist.
-  expect Some(target_list_anchor_element_input) =
-    inputs |> list.at(target_list_anchor_element_input_index)
+  // 3. Specified outputs related to the linked list must exist.
   expect Some(target_list_anchor_element_output) =
     outputs |> list.at(target_list_anchor_element_output_index)
   expect Some(target_list_inserted_node) =
@@ -161,6 +156,7 @@ pub fn validate_operator_transfer_and_get_inserted_data(
 
   // 4. Ordered insertion in the linked list must be proper.
   let
+    _anchor_input,
     anchor_lovelace_change,
     _m_anchor_key,
     _anchor_data,
@@ -170,10 +166,10 @@ pub fn validate_operator_transfer_and_get_inserted_data(
     _inserted_node_link,
   <-
     linked_list.insert_ascending(
-      target_list_anchor_element_input,
-      target_list_anchor_element_output,
-      target_list_inserted_node,
-      mint,
+      continued_anchor_element_output: target_list_anchor_element_output,
+      new_node_output: target_list_inserted_node,
+      inputs: inputs,
+      tx_mint: mint,
     )
 
   // 5. ADA of anchor element must be preserved.
@@ -231,12 +227,11 @@ pub fn slash_fraudulent_operator_and_get_info(
     Pairs<ScriptPurpose, Redeemer>,
   ) ->
     Bool,
-) -> linked_list.Eval {
+) -> linked_list.ElementEval<Bool> {
   let SlashingArguments {
     slashed_operator,
     hub_oracle_ref_input_index,
-    slashed_operator_anchor_element_input_index,
-    slashed_operator_node_input_index,
+    slashed_operator_anchor_element_input_outref,
     slashed_operator_anchor_element_output_index,
     slashing_reason,
   } = slashing_arguments
@@ -260,31 +255,29 @@ pub fn slash_fraudulent_operator_and_get_info(
       hub_oracle_ref_input_index,
     )
 
-  // 2. Specified inputs and output for removal of the slashed operator's node
-  //    from the linked list must exist at their indices.
-  expect Some(slashed_operator_anchor_element_input) =
-    inputs |> list.at(slashed_operator_anchor_element_input_index)
-  expect Some(slashed_operator_node_input) =
-    inputs |> list.at(slashed_operator_node_input_index)
+  // 2. Specified output for removal of the slashed operator's node from the
+  //    linked list must exist at its index.
   expect Some(slashed_operator_anchor_element_output) =
     outputs |> list.at(slashed_operator_anchor_element_output_index)
 
   // 3. Linked list's removal logic must be valid for the specified inputs and
   //    output.
   let
+    _anchor_input,
     anchor_lovelace_change,
     m_anchor_key,
     _anchor_data,
+    _slashed_operator_node_input,
     slashed_operator_node_lovelace,
     slashed_operator_node_key,
     slashed_operator_node_data,
     slashed_operator_node_link,
   <-
     linked_list.remove(
-      slashed_operator_anchor_element_input,
-      slashed_operator_node_input,
-      slashed_operator_anchor_element_output,
-      mint,
+      anchor_input_outref: slashed_operator_anchor_element_input_outref,
+      continued_anchor_element_output: slashed_operator_anchor_element_output,
+      inputs: inputs,
+      tx_mint: mint,
     )
 
   // 4. ADA of anchor element must be preserved.

--- a/onchain/aiken/lib/midgard/operator-directory/active-operators.ak
+++ b/onchain/aiken/lib/midgard/operator-directory/active-operators.ak
@@ -35,7 +35,6 @@ pub type SpendRedeemer {
     active_node_input_index: Int,
     active_node_output_index: Int,
     hub_oracle_ref_input_index: Int,
-    state_queue_input_index: Int,
     state_queue_redeemer_index: Int,
   }
   UpdateBondHoldNewSettlement {

--- a/onchain/aiken/lib/midgard/operator-directory/active-operators.ak
+++ b/onchain/aiken/lib/midgard/operator-directory/active-operators.ak
@@ -2,6 +2,7 @@ use aiken/crypto.{VerificationKeyHash}
 use aiken/primitive/bytearray
 use aiken_design_patterns/linked_list
 use cardano/assets.{AssetName, PolicyId}
+use cardano/transaction.{OutputReference}
 use midgard/common/types.{PosixTime}
 use midgard/operator_directory.{SlashingArguments}
 
@@ -88,11 +89,10 @@ pub type OperatorRemovalSchedulerSync {
 ///       as it won't require involvement of the scheduler UTxO.
 pub type MintRedeemer {
   Init { output_index: Int }
-  Deinit { input_index: Int }
+  Deinit
   ActivateOperator {
     new_active_operator_key: VerificationKeyHash,
     new_active_operator_bond_unlock_time: Option<PosixTime>,
-    active_operator_anchor_element_input_index: Int,
     active_operator_anchor_element_output_index: Int,
     active_operator_inserted_node_output_index: Int,
     registered_operators_redeemer_index: Int,
@@ -100,8 +100,7 @@ pub type MintRedeemer {
   RetireOperator {
     active_operator_key: VerificationKeyHash,
     hub_oracle_ref_input_index: Int,
-    active_operator_anchor_element_input_index: Int,
-    active_operator_removed_node_input_index: Int,
+    active_operator_anchor_element_input_outref: OutputReference,
     active_operator_anchor_element_output_index: Int,
     retired_operators_redeemer_index: Int,
     penalize_for_inactivity: Bool,
@@ -114,11 +113,11 @@ pub type MintRedeemer {
 }
 
 pub fn finalize_linked_list(
-  eval: linked_list.Eval,
+  eval: linked_list.ElementEval<Bool>,
   nft_policy_id: PolicyId,
 ) -> Bool {
   eval
-    |> linked_list.run_eval_with(
+    |> linked_list.run_element_with(
         nft_policy_id,
         root_asset_name,
         node_asset_name_prefix,

--- a/onchain/aiken/lib/midgard/operator-directory/registered-operators.ak
+++ b/onchain/aiken/lib/midgard/operator-directory/registered-operators.ak
@@ -3,6 +3,7 @@ use aiken/crypto.{VerificationKeyHash}
 use aiken/primitive/bytearray
 use aiken_design_patterns/linked_list
 use cardano/assets.{AssetName, PolicyId}
+use cardano/transaction.{OutputReference}
 use midgard/common/types.{PosixTime}
 use midgard/operator_directory.{SlashingArguments}
 
@@ -41,10 +42,9 @@ pub type OperatorOrigin {
 
 pub type MintRedeemer {
   Init { output_index: Int }
-  Deinit { input_index: Int }
+  Deinit
   RegisterOperator {
     registering_operator: VerificationKeyHash,
-    root_input_index: Int,
     root_output_index: Int,
     registered_node_output_index: Int,
     hub_oracle_ref_input_index: Int,
@@ -53,8 +53,7 @@ pub type MintRedeemer {
   }
   ActivateOperator {
     activating_operator: VerificationKeyHash,
-    anchor_element_input_index: Int,
-    removed_node_input_index: Int,
+    anchor_element_input_outref: OutputReference,
     anchor_element_output_index: Int,
     hub_oracle_ref_input_index: Int,
     retired_operators_element_ref_input_index: Int,
@@ -62,14 +61,12 @@ pub type MintRedeemer {
   }
   DeregisterOperator {
     deregistering_operator: VerificationKeyHash,
-    anchor_element_input_index: Int,
-    removed_node_input_index: Int,
+    anchor_element_input_outref: OutputReference,
     anchor_element_output_index: Int,
   }
   SlashDuplicateOperator {
     duplicate_operator: VerificationKeyHash,
-    anchor_element_input_index: Int,
-    removed_node_input_index: Int,
+    anchor_element_input_outref: OutputReference,
     anchor_element_output_index: Int,
     duplicate_node_ref_input_index: Int,
     duplicate_operator_status: DuplicateOperatorStatus,
@@ -88,11 +85,11 @@ pub fn node_key_to_activation_time(node_key: ByteArray) -> PosixTime {
 }
 
 pub fn finalize_linked_list(
-  eval: linked_list.Eval,
+  eval: linked_list.ElementEval<Bool>,
   nft_policy_id: PolicyId,
 ) -> Bool {
   eval
-    |> linked_list.run_eval_with(
+    |> linked_list.run_element_with(
         nft_policy_id,
         root_asset_name,
         node_asset_name_prefix,

--- a/onchain/aiken/lib/midgard/operator-directory/retired-operators.ak
+++ b/onchain/aiken/lib/midgard/operator-directory/retired-operators.ak
@@ -2,6 +2,7 @@ use aiken/crypto.{VerificationKeyHash}
 use aiken/primitive/bytearray
 use aiken_design_patterns/linked_list
 use cardano/assets.{AssetName, PolicyId}
+use cardano/transaction.{OutputReference}
 use midgard/common/types.{PosixTime}
 use midgard/operator_directory.{SlashingArguments}
 
@@ -28,12 +29,11 @@ pub type Datum =
 
 pub type MintRedeemer {
   Init { output_index: Int }
-  Deinit { input_index: Int }
+  Deinit
   RetireOperator {
     new_retired_operator_key: VerificationKeyHash,
     bond_unlock_time: Option<PosixTime>,
     hub_oracle_ref_input_index: Int,
-    retired_operator_anchor_element_input_index: Int,
     retired_operator_anchor_element_output_index: Int,
     retired_operator_inserted_node_output_index: Int,
     active_operators_redeemer_index: Int,
@@ -42,26 +42,24 @@ pub type MintRedeemer {
     retired_operator_key: VerificationKeyHash,
     retired_operator_bond_unlock_time: Option<PosixTime>,
     hub_oracle_ref_input_index: Int,
-    retired_operator_anchor_element_input_index: Int,
-    retired_operator_removed_node_input_index: Int,
+    retired_operator_anchor_element_input_outref: OutputReference,
     retired_operator_anchor_element_output_index: Int,
     registered_operators_redeemer_index: Int,
   }
   RecoverOperatorBond {
     retired_operator_key: VerificationKeyHash,
-    retired_operator_anchor_element_input_index: Int,
-    retired_operator_removed_node_input_index: Int,
+    retired_operator_anchor_element_input_outref: OutputReference,
     retired_operator_anchor_element_output_index: Int,
   }
   SlashOperator { slashing_arguments: SlashingArguments }
 }
 
 pub fn finalize_linked_list(
-  eval: linked_list.Eval,
+  eval: linked_list.ElementEval<Bool>,
   nft_policy_id: PolicyId,
 ) -> Bool {
   eval
-    |> linked_list.run_eval_with(
+    |> linked_list.run_element_with(
         nft_policy_id,
         root_asset_name,
         node_asset_name_prefix,

--- a/onchain/aiken/lib/midgard/state-queue.ak
+++ b/onchain/aiken/lib/midgard/state-queue.ak
@@ -3,7 +3,7 @@ use aiken/crypto.{VerificationKeyHash}
 use aiken/primitive/bytearray
 use aiken_design_patterns/linked_list
 use cardano/assets.{AssetName, PolicyId}
-use cardano/transaction.{Input, Output}
+use cardano/transaction.{Input, Output, OutputReference}
 use midgard/ledger_state.{
   ConfirmedState, DepositsRoot, Header, HeaderHash, MidgardTxsRoot,
   WithdrawalsRoot,
@@ -34,7 +34,7 @@ pub type Datum =
   linked_list.Element<ConfirmedState, StateQueueNode>
 
 pub type SpendRedeemer {
-  LinkedListMutation { state_queue_mint_redeemer_index: Int }
+  LinkedListMutation
   AttachDaAttestation {
     state_queue_input_index: Int,
     da_attestation_mint_redeemer_index: Int,
@@ -52,20 +52,19 @@ pub type SlashingApproach {
 
 pub type BlockRemovalApproach {
   RemoveLastFraudulentBlock {
-    anchor_element_input_index: Int,
+    anchor_element_input_outref: OutputReference,
     anchor_element_output_index: Int,
   }
   RemoveFraudulentBlocksLink {
+    fraudulent_node_input_outref: OutputReference,
     fraudulent_node_output_index: Int,
-    removed_block_input_index: Int,
   }
 }
 
 pub type MintRedeemer {
   Init { output_index: Int }
-  Deinit { input_index: Int }
+  Deinit
   CommitBlockHeader {
-    latest_block_input_index: Int,
     new_block_output_index: Int,
     continued_latest_block_output_index: Int,
     operator: VerificationKeyHash,
@@ -75,8 +74,7 @@ pub type MintRedeemer {
   }
   MergeToConfirmedState {
     header_node_key: ByteArray,
-    header_node_input_index: Int,
-    confirmed_state_input_index: Int,
+    confirmed_state_input_outref: OutputReference,
     confirmed_state_output_index: Int,
     m_settlement_redeemer_index: Option<Int>,
     merged_block_transactions_root: MidgardTxsRoot,
@@ -87,7 +85,6 @@ pub type MintRedeemer {
     fraudulent_operator: VerificationKeyHash,
     fraudulent_blocks_header_hash: HeaderHash,
     slashing_approach: SlashingApproach,
-    fraudulent_node_input_index: Int,
     fraud_proof_ref_input_index: Int,
     block_removal_approach: BlockRemovalApproach,
   }
@@ -102,6 +99,7 @@ pub fn get_confirmed_state(
     reference_inputs |> list.at(state_queue_node_ref_input_index)
   let linked_list_eval = {
     let
+      _state_queue_element_address,
       _state_queue_element_lovelace,
       m_state_queue_element_key,
       state_queue_element_data,
@@ -146,6 +144,7 @@ pub fn get_state_queue_node(
     reference_inputs |> list.at(state_queue_node_ref_input_index)
   let linked_list_eval = {
     let
+      _state_queue_element_address,
       _state_queue_element_lovelace,
       m_state_queue_element_key,
       state_queue_element_data,
@@ -171,6 +170,7 @@ fn get_node_info(
 ) -> result {
   let linked_list_eval = {
     let
+      _address,
       lovelace,
       m_header_hash,
       data,
@@ -249,11 +249,11 @@ pub fn get_prev_header_hash_of_node(
 }
 
 pub fn finalize_linked_list(
-  eval: linked_list.Eval,
+  eval: linked_list.ElementEval<Bool>,
   state_queue_policy: PolicyId,
 ) -> Bool {
   eval
-    |> linked_list.run_eval_with(
+    |> linked_list.run_element_with(
         state_queue_policy,
         confirmed_state_asset_name,
         block_asset_name_prefix,

--- a/onchain/aiken/validators/operator-directory/active-operators.ak
+++ b/onchain/aiken/validators/operator-directory/active-operators.ak
@@ -49,7 +49,7 @@ validator spend(
         active_node_input_index,
         active_node_output_index,
         hub_oracle_ref_input_index,
-        state_queue_input_index,
+        state_queue_input_index: _state_queue_input_index,
         state_queue_redeemer_index,
       } -> {
         let Transaction {
@@ -83,20 +83,18 @@ validator spend(
             validity_range,
           )
 
-        // 2. Transaction must spend a UTxO from state queue with the Commit
-        //    Block Header redeemer. The operator's signature should be
+        // 2. State queue's minting script must be invoked with the
+        //    CommitBlockHeader redeemer. The operator's signature should be
         //    validated there.
         expect state_queue.CommitBlockHeader {
           operator: state_queue_redeemer_operator,
           ..
         } =
-          utils.get_spending_redeemer_data_at(
-            hub_datum.state_queue_addr,
-            state_queue_input_index,
-            state_queue_redeemer_index,
-            inputs,
-            redeemers,
-          )
+          redeemers
+            |> utils.get_redeemer_at(
+                expected_purpose: Mint(hub_datum.state_queue),
+                redeemer_index: state_queue_redeemer_index,
+              )
 
         // 3. The operator specified in state queue's redeemer must match the
         //    key of the spending active operator node.

--- a/onchain/aiken/validators/operator-directory/active-operators.ak
+++ b/onchain/aiken/validators/operator-directory/active-operators.ak
@@ -49,7 +49,6 @@ validator spend(
         active_node_input_index,
         active_node_output_index,
         hub_oracle_ref_input_index,
-        state_queue_input_index: _state_queue_input_index,
         state_queue_redeemer_index,
       } -> {
         let Transaction {

--- a/onchain/aiken/validators/operator-directory/active-operators.ak
+++ b/onchain/aiken/validators/operator-directory/active-operators.ak
@@ -235,6 +235,7 @@ validator spend(
         // 3. Spending and reproducing the linked list node must be proper.
         {
           let
+            _active_node_address,
             lovelace_change,
             m_operator,
             active_node_input_data,
@@ -275,17 +276,18 @@ validator spend(
             }
           expect active_node_output_data == expected_output_node_data
 
-          // 8. The new strikes count must not exceed the maximum allowed. This
-          //    is there to cover one specific edge case: If the appointed
-          //    operator is the only member of the active operators set,
-          //    inactivity causes the scheduler to rewind back to the same
-          //    operator. Allowing this to happen indefinitely, gives an
-          //    attacker the opportunity to constantly spend the operator's node
-          //    UTxO and prevent the retirement transaction to go through.
+          // 8. The new strikes count must not exceed the maximum allowed.
+          //    This is there to cover one specific edge case: If the
+          //    appointed operator is the only member of the active operators
+          //    set, inactivity causes the scheduler to rewind back to the
+          //    same operator. Allowing this to happen indefinitely, gives an
+          //    attacker the opportunity to constantly spend the operator's
+          //    node UTxO and prevent the retirement transaction to go
+          //    through.
           //
           //    With this check in place, the operator's UTxO cannot be spent
-          //    for strikes any further, and the node will be free for transfer
-          //    to the retired set.
+          //    for strikes any further, and the node will be free for
+          //    transfer to the retired set.
           expect new_inactivity_strikes <= max_inactivity_strikes
 
           // Done.
@@ -316,18 +318,11 @@ validator mint(
           output_index,
           self,
         )
-      Deinit { input_index } ->
-        deinit(
-          hub_oracle_script_hash,
-          own_policy_id,
-          root_asset_name,
-          input_index,
-          self,
-        )
+      Deinit ->
+        deinit(hub_oracle_script_hash, own_policy_id, root_asset_name, self)
       ActivateOperator {
         new_active_operator_key,
         new_active_operator_bond_unlock_time,
-        active_operator_anchor_element_input_index,
         active_operator_anchor_element_output_index,
         active_operator_inserted_node_output_index,
         registered_operators_redeemer_index,
@@ -351,7 +346,6 @@ validator mint(
                 } = registered_operators_redeemer_data
                 (activating_operator, False)
               },
-              active_operator_anchor_element_input_index,
               active_operator_anchor_element_output_index,
               active_operator_inserted_node_output_index,
               inputs,
@@ -377,8 +371,7 @@ validator mint(
       RetireOperator {
         active_operator_key,
         hub_oracle_ref_input_index,
-        active_operator_anchor_element_input_index,
-        active_operator_removed_node_input_index,
+        active_operator_anchor_element_input_outref,
         active_operator_anchor_element_output_index,
         retired_operators_redeemer_index,
         penalize_for_inactivity,
@@ -416,32 +409,30 @@ validator mint(
             hub_oracle_ref_input_index,
           )
 
-        // 3. Specified inputs and output for removal of the active operator's
-        //    node from the linked list must exist at their indices.
-        expect Some(active_operator_anchor_element_input) =
-          inputs |> list.at(active_operator_anchor_element_input_index)
-        expect Some(active_operator_removed_node_input) =
-          inputs |> list.at(active_operator_removed_node_input_index)
+        // 3. Specified output for removal of the active operator's node from
+        //    the linked list must exist at its index.
         expect Some(active_operator_anchor_element_output) =
           outputs |> list.at(active_operator_anchor_element_output_index)
 
         // 4. Linked list's removal logic must be valid for the specified
-        //    inputs and output.
+        //    anchor outref and output.
         {
           let
+            _anchor_input,
             anchor_lovelace_change,
             m_anchor_key,
             _anchor_data,
+            _active_operator_removed_node_input,
             _active_operator_lovelace,
             active_operator_node_key,
             active_operator_node_data,
             active_operator_node_link,
           <-
             linked_list.remove(
-              active_operator_anchor_element_input,
-              active_operator_removed_node_input,
-              active_operator_anchor_element_output,
-              mint,
+              anchor_input_outref: active_operator_anchor_element_input_outref,
+              continued_anchor_element_output: active_operator_anchor_element_output,
+              inputs: inputs,
+              tx_mint: mint,
             )
 
           // 5. Anchor element's ADA must be preserved.
@@ -472,14 +463,14 @@ validator mint(
 
           // 8. The `bond_unlock_time` redeemer argument from the retired
           //    operators directory must match the removing node's datum. This
-          //    allows the minting of the retired operator's node to be able to
-          //    rely on its correctness.
+          //    allows the minting of the retired operator's node to be able
+          //    to rely on its correctness.
           expect
             removing_nodes_bond_unlock_time == retired_operators_redeemer_bond_unlock_time
 
           if penalize_for_inactivity {
-            // 9a. Since retired operators minting script relies on the penalty
-            //     flag here, its correctness must be verified.
+            // 9a. Since retired operators minting script relies on the
+            //     penalty flag here, its correctness must be verified.
             expect inactivity_strikes >= max_inactivity_strikes
 
             // 10a. With enough strikes, anyone can partially slash the
@@ -576,6 +567,7 @@ fn spend_for_updating_bond_unlock_time(
   //    reproduced without affecting the linked list structure.
   {
     let
+      _active_node_address,
       lovelace_change,
       m_operator,
       active_node_input_data,

--- a/onchain/aiken/validators/operator-directory/registered-operators.ak
+++ b/onchain/aiken/validators/operator-directory/registered-operators.ak
@@ -57,17 +57,10 @@ validator mint(
           output_index,
           self,
         )
-      Deinit { input_index } ->
-        deinit(
-          hub_oracle_script_hash,
-          own_policy_id,
-          root_asset_name,
-          input_index,
-          self,
-        )
+      Deinit ->
+        deinit(hub_oracle_script_hash, own_policy_id, root_asset_name, self)
       RegisterOperator {
         registering_operator,
-        root_input_index,
         root_output_index,
         registered_node_output_index,
         hub_oracle_ref_input_index,
@@ -110,9 +103,7 @@ validator mint(
                 active_operators_mint_script_hash,
               )
 
-        // 4. Linked list prepend input and outputs must exist at specified
-        //    indices.
-        expect Some(root_input) = inputs |> list.at(root_input_index)
+        // 4. Linked list prepend outputs must exist at specified indices.
         expect Some(root_output) = outputs |> list.at(root_output_index)
         expect Some(registered_node_output) =
           outputs |> list.at(registered_node_output_index)
@@ -129,6 +120,7 @@ validator mint(
         //          unnecessarily longer.
         {
           let
+            _anchor_input,
             _anchor_lovelace_change,
             _m_anchor_key,
             _anchor_data,
@@ -138,10 +130,10 @@ validator mint(
             _registered_node_link,
           <-
             linked_list.insert_descending(
-              root_input,
-              root_output,
-              registered_node_output,
-              mint,
+              continued_anchor_element_output: root_output,
+              new_node_output: registered_node_output,
+              inputs: inputs,
+              tx_mint: mint,
             )
 
           // 6. The Lovelace in the registered node must equal the
@@ -156,15 +148,15 @@ validator mint(
               validity_range,
             )
 
-          // 8. The key of registered node must match the big-endian encoding of
-          //    `activation_time`
+          // 8. The key of registered node must match the big-endian encoding
+          //    of `activation_time`
           expect
             registered_node_key == activation_time_to_node_key(activation_time)
 
           when operator_origin is {
             ReturningOperator { retired_operators_redeemer_index } -> {
-              // 9a. `ReregisterOperator` redeemer of the retired operators set
-              //     must be invoked with a matching operator key.
+              // 9a. `ReregisterOperator` redeemer of the retired operators
+              //     set must be invoked with a matching operator key.
               expect retired_operators.ReregisterOperator {
                 retired_operator_key,
                 retired_operator_bond_unlock_time,
@@ -220,8 +212,7 @@ validator mint(
       }
       ActivateOperator {
         activating_operator,
-        anchor_element_input_index,
-        removed_node_input_index,
+        anchor_element_input_outref,
         anchor_element_output_index,
         hub_oracle_ref_input_index,
         retired_operators_element_ref_input_index,
@@ -282,8 +273,7 @@ validator mint(
           remove_operator_and_get_node_key_and_bond_unlock_time(
             own_policy_id,
             activating_operator,
-            anchor_element_input_index,
-            removed_node_input_index,
+            anchor_element_input_outref,
             anchor_element_output_index,
             inputs,
             outputs,
@@ -304,8 +294,7 @@ validator mint(
       }
       DeregisterOperator {
         deregistering_operator,
-        anchor_element_input_index,
-        removed_node_input_index,
+        anchor_element_input_outref,
         anchor_element_output_index,
       } -> {
         let Transaction { inputs, outputs, mint, extra_signatories, .. } = self
@@ -322,8 +311,7 @@ validator mint(
           remove_operator_and_get_node_key_and_bond_unlock_time(
             own_policy_id,
             deregistering_operator,
-            anchor_element_input_index,
-            removed_node_input_index,
+            anchor_element_input_outref,
             anchor_element_output_index,
             inputs,
             outputs,
@@ -344,8 +332,7 @@ validator mint(
       }
       SlashDuplicateOperator {
         duplicate_operator,
-        anchor_element_input_index,
-        removed_node_input_index,
+        anchor_element_input_outref,
         anchor_element_output_index,
         duplicate_node_ref_input_index,
         duplicate_operator_status,
@@ -367,8 +354,7 @@ validator mint(
           remove_operator_and_get_node_key_and_bond_unlock_time(
             own_policy_id,
             duplicate_operator,
-            anchor_element_input_index,
-            removed_node_input_index,
+            anchor_element_input_outref,
             anchor_element_output_index,
             inputs,
             outputs,
@@ -388,6 +374,7 @@ validator mint(
             //     set with an operator key that matches the removed operator.
             {
               let
+                _node_address,
                 _node_lovelace,
                 _m_key,
                 node_data,
@@ -415,6 +402,7 @@ validator mint(
             //     set, with a key that matches the removed node.
             {
               let
+                _node_address,
                 _node_lovelace,
                 m_key,
                 _node_data,
@@ -435,6 +423,7 @@ validator mint(
             //     set, with a key that matches the removed node.
             {
               let
+                _node_address,
                 _node_lovelace,
                 m_key,
                 _node_data,
@@ -490,19 +479,14 @@ validator mint(
 fn remove_operator_and_get_node_key_and_bond_unlock_time(
   own_policy_id: PolicyId,
   removed_operator: VerificationKeyHash,
-  anchor_element_input_index: Int,
-  removed_node_input_index: Int,
+  anchor_element_input_outref: OutputReference,
   anchor_element_output_index: Int,
   inputs: List<Input>,
   outputs: List<Output>,
   mint: Value,
   custom_validator: fn(linked_list.NodeKey, Option<PosixTime>) -> Bool,
 ) -> Bool {
-  // 1. Linked list inputs and output for removal must exist at specified
-  //    indices.
-  expect Some(anchor_element_input) =
-    inputs |> list.at(anchor_element_input_index)
-  expect Some(removed_node_input) = inputs |> list.at(removed_node_input_index)
+  // 1. Linked list output for removal must exist at specified index.
   expect Some(anchor_element_output) =
     outputs |> list.at(anchor_element_output_index)
 
@@ -510,19 +494,21 @@ fn remove_operator_and_get_node_key_and_bond_unlock_time(
   //    valid.
   {
     let
+      _anchor_input,
       anchor_lovelace_change,
       _m_anchor_key,
       _anchor_data,
+      _removed_node_input,
       _removed_node_lovelace,
       removed_node_key,
       removed_node_data,
       _removed_node_link,
     <-
       linked_list.remove(
-        anchor_element_input,
-        removed_node_input,
-        anchor_element_output,
-        mint,
+        anchor_input_outref: anchor_element_input_outref,
+        continued_anchor_element_output: anchor_element_output,
+        inputs: inputs,
+        tx_mint: mint,
       )
 
     // 3. ADA bond of the anchor node (or min required ADA if anchor is root)

--- a/onchain/aiken/validators/operator-directory/retired-operators.ak
+++ b/onchain/aiken/validators/operator-directory/retired-operators.ak
@@ -46,19 +46,12 @@ validator mint(hub_oracle_script_hash: PolicyId) {
           output_index,
           self,
         )
-      Deinit { input_index } ->
-        deinit(
-          hub_oracle_script_hash,
-          own_policy_id,
-          root_asset_name,
-          input_index,
-          self,
-        )
+      Deinit ->
+        deinit(hub_oracle_script_hash, own_policy_id, root_asset_name, self)
       RetireOperator {
         new_retired_operator_key,
         bond_unlock_time,
         hub_oracle_ref_input_index,
-        retired_operator_anchor_element_input_index,
         retired_operator_anchor_element_output_index,
         retired_operator_inserted_node_output_index,
         active_operators_redeemer_index,
@@ -89,7 +82,6 @@ validator mint(hub_oracle_script_hash: PolicyId) {
                 } = active_operators_redeemer_data
                 (active_operator_key, penalize_for_inactivity)
               },
-              retired_operator_anchor_element_input_index,
               retired_operator_anchor_element_output_index,
               retired_operator_inserted_node_output_index,
               inputs,
@@ -114,8 +106,7 @@ validator mint(hub_oracle_script_hash: PolicyId) {
         retired_operator_key,
         retired_operator_bond_unlock_time,
         hub_oracle_ref_input_index,
-        retired_operator_anchor_element_input_index,
-        retired_operator_removed_node_input_index,
+        retired_operator_anchor_element_input_outref,
         retired_operator_anchor_element_output_index,
         registered_operators_redeemer_index,
       } -> {
@@ -158,10 +149,6 @@ validator mint(hub_oracle_script_hash: PolicyId) {
         //    redeemer argument here.
         expect registering_operator == retired_operator_key
 
-        expect Some(retired_operator_anchor_element_input) =
-          inputs |> list.at(retired_operator_anchor_element_input_index)
-        expect Some(retired_operator_removed_node_input) =
-          inputs |> list.at(retired_operator_removed_node_input_index)
         expect Some(retired_operator_anchor_element_output) =
           outputs |> list.at(retired_operator_anchor_element_output_index)
 
@@ -169,26 +156,28 @@ validator mint(hub_oracle_script_hash: PolicyId) {
         //    operators set.
         {
           let
+            _anchor_input,
             anchor_lovelace_change,
             _m_anchor_key,
             _anchor_data,
+            _retired_operator_removed_node_input,
             _retired_operator_lovelace,
             retired_operator_node_key,
             retired_operator_node_data,
             _retired_operator_node_link,
           <-
             linked_list.remove(
-              retired_operator_anchor_element_input,
-              retired_operator_removed_node_input,
-              retired_operator_anchor_element_output,
-              mint,
+              anchor_input_outref: retired_operator_anchor_element_input_outref,
+              continued_anchor_element_output: retired_operator_anchor_element_output,
+              inputs: inputs,
+              tx_mint: mint,
             )
 
           // 5. ADA bond of the anchor element must be preserved.
           expect anchor_lovelace_change >= 0
 
-          // 6. The removing node's key must match the re-registering operator's
-          //    key.
+          // 6. The removing node's key must match the re-registering
+          //    operator's key.
           expect retired_operator_key == retired_operator_node_key
 
           // 7. Correctness of the redeemer argument must be validated for the
@@ -203,8 +192,7 @@ validator mint(hub_oracle_script_hash: PolicyId) {
       }
       RecoverOperatorBond {
         retired_operator_key,
-        retired_operator_anchor_element_input_index,
-        retired_operator_removed_node_input_index,
+        retired_operator_anchor_element_input_outref,
         retired_operator_anchor_element_output_index,
       } -> {
         let Transaction {
@@ -220,12 +208,8 @@ validator mint(hub_oracle_script_hash: PolicyId) {
         //    destination of the ADA bond is approved.
         expect retired_operator_key |> utils.has_signed(extra_signatories)
 
-        // 2. Specified inputs and output for removal of the retired operator's
-        //    node from the linked list must exist at their indices.
-        expect Some(retired_operator_anchor_element_input) =
-          inputs |> list.at(retired_operator_anchor_element_input_index)
-        expect Some(retired_operator_removed_node_input) =
-          inputs |> list.at(retired_operator_removed_node_input_index)
+        // 2. Specified output for removal of the retired operator's node from
+        //    the linked list must exist at its index.
         expect Some(retired_operator_anchor_element_output) =
           outputs |> list.at(retired_operator_anchor_element_output_index)
 
@@ -233,19 +217,21 @@ validator mint(hub_oracle_script_hash: PolicyId) {
         //    must be valid.
         {
           let
+            _anchor_input,
             anchor_lovelace_change,
             _m_anchor_key,
             _anchor_data,
+            _retired_operator_removed_node_input,
             _retired_operator_lovelace,
             retired_operator_node_key,
             retired_operator_node_data,
             _retired_operator_node_link,
           <-
             linked_list.remove(
-              retired_operator_anchor_element_input,
-              retired_operator_removed_node_input,
-              retired_operator_anchor_element_output,
-              mint,
+              anchor_input_outref: retired_operator_anchor_element_input_outref,
+              continued_anchor_element_output: retired_operator_anchor_element_output,
+              inputs: inputs,
+              tx_mint: mint,
             )
 
           // 4. ADA of the removing node's anchor element must be preserved.
@@ -254,9 +240,9 @@ validator mint(hub_oracle_script_hash: PolicyId) {
           // 5. The key of the removing node must match the retired operator.
           expect retired_operator_key == retired_operator_node_key
 
-          // 6. The retirement of the operator must be mature. In other words,
-          //    lower bound of the transaction must be later than retired
-          //    operator's commitment time.
+          // 6. The retirement of the operator must be mature. In other
+          //    words, lower bound of the transaction must be later than
+          //    retired operator's commitment time.
           expect NodeData{bond_unlock_time: Some(bond_unlock_time)} =
             retired_operator_node_data
           expect validity_range |> interval.is_entirely_after(bond_unlock_time)

--- a/onchain/aiken/validators/scheduler.ak
+++ b/onchain/aiken/validators/scheduler.ak
@@ -652,6 +652,7 @@ fn validate_operator_inactivity_and_get_its_link(
   expect
     {
       let
+        _state_queue_address,
         _state_queue_lovelace,
         m_header_hash,
         confirmed_state_or_header_data,
@@ -777,6 +778,7 @@ fn validate_root_is_reached(
 
   {
     let
+      _active_root_address,
       _active_root_lovelace,
       m_active_root_key,
       _active_root_data,
@@ -809,6 +811,7 @@ fn validate_operator_is_the_last_active_node(
 
   {
     let
+      _active_node_address,
       _active_node_lovelace,
       m_active_node_key,
       _active_node_data,
@@ -844,6 +847,7 @@ fn validate_new_shifts_node_is_next(
   // previous operator.
   {
     let
+      _active_node_address,
       _active_node_lovelace,
       m_active_node_key,
       _active_node_data,
@@ -955,6 +959,7 @@ fn validate_no_registered_operators_can_activate(
 
   {
     let
+      _registered_element_address,
       _registered_element_lovelace,
       m_registered_element_key,
       _registered_element_data,

--- a/onchain/aiken/validators/state-queue.ak
+++ b/onchain/aiken/validators/state-queue.ak
@@ -28,49 +28,6 @@ use midgard/state_queue.{
   finalize_linked_list, no_da_attestation,
 }
 
-fn input_at_index_is(
-  inputs: List<Input>,
-  input_index: Int,
-  own_ref: OutputReference,
-) -> Bool {
-  expect Some(Input { output_reference, .. }) = inputs |> list.at(input_index)
-  output_reference == own_ref
-}
-
-fn input_is_authorized_by_mint_redeemer(
-  mint_redeemer: MintRedeemer,
-  inputs: List<Input>,
-  own_ref: OutputReference,
-) -> Bool {
-  when mint_redeemer is {
-    Init { .. } -> False
-    Deinit { input_index } -> input_at_index_is(inputs, input_index, own_ref)
-    CommitBlockHeader { latest_block_input_index, .. } ->
-      input_at_index_is(inputs, latest_block_input_index, own_ref)
-    MergeToConfirmedState {
-      header_node_input_index,
-      confirmed_state_input_index,
-      ..
-    } -> or {
-        input_at_index_is(inputs, header_node_input_index, own_ref),
-        input_at_index_is(inputs, confirmed_state_input_index, own_ref),
-      }
-    RemoveFraudulentBlockHeader {
-      fraudulent_node_input_index,
-      block_removal_approach,
-      ..
-    } -> or {
-        input_at_index_is(inputs, fraudulent_node_input_index, own_ref),
-        when block_removal_approach is {
-          RemoveFraudulentBlocksLink { removed_block_input_index, .. } ->
-            input_at_index_is(inputs, removed_block_input_index, own_ref)
-          RemoveLastFraudulentBlock { anchor_element_input_index, .. } ->
-            input_at_index_is(inputs, anchor_element_input_index, own_ref)
-        },
-      }
-  }
-}
-
 validator spend(
   state_queue_mint_script_hash: ByteArray,
   da_attestation_policy_id: PolicyId,
@@ -82,25 +39,11 @@ validator spend(
     tx: Transaction,
   ) {
     when redeemer is {
-      LinkedListMutation { state_queue_mint_redeemer_index } -> {
-        let mint_redeemer_data =
-          tx.redeemers
-            |> utils.get_redeemer_at(
-                Mint(state_queue_mint_script_hash),
-                state_queue_mint_redeemer_index,
-              )
-        expect mint_redeemer: MintRedeemer = mint_redeemer_data
-        expect
-          input_is_authorized_by_mint_redeemer(
-            mint_redeemer,
-            tx.inputs,
-            own_ref,
-          )
+      LinkedListMutation ->
         linked_list.spend_for_adding_or_removing_an_element(
           state_queue_mint_script_hash,
           tx.mint,
         )
-      }
       AttachDaAttestation {
         state_queue_input_index,
         da_attestation_mint_redeemer_index,
@@ -175,7 +118,7 @@ validator mint(
             ) == 1,
             produced_element_output: root_output,
             tx_mint: mint,
-            root_validator: fn(_root_lovelace: Lovelace, root_data: Data) -> Bool {
+            root_validator: fn(_, _root_lovelace: Lovelace, root_data: Data) -> Bool {
               root_data == expected_root_data
             },
           )
@@ -187,22 +130,19 @@ validator mint(
         // Done.
         True
       }
-      Deinit { input_index } -> {
+      Deinit -> {
         let Transaction { inputs, mint, .. } = self
 
-        // 1. An input must exist at specified index.
-        expect Some(own_input) = inputs |> list.at(input_index)
-
-        // 2. Hub oracle NFT must be getting burnt.
+        // 1. Hub oracle NFT must be getting burnt.
         expect quantity_of(mint, hub_oracle_script_hash, hub.asset_name) == -1
 
-        // 3. Linked list de-initialization must be valid. No other validations
+        // 2. Linked list de-initialization must be valid. No other validations
         //    required.
         expect
           linked_list.deinit(
-            root_input: own_input,
+            inputs: inputs,
             tx_mint: mint,
-            root_validator: fn(_, _) -> Bool { True },
+            root_validator: fn(_, _, _) -> Bool { True },
           )
             |> linked_list.run_root_with(
                 own_policy_id,
@@ -213,7 +153,6 @@ validator mint(
         True
       }
       CommitBlockHeader {
-        latest_block_input_index,
         new_block_output_index,
         continued_latest_block_output_index,
         operator,
@@ -237,17 +176,16 @@ validator mint(
         // 2. The transaction must be signed by `operator`.
         expect operator |> utils.has_signed(extra_signatories)
 
-        expect Some(anchor_element_input) =
-          inputs |> list.at(latest_block_input_index)
         expect Some(continued_anchor_element_output) =
           outputs |> list.at(continued_latest_block_output_index)
         expect Some(new_block_output) =
           outputs |> list.at(new_block_output_index)
 
-        // 3. Indicated inputs and output must properly adhere to unordered
-        //    linked list append requirements.
+        // 3. Indicated outputs must properly adhere to unordered linked list
+        //    append requirements.
         {
           let
+            _anchor_input,
             _anchor_lovelace_change,
             m_anchor_key,
             anchor_data,
@@ -256,18 +194,18 @@ validator mint(
             output_header_data,
           <-
             linked_list.append_unordered(
-              anchor_element_input,
-              continued_anchor_element_output,
-              new_block_output,
-              mint,
+              continued_anchor_element_output: continued_anchor_element_output,
+              new_node_output: new_block_output,
+              inputs: inputs,
+              tx_mint: mint,
             )
 
           expect StateQueueNode { header: output_header, da_attestation } =
             output_header_data
           expect da_attestation == no_da_attestation
 
-          // 4. The new block in state queue must have the hash of the header as
-          //    its linked list key.
+          // 4. The new block in state queue must have the hash of the header
+          //    as its linked list key.
           let output_header_hash =
             crypto.blake2b_224(builtin.serialise_data(output_header))
           expect output_header_key == output_header_hash
@@ -299,8 +237,8 @@ validator mint(
               scheduler_ref_input_index: scheduler_ref_input_index,
             )
 
-          // 8. The `operator` field of `scheduler_state` must match `operator`
-          //    from redeemer.
+          // 8. The `operator` field of `scheduler_state` must match
+          //    `operator` from redeemer.
           expect operator == scheduler_operator
 
           // Update the operator's timestamp in the active operators set:
@@ -359,8 +297,7 @@ validator mint(
       }
       MergeToConfirmedState {
         header_node_key,
-        header_node_input_index,
-        confirmed_state_input_index,
+        confirmed_state_input_outref,
         confirmed_state_output_index,
         m_settlement_redeemer_index,
         merged_block_transactions_root,
@@ -370,23 +307,20 @@ validator mint(
         let Transaction { inputs, outputs, mint, redeemers, validity_range, .. } =
           self
 
-        // 1. Inputs and output of linked list must exist in the specified
-        //    indices.
-        expect Some(confirmed_state_input) =
-          inputs |> list.at(confirmed_state_input_index)
-        expect Some(header_node_input) =
-          inputs |> list.at(header_node_input_index)
+        // 1. Output of linked list must exist in the specified index.
         expect Some(continued_confirmed_state_output) =
           outputs |> list.at(confirmed_state_output_index)
 
-        // 2. Specified inputs and output must properly adhere to the fold
+        // 2. Specified root input outref and output must properly adhere to the fold
         //    logic of the linked list.
         //
         //    TODO: We are not caring about the min ADA in the folding block.
         {
           let
+            _confirmed_state_input,
             _confirmed_state_lovelace_change,
             input_confirmed_state_data,
+            _input_header_node,
             _input_header_lovelace,
             input_header_node_key,
             input_header_node_data,
@@ -394,15 +328,14 @@ validator mint(
             output_confirmed_state_data,
           <-
             linked_list.fold_from_root(
-              confirmed_state_input,
-              header_node_input,
-              continued_confirmed_state_output,
-              mint,
+              anchor_root_input_outref: confirmed_state_input_outref,
+              continued_anchor_root_output: continued_confirmed_state_output,
+              inputs: inputs,
+              tx_mint: mint,
             )
 
           // 3. The key of the header node specified in the redeemer must
-          //    properly associate with the input picked using
-          //    `header_node_input_index`.
+          //    properly associate with the folded input.
           expect input_header_node_key == header_node_key
 
           expect StateQueueNode { header: input_header, da_attestation } =
@@ -511,7 +444,6 @@ validator mint(
         fraudulent_operator,
         fraudulent_blocks_header_hash,
         slashing_approach,
-        fraudulent_node_input_index,
         fraud_proof_ref_input_index,
         block_removal_approach,
       } -> {
@@ -605,17 +537,14 @@ validator mint(
               }
           }
 
-        expect Some(fraudulent_node_input) =
-          inputs |> list.at(fraudulent_node_input_index)
-
         // Remove fraudulent block or its link from the state queue:
         // 3. Let `block_removal_approach` be a redeemer argument that specifies
         //    whether the fraudulent block itself can be removed:
         expect
           when block_removal_approach is {
             RemoveFraudulentBlocksLink {
+              fraudulent_node_input_outref,
               fraudulent_node_output_index,
-              removed_block_input_index,
             } -> {
               // 4a. If the fraudulent block has a link, its successor node must
               //     be removed first.
@@ -624,24 +553,24 @@ validator mint(
               //     > The successor node is also considered fraudulent because
               //     > of getting appended to a fraudulent block, so it does not
               //     > need to have an associated fraud proof token.
-              expect Some(removed_block_input) =
-                inputs |> list.at(removed_block_input_index)
               expect Some(fraudulent_node_output) =
                 outputs |> list.at(fraudulent_node_output_index)
               let
+                _fraudulent_header_input,
                 _fraudulent_header_lovelace_change,
                 m_fraudulent_header_hash,
                 _fraudulent_header_data,
+                _removed_block_input,
                 _removed_node_lovelace,
                 _removed_node_header_hash,
                 removed_node_header_data,
                 _removed_node_link,
               <-
                 linked_list.remove(
-                  fraudulent_node_input,
-                  removed_block_input,
-                  fraudulent_node_output,
-                  mint,
+                  anchor_input_outref: fraudulent_node_input_outref,
+                  continued_anchor_element_output: fraudulent_node_output,
+                  inputs: inputs,
+                  tx_mint: mint,
                 )
               expect
                 Some(fraudulent_blocks_header_hash) == m_fraudulent_header_hash
@@ -651,29 +580,29 @@ validator mint(
               operator_vkey == fraudulent_operator
             }
             RemoveLastFraudulentBlock {
-              anchor_element_input_index,
+              anchor_element_input_outref,
               anchor_element_output_index,
             } -> {
               // 4b. If the fraudulent block has no links, it can be removed
               //     from the very end of the state queue.
-              expect Some(anchor_element_input) =
-                inputs |> list.at(anchor_element_input_index)
               expect Some(anchor_element_output) =
                 outputs |> list.at(anchor_element_output_index)
               let
+                _anchor_input,
                 _anchor_lovelace_change,
                 _m_anchor_key,
                 _anchor_data,
+                _removed_node_input,
                 _removed_node_lovelace,
                 removed_node_header_hash,
                 removed_node_header_data,
                 removed_node_link,
               <-
                 linked_list.remove(
-                  anchor_element_input,
-                  fraudulent_node_input,
-                  anchor_element_output,
-                  mint,
+                  anchor_input_outref: anchor_element_input_outref,
+                  continued_anchor_element_output: anchor_element_output,
+                  inputs: inputs,
+                  tx_mint: mint,
                 )
               expect fraudulent_blocks_header_hash == removed_node_header_hash
               expect StateQueueNode { header: removed_node_header, .. } =


### PR DESCRIPTION
The new version fixes the vulnerability that allowed multiple spends during linked list mint operations by handling the inputs list scanning rather than relying on callers to do so.

It also introduces the API for nested linked list which we can use for the new fraud proof catalogue implementation.

I also removed extra checks around `LinkedListMutation` endpoint of the state queue. All minting endpoints of state queue are routed through the linked list module, and it should suffice for the spending endpoint to simply delegate its logic to the minting policy.