### PR TITLE
fix: make deposit submission crash-safe

### DIFF
--- a/demo/midgard-node/README.md
+++ b/demo/midgard-node/README.md
@@ -53,6 +53,75 @@ It is responsible for:
   queue overflow falls back to an inline write, and graceful shutdown drains the
   queue.
 
+## Durable Deposit Submission and Recovery
+
+Midgard persists the exact signed Cardano transaction before making the first
+provider submission call. The durable row binds the transaction hash, signed
+CBOR, deposit event identity, expected deposit output, and every spend,
+collateral, and reference-input dependency. Recovery never rebuilds or re-signs
+that transaction.
+
+Submission is status-first. Before any provider call, the node checks the
+durable attempt against historical Kupo results and an acquired Ogmios mempool
+snapshot. A provider call is permitted only while the row is still `prepared`,
+which durably proves that no submission has ever been claimed, and current
+evidence says the exact transaction is unseen, every recorded dependency
+remains unspent, and the signed validity interval still has a safe submission
+window. The one-way compare-and-set transition to `submission_unknown` happens
+before the provider receives the exact persisted CBOR.
+
+Historical chain presence and mempool acceptance always block submission. Once
+a provider call has been claimed, `submission_unknown`, `submitted`, and
+`ambiguous` attempts are observation-only and are never automatically
+resubmitted—even when the transaction is not currently visible. Only a
+never-claimed prepared transaction can become terminal `expired`; expiry after
+a possible provider call remains ambiguous until positive chain evidence is
+found. Provider disagreement, stale indexer evidence, changed dependencies, or
+an unknown submission response also fails closed without another provider call.
+Kupo evidence is accepted as committed only after both its checkpoint
+(`X-Most-Recent-Checkpoint` plus `ETag`) and the deposit creation point intersect
+the current Ogmios chain. Absence is usable only when that checkpoint also
+covers the final queried Ogmios chain-tip slot; wall-clock slot extrapolation
+cannot prove indexer coverage. The default pruned Kupo deployment may no longer
+expose an old consumed output; that case deliberately remains ambiguous and
+cannot reopen submission.
+
+Node runtime starts a bounded background observation sweep after L1 deposit
+catch-up without gating the HTTP server: at most 32 open attempts, four at a
+time, with a 15-second budget per attempt. It may advance journal state from
+positive provider evidence, but it never submits a transaction. Ambiguous and
+deferred attempts remain available for explicit operator reconciliation; they
+do not become background retries.
+
+Inspect an attempt without any possibility of submission:
+
+```sh
+node dist/index.js reconcile-deposit-submission --tx-hash <64-hex-tx-hash>
+```
+
+The result includes the observed state and `nextSafeAction`. Use this command
+first when investigating a timeout or restart.
+
+Explicitly resume the exact persisted transaction:
+
+```sh
+node dist/index.js resume-deposit-submission --tx-hash <64-hex-tx-hash>
+```
+
+This command requires database and L1 provider access, but it does not take a
+seed phrase and does not invoke the deposit builder or signer. It observes
+status again before acting. Only a synchronized unseen result for a
+never-claimed `prepared` row can enter the one-way compare-and-set transition
+and make its initial exact-byte provider call. Concurrent invocations cannot
+both claim that transition, and no post-call state can transition back to a
+submittable state.
+
+Never work around an `ambiguous` post-call result by rerunning
+`submit-deposit`; first establish provider/indexer health and inspect the stored
+attempt. A never-claimed transaction that reached terminal `expired` is
+different: after confirming the stored attempt did not commit, a still-desired
+deposit may be started as an explicit new `submit-deposit` operation.
+
 ## Transaction Preparation Checks
 
 Before using live preprod e2e as a debugging loop for builder, wallet,
@@ -243,8 +312,14 @@ pnpm listen
   generated reference-script auth policy, and any published reference-script
   UTxOs visible at the configured reference-script deploy address.
 - `node dist/index.js submit-deposit`: build and submit an L1 deposit into the
-  Midgard deposit contract for a target L2 address. Submitted deposits are
-  journaled before confirmation wait so timeouts can be reconciled by tx hash.
+  Midgard deposit contract for a target L2 address. The exact signed
+  transaction is durably journaled before the first provider submission.
+- `node dist/index.js reconcile-deposit-submission --tx-hash <hex>`: observe a
+  durable deposit attempt without submitting it.
+- `node dist/index.js resume-deposit-submission --tx-hash <hex>`: resume a
+  durable attempt from its exact stored signed bytes. See
+  [Durable Deposit Submission and Recovery](#durable-deposit-submission-and-recovery)
+  for the fail-closed recovery procedure.
 - `pnpm submit:l2-transfer`: build and submit a Midgard-native user transfer.
 - `node dist/index.js project-deposits-once`: fetch L1 deposit events once and
   project newly visible deposits into the local Midgard ledger view.

--- a/demo/midgard-node/package.json
+++ b/demo/midgard-node/package.json
@@ -114,6 +114,7 @@
   "author": "Anastasia Labs",
   "license": "ISC",
   "dependencies": {
+    "@cardano-ogmios/client": "6.9.0",
     "@aiken-lang/merkle-patricia-forestry": "github:Anastasia-Labs/merkle-patricia-forestry#b139785f7c118854f9824c26cc443e2df95cb50e&path:/off-chain",
     "@al-ft/lucid-midgard": "workspace:*",
     "@al-ft/midgard-core": "workspace:*",

--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -93,6 +93,7 @@ import {
   WriteBehind,
   writeBehindFiber,
 } from "@/services/index.js";
+import { reconcileOpenDepositSubmissionAttemptsProgram } from "@/transactions/submit-deposit.js";
 import { backfillMissingDaPayloadsFromFinalizedJournals } from "@/workers/commit-block-header/da-payload-backfill.js";
 import { MidgardMpf, utxoToInsertBatchOp } from "@/workers/utils/mpf.js";
 
@@ -544,6 +545,27 @@ export const runNode = (
     const mkSchedule = (millisBetweenRuns: number) =>
       Schedule.spaced(Duration.millis(millisBetweenRuns));
 
+    const backgroundDepositSubmissionReconciliation =
+      reconcileOpenDepositSubmissionAttemptsProgram().pipe(
+        Effect.tap(({ open, inspected, deferred, results }) => {
+          const statuses = results.reduce<Record<string, number>>(
+            (counts, result) => ({
+              ...counts,
+              [result.status]: (counts[result.status] ?? 0) + 1,
+            }),
+            {},
+          );
+          return Effect.logInfo(
+            `Background durable deposit submission reconciliation open=${open.toString()},inspected=${inspected.toString()},deferred=${deferred.toString()},statuses=${JSON.stringify(statuses)}; no transactions were submitted.`,
+          );
+        }),
+        Effect.catchAll(
+          logStartupFailure(
+            "Background durable deposit submission reconciliation failed",
+          ),
+        ),
+      );
+
     const program = Effect.all(
       [
         admissionBacklogGaugeFiber(
@@ -551,6 +573,7 @@ export const runNode = (
         ),
         writeBehindFiber,
         appThread,
+        backgroundDepositSubmissionReconciliation,
         retainedPayloadServerThread(retrieveRetainedDaPayload),
         daPublicationReconcilerFiber(
           mkSchedule(nodeConfig.MIDGARD_DA_PUBLISH_RECONCILE_INTERVAL_MS),

--- a/demo/midgard-node/src/database/depositSubmissionAttempts.ts
+++ b/demo/midgard-node/src/database/depositSubmissionAttempts.ts
@@ -13,14 +13,19 @@ export const tableName = "deposit_submission_attempts";
 export enum Columns {
   TX_HASH = "tx_hash",
   DEPOSIT_EVENT_ID = "deposit_event_id",
+  SIGNED_TX_CBOR = "signed_tx_cbor",
   EXPECTED_DEPOSIT_OUT_REF = "expected_deposit_out_ref",
   EXPECTED_L2_ADDRESS = "expected_l2_address",
   EXPECTED_LOVELACE = "expected_lovelace",
   EXPECTED_ASSETS = "expected_assets",
   METADATA = "metadata",
-  FUNDING_OUT_REFS = "funding_out_refs",
+  DEPENDENCY_OUT_REFS = "dependency_out_refs",
+  STATUS = "status",
+  PREPARED_AT = "prepared_at",
+  ATTEMPT_COUNT = "attempt_count",
+  LAST_SUBMISSION_AT = "last_submission_at",
   SUBMITTED_AT = "submitted_at",
-  CONFIRMATION_STATUS = "confirmation_status",
+  PROVIDER_ACKNOWLEDGEMENT = "provider_acknowledgement",
   CONFIRMED_AT = "confirmed_at",
   LAST_RECONCILED_AT = "last_reconciled_at",
   LAST_ERROR = "last_error",
@@ -28,16 +33,24 @@ export enum Columns {
 }
 
 export const Status = {
-  SubmittedConfirmationUnknown: "submitted_confirmation_unknown",
+  Prepared: "prepared",
+  SubmissionUnknown: "submission_unknown",
+  Submitted: "submitted",
   Confirmed: "confirmed",
   ReconciledAfterTimeout: "reconciled_after_timeout",
   Ambiguous: "ambiguous",
-  RetryAllowed: "retry_allowed",
+  Expired: "expired",
 } as const;
 
 export type Status = (typeof Status)[keyof typeof Status];
 
 export type SerializedAssets = Readonly<Record<string, string>>;
+
+export type DependencyOutRefs = {
+  readonly spend: readonly string[];
+  readonly collateral: readonly string[];
+  readonly reference: readonly string[];
+};
 
 export type Metadata = {
   readonly depositAddress: string;
@@ -55,30 +68,36 @@ export type Metadata = {
 export type Row = {
   [Columns.TX_HASH]: Buffer;
   [Columns.DEPOSIT_EVENT_ID]: Buffer;
+  [Columns.SIGNED_TX_CBOR]: Buffer;
   [Columns.EXPECTED_DEPOSIT_OUT_REF]: string;
   [Columns.EXPECTED_L2_ADDRESS]: string;
   [Columns.EXPECTED_LOVELACE]: string;
   [Columns.EXPECTED_ASSETS]: SerializedAssets;
   [Columns.METADATA]: Metadata;
-  [Columns.FUNDING_OUT_REFS]: readonly string[];
-  [Columns.SUBMITTED_AT]: Date;
-  [Columns.CONFIRMATION_STATUS]: Status;
+  [Columns.DEPENDENCY_OUT_REFS]: DependencyOutRefs;
+  [Columns.STATUS]: Status;
+  [Columns.PREPARED_AT]: Date;
+  [Columns.ATTEMPT_COUNT]: number;
+  [Columns.LAST_SUBMISSION_AT]: Date | null;
+  [Columns.SUBMITTED_AT]: Date | null;
+  [Columns.PROVIDER_ACKNOWLEDGEMENT]: string | null;
   [Columns.CONFIRMED_AT]: Date | null;
   [Columns.LAST_RECONCILED_AT]: Date | null;
   [Columns.LAST_ERROR]: string | null;
   [Columns.UPDATED_AT]: Date;
 };
 
-export type InsertSubmittedInput = Pick<
+export type InsertPreparedInput = Pick<
   Row,
   | Columns.TX_HASH
   | Columns.DEPOSIT_EVENT_ID
+  | Columns.SIGNED_TX_CBOR
   | Columns.EXPECTED_DEPOSIT_OUT_REF
   | Columns.EXPECTED_L2_ADDRESS
   | Columns.EXPECTED_LOVELACE
   | Columns.EXPECTED_ASSETS
   | Columns.METADATA
-  | Columns.FUNDING_OUT_REFS
+  | Columns.DEPENDENCY_OUT_REFS
 >;
 
 const stableStringify = (value: unknown): string => {
@@ -110,9 +129,10 @@ const normalizeJsonb = (value: unknown): unknown => {
   }
 };
 
-const sameSubmittedPayload = (row: Row, input: InsertSubmittedInput): boolean =>
+const samePreparedPayload = (row: Row, input: InsertPreparedInput): boolean =>
   row[Columns.TX_HASH].equals(input[Columns.TX_HASH]) &&
   row[Columns.DEPOSIT_EVENT_ID].equals(input[Columns.DEPOSIT_EVENT_ID]) &&
+  row[Columns.SIGNED_TX_CBOR].equals(input[Columns.SIGNED_TX_CBOR]) &&
   row[Columns.EXPECTED_DEPOSIT_OUT_REF] ===
     input[Columns.EXPECTED_DEPOSIT_OUT_REF] &&
   row[Columns.EXPECTED_L2_ADDRESS] === input[Columns.EXPECTED_L2_ADDRESS] &&
@@ -121,8 +141,15 @@ const sameSubmittedPayload = (row: Row, input: InsertSubmittedInput): boolean =>
     stableStringify(input[Columns.EXPECTED_ASSETS]) &&
   stableStringify(normalizeJsonb(row[Columns.METADATA])) ===
     stableStringify(input[Columns.METADATA]) &&
-  stableStringify(normalizeJsonb(row[Columns.FUNDING_OUT_REFS])) ===
-    stableStringify(input[Columns.FUNDING_OUT_REFS]);
+  stableStringify(normalizeJsonb(row[Columns.DEPENDENCY_OUT_REFS])) ===
+    stableStringify(input[Columns.DEPENDENCY_OUT_REFS]);
+
+const transitionError = (txHash: Buffer, transition: string): DatabaseError =>
+  new DatabaseError({
+    table: tableName,
+    message: `Deposit submission attempt cannot transition via ${transition}`,
+    cause: `tx_hash=${txHash.toString("hex")}`,
+  });
 
 export const retrieveByTxHash = (
   txHash: Buffer,
@@ -148,7 +175,7 @@ export const retrieveByEventId = (
     const sql = yield* SqlClient.SqlClient;
     return yield* sql<Row>`SELECT * FROM ${sql(tableName)}
       WHERE ${sql(Columns.DEPOSIT_EVENT_ID)} = ${eventId}
-      ORDER BY ${sql(Columns.SUBMITTED_AT)} ASC, ${sql(Columns.TX_HASH)} ASC`;
+      ORDER BY ${sql(Columns.PREPARED_AT)} ASC, ${sql(Columns.TX_HASH)} ASC`;
   }).pipe(
     Effect.withLogSpan(`retrieveByEventId ${tableName}`),
     sqlErrorToDatabaseError(
@@ -165,12 +192,13 @@ export const retrieveOpenAttempts = (): Effect.Effect<
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     return yield* sql<Row>`SELECT * FROM ${sql(tableName)}
-      WHERE ${sql(Columns.CONFIRMATION_STATUS)} IN (
-        ${Status.SubmittedConfirmationUnknown},
-        ${Status.Ambiguous},
-        ${Status.RetryAllowed}
+      WHERE ${sql(Columns.STATUS)} IN (
+        ${Status.Prepared},
+        ${Status.SubmissionUnknown},
+        ${Status.Submitted},
+        ${Status.Ambiguous}
       )
-      ORDER BY ${sql(Columns.SUBMITTED_AT)} ASC, ${sql(Columns.TX_HASH)} ASC`;
+      ORDER BY ${sql(Columns.PREPARED_AT)} ASC, ${sql(Columns.TX_HASH)} ASC`;
   }).pipe(
     Effect.withLogSpan(`retrieveOpenAttempts ${tableName}`),
     sqlErrorToDatabaseError(
@@ -179,143 +207,286 @@ export const retrieveOpenAttempts = (): Effect.Effect<
     ),
   );
 
-export const insertSubmitted = (
-  input: InsertSubmittedInput,
+export const insertPrepared = (
+  input: InsertPreparedInput,
 ): Effect.Effect<Row, DatabaseError, Database> =>
   Effect.gen(function* () {
-    const existing = yield* retrieveByTxHash(input[Columns.TX_HASH]);
-    if (Option.isSome(existing)) {
-      if (sameSubmittedPayload(existing.value, input)) {
-        return existing.value;
-      }
-      return yield* Effect.fail(
-        new DatabaseError({
-          table: tableName,
-          message:
-            "Refusing to overwrite deposit submission attempt because the existing tx hash has different expected payload",
-          cause: `tx_hash=${input[Columns.TX_HASH].toString("hex")}`,
-        }),
-      );
-    }
-
     const sql = yield* SqlClient.SqlClient;
     const rows = yield* sql<Row>`
       INSERT INTO ${sql(tableName)} (
         ${sql(Columns.TX_HASH)},
         ${sql(Columns.DEPOSIT_EVENT_ID)},
+        ${sql(Columns.SIGNED_TX_CBOR)},
         ${sql(Columns.EXPECTED_DEPOSIT_OUT_REF)},
         ${sql(Columns.EXPECTED_L2_ADDRESS)},
         ${sql(Columns.EXPECTED_LOVELACE)},
         ${sql(Columns.EXPECTED_ASSETS)},
         ${sql(Columns.METADATA)},
-        ${sql(Columns.FUNDING_OUT_REFS)},
-        ${sql(Columns.CONFIRMATION_STATUS)}
+        ${sql(Columns.DEPENDENCY_OUT_REFS)},
+        ${sql(Columns.STATUS)}
       ) VALUES (
         ${input[Columns.TX_HASH]},
         ${input[Columns.DEPOSIT_EVENT_ID]},
+        ${input[Columns.SIGNED_TX_CBOR]},
         ${input[Columns.EXPECTED_DEPOSIT_OUT_REF]},
         ${input[Columns.EXPECTED_L2_ADDRESS]},
         ${input[Columns.EXPECTED_LOVELACE]},
-        CAST(${stableStringify(input[Columns.EXPECTED_ASSETS])} AS JSONB),
-        CAST(${stableStringify(input[Columns.METADATA])} AS JSONB),
-        CAST(${stableStringify(input[Columns.FUNDING_OUT_REFS])} AS JSONB),
-        ${Status.SubmittedConfirmationUnknown}
+        CAST(CAST(${stableStringify(input[Columns.EXPECTED_ASSETS])} AS TEXT) AS JSONB),
+        CAST(CAST(${stableStringify(input[Columns.METADATA])} AS TEXT) AS JSONB),
+        CAST(CAST(${stableStringify(input[Columns.DEPENDENCY_OUT_REFS])} AS TEXT) AS JSONB),
+        ${Status.Prepared}
       )
+      ON CONFLICT (${sql(Columns.TX_HASH)}) DO NOTHING
       RETURNING *`;
-    return rows[0]!;
+    if (rows.length === 1) {
+      return rows[0]!;
+    }
+
+    const existing = yield* retrieveByTxHash(input[Columns.TX_HASH]);
+    if (Option.isSome(existing) && samePreparedPayload(existing.value, input)) {
+      return existing.value;
+    }
+    return yield* Effect.fail(
+      new DatabaseError({
+        table: tableName,
+        message:
+          "Refusing to overwrite deposit submission attempt because the existing tx hash has different signed bytes or expected payload",
+        cause: `tx_hash=${input[Columns.TX_HASH].toString("hex")}`,
+      }),
+    );
   }).pipe(
-    Effect.withLogSpan(`insertSubmitted ${tableName}`),
+    Effect.withLogSpan(`insertPrepared ${tableName}`),
     sqlErrorToDatabaseError(
       tableName,
-      "Failed to insert deposit submission attempt",
+      "Failed to prepare deposit submission attempt",
     ),
   );
 
-const markStatus = ({
-  txHash,
-  status,
-  confirmedAt,
-  lastReconciledAt,
-  lastError,
-}: {
-  readonly txHash: Buffer;
-  readonly status: Status;
-  readonly confirmedAt?: Date | null;
-  readonly lastReconciledAt?: Date | null;
-  readonly lastError?: string | null;
-}): Effect.Effect<Row, DatabaseError, Database> =>
+export const beginSubmission = (
+  txHash: Buffer,
+  submissionAt: Date = new Date(),
+): Effect.Effect<Row, DatabaseError, Database> =>
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     const rows = yield* sql<Row>`
       UPDATE ${sql(tableName)}
       SET
-        ${sql(Columns.CONFIRMATION_STATUS)} = ${status},
-        ${sql(Columns.CONFIRMED_AT)} = ${
-          confirmedAt === undefined ? null : confirmedAt
-        },
-        ${sql(Columns.LAST_RECONCILED_AT)} = ${
-          lastReconciledAt === undefined ? null : lastReconciledAt
-        },
-        ${sql(Columns.LAST_ERROR)} = ${
-          lastError === undefined ? null : lastError
-        },
-        ${sql(Columns.UPDATED_AT)} = NOW()
+        ${sql(Columns.STATUS)} = ${Status.SubmissionUnknown},
+        ${sql(Columns.ATTEMPT_COUNT)} = ${sql(Columns.ATTEMPT_COUNT)} + 1,
+        ${sql(Columns.LAST_SUBMISSION_AT)} = ${submissionAt},
+        ${sql(Columns.SUBMITTED_AT)} = NULL,
+        ${sql(Columns.PROVIDER_ACKNOWLEDGEMENT)} = NULL,
+        ${sql(Columns.UPDATED_AT)} = ${submissionAt}
       WHERE ${sql(Columns.TX_HASH)} = ${txHash}
+        AND ${sql(Columns.STATUS)} = ${Status.Prepared}
       RETURNING *`;
     if (rows.length === 1) {
       return rows[0]!;
     }
-    return yield* Effect.fail(
-      new DatabaseError({
-        table: tableName,
-        message: "Deposit submission attempt does not exist",
-        cause: `tx_hash=${txHash.toString("hex")}`,
-      }),
-    );
+    return yield* Effect.fail(transitionError(txHash, "beginSubmission"));
   }).pipe(
-    Effect.withLogSpan(`markStatus ${tableName}`),
+    Effect.withLogSpan(`beginSubmission ${tableName}`),
     sqlErrorToDatabaseError(
       tableName,
-      "Failed to update deposit submission attempt status",
+      "Failed to begin deposit transaction submission",
     ),
   );
+
+export const markSubmitted = (
+  txHash: Buffer,
+  providerAcknowledgement: string,
+  submittedAt: Date = new Date(),
+): Effect.Effect<Row, DatabaseError, Database> =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<Row>`
+      UPDATE ${sql(tableName)}
+      SET
+        ${sql(Columns.STATUS)} = ${Status.Submitted},
+        ${sql(Columns.SUBMITTED_AT)} = ${submittedAt},
+        ${sql(Columns.PROVIDER_ACKNOWLEDGEMENT)} = ${providerAcknowledgement},
+        ${sql(Columns.LAST_ERROR)} = NULL,
+        ${sql(Columns.UPDATED_AT)} = ${submittedAt}
+      WHERE ${sql(Columns.TX_HASH)} = ${txHash}
+        AND ${sql(Columns.STATUS)} = ${Status.SubmissionUnknown}
+      RETURNING *`;
+    if (rows.length === 1) {
+      return rows[0]!;
+    }
+    const existing = yield* retrieveByTxHash(txHash);
+    if (
+      Option.isSome(existing) &&
+      (existing.value[Columns.STATUS] === Status.Submitted ||
+        existing.value[Columns.STATUS] === Status.Confirmed ||
+        existing.value[Columns.STATUS] === Status.ReconciledAfterTimeout)
+    ) {
+      return existing.value;
+    }
+    return yield* Effect.fail(transitionError(txHash, "markSubmitted"));
+  }).pipe(
+    Effect.withLogSpan(`markSubmitted ${tableName}`),
+    sqlErrorToDatabaseError(
+      tableName,
+      "Failed to record provider acknowledgement for deposit submission",
+    ),
+  );
+
+const evidenceStatuses = [
+  Status.Prepared,
+  Status.SubmissionUnknown,
+  Status.Submitted,
+  Status.Ambiguous,
+] as const;
 
 export const markConfirmed = (
   txHash: Buffer,
   confirmedAt: Date = new Date(),
 ): Effect.Effect<Row, DatabaseError, Database> =>
-  markStatus({
-    txHash,
-    status: Status.Confirmed,
-    confirmedAt,
-    lastReconciledAt: null,
-    lastError: null,
-  });
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<Row>`
+      UPDATE ${sql(tableName)}
+      SET
+        ${sql(Columns.STATUS)} = ${Status.Confirmed},
+        ${sql(Columns.CONFIRMED_AT)} = ${confirmedAt},
+        ${sql(Columns.LAST_ERROR)} = NULL,
+        ${sql(Columns.UPDATED_AT)} = ${confirmedAt}
+      WHERE ${sql(Columns.TX_HASH)} = ${txHash}
+        AND ${sql(Columns.STATUS)} IN ${sql.in(evidenceStatuses)}
+      RETURNING *`;
+    if (rows.length === 1) {
+      return rows[0]!;
+    }
+    const existing = yield* retrieveByTxHash(txHash);
+    if (
+      Option.isSome(existing) &&
+      (existing.value[Columns.STATUS] === Status.Confirmed ||
+        existing.value[Columns.STATUS] === Status.ReconciledAfterTimeout)
+    ) {
+      return existing.value;
+    }
+    return yield* Effect.fail(transitionError(txHash, "markConfirmed"));
+  }).pipe(
+    Effect.withLogSpan(`markConfirmed ${tableName}`),
+    sqlErrorToDatabaseError(
+      tableName,
+      "Failed to confirm deposit submission attempt",
+    ),
+  );
 
 export const markReconciled = (
   txHash: Buffer,
   reconciledAt: Date = new Date(),
 ): Effect.Effect<Row, DatabaseError, Database> =>
-  markStatus({
-    txHash,
-    status: Status.ReconciledAfterTimeout,
-    confirmedAt: reconciledAt,
-    lastReconciledAt: reconciledAt,
-    lastError: null,
-  });
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<Row>`
+      UPDATE ${sql(tableName)}
+      SET
+        ${sql(Columns.STATUS)} = ${Status.ReconciledAfterTimeout},
+        ${sql(Columns.CONFIRMED_AT)} = ${reconciledAt},
+        ${sql(Columns.LAST_RECONCILED_AT)} = ${reconciledAt},
+        ${sql(Columns.LAST_ERROR)} = NULL,
+        ${sql(Columns.UPDATED_AT)} = ${reconciledAt}
+      WHERE ${sql(Columns.TX_HASH)} = ${txHash}
+        AND ${sql(Columns.STATUS)} IN ${sql.in(evidenceStatuses)}
+      RETURNING *`;
+    if (rows.length === 1) {
+      return rows[0]!;
+    }
+    const existing = yield* retrieveByTxHash(txHash);
+    if (
+      Option.isSome(existing) &&
+      (existing.value[Columns.STATUS] === Status.ReconciledAfterTimeout ||
+        existing.value[Columns.STATUS] === Status.Confirmed)
+    ) {
+      return existing.value;
+    }
+    return yield* Effect.fail(transitionError(txHash, "markReconciled"));
+  }).pipe(
+    Effect.withLogSpan(`markReconciled ${tableName}`),
+    sqlErrorToDatabaseError(
+      tableName,
+      "Failed to reconcile deposit submission attempt",
+    ),
+  );
 
 export const markAmbiguous = (
   txHash: Buffer,
   error: string,
   reconciledAt: Date = new Date(),
 ): Effect.Effect<Row, DatabaseError, Database> =>
-  markStatus({
-    txHash,
-    status: Status.Ambiguous,
-    confirmedAt: null,
-    lastReconciledAt: reconciledAt,
-    lastError: error,
-  });
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<Row>`
+      UPDATE ${sql(tableName)}
+      SET
+        ${sql(Columns.STATUS)} = ${Status.Ambiguous},
+        ${sql(Columns.CONFIRMED_AT)} = NULL,
+        ${sql(Columns.LAST_RECONCILED_AT)} = ${reconciledAt},
+        ${sql(Columns.LAST_ERROR)} = ${error},
+        ${sql(Columns.UPDATED_AT)} = ${reconciledAt}
+      WHERE ${sql(Columns.TX_HASH)} = ${txHash}
+        AND ${sql(Columns.STATUS)} = ${Status.SubmissionUnknown}
+      RETURNING *`;
+    if (rows.length === 1) {
+      return rows[0]!;
+    }
+    const existing = yield* retrieveByTxHash(txHash);
+    if (
+      Option.isSome(existing) &&
+      (existing.value[Columns.STATUS] === Status.Ambiguous ||
+        existing.value[Columns.STATUS] === Status.Submitted ||
+        existing.value[Columns.STATUS] === Status.Confirmed ||
+        existing.value[Columns.STATUS] === Status.ReconciledAfterTimeout)
+    ) {
+      return existing.value;
+    }
+    return yield* Effect.fail(transitionError(txHash, "markAmbiguous"));
+  }).pipe(
+    Effect.withLogSpan(`markAmbiguous ${tableName}`),
+    sqlErrorToDatabaseError(
+      tableName,
+      "Failed to mark deposit submission attempt ambiguous",
+    ),
+  );
+
+export const markExpired = (
+  txHash: Buffer,
+  error: string,
+  reconciledAt: Date = new Date(),
+): Effect.Effect<Row, DatabaseError, Database> =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<Row>`
+      UPDATE ${sql(tableName)}
+      SET
+        ${sql(Columns.STATUS)} = ${Status.Expired},
+        ${sql(Columns.CONFIRMED_AT)} = NULL,
+        ${sql(Columns.LAST_RECONCILED_AT)} = ${reconciledAt},
+        ${sql(Columns.LAST_ERROR)} = ${error},
+        ${sql(Columns.UPDATED_AT)} = ${reconciledAt}
+      WHERE ${sql(Columns.TX_HASH)} = ${txHash}
+        AND ${sql(Columns.STATUS)} = ${Status.Prepared}
+      RETURNING *`;
+    if (rows.length === 1) {
+      return rows[0]!;
+    }
+    const existing = yield* retrieveByTxHash(txHash);
+    if (
+      Option.isSome(existing) &&
+      existing.value[Columns.STATUS] === Status.Expired
+    ) {
+      return existing.value;
+    }
+    return yield* Effect.fail(transitionError(txHash, "markExpired"));
+  }).pipe(
+    Effect.withLogSpan(`markExpired ${tableName}`),
+    sqlErrorToDatabaseError(
+      tableName,
+      "Failed to mark deposit submission attempt expired",
+    ),
+  );
 
 export const clear: Effect.Effect<void, DatabaseError, Database> =
   clearTable(tableName);

--- a/demo/midgard-node/src/database/migrations/index.ts
+++ b/demo/midgard-node/src/database/migrations/index.ts
@@ -103,8 +103,8 @@ export const APPLICATION_INDEX_NAMES = [
   "idx_da_payloads_created_at",
   "idx_da_payload_publications_retry",
   "idx_da_payload_announcements_retry",
-  "idx_deposit_submission_attempts_deposit_event_id",
-  "idx_deposit_submission_attempts_status_submitted_at",
+  "idx_deposit_submission_attempts_status_prepared_at",
+  "idx_deposit_submission_attempts_active_event_id",
 ] as const;
 
 export const migrationByVersion = new Map(

--- a/demo/midgard-node/src/database/migrations/sql/0001_initial_schema.sql
+++ b/demo/midgard-node/src/database/migrations/sql/0001_initial_schema.sql
@@ -185,19 +185,34 @@ CREATE TABLE public.da_payloads (
 CREATE TABLE public.deposit_submission_attempts (
     tx_hash bytea NOT NULL,
     deposit_event_id bytea NOT NULL,
+    signed_tx_cbor bytea NOT NULL,
     expected_deposit_out_ref text NOT NULL,
     expected_l2_address text NOT NULL,
     expected_lovelace text NOT NULL,
     expected_assets jsonb NOT NULL,
     metadata jsonb NOT NULL,
-    funding_out_refs jsonb NOT NULL,
-    submitted_at timestamp with time zone DEFAULT now() NOT NULL,
-    confirmation_status text NOT NULL,
+    dependency_out_refs jsonb NOT NULL,
+    status text DEFAULT 'prepared'::text NOT NULL,
+    prepared_at timestamp with time zone DEFAULT now() NOT NULL,
+    attempt_count integer DEFAULT 0 NOT NULL,
+    last_submission_at timestamp with time zone,
+    submitted_at timestamp with time zone,
+    provider_acknowledgement text,
     confirmed_at timestamp with time zone,
     last_reconciled_at timestamp with time zone,
     last_error text,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT deposit_submission_attempts_confirmation_status_check CHECK ((confirmation_status = ANY (ARRAY['submitted_confirmation_unknown'::text, 'confirmed'::text, 'reconciled_after_timeout'::text, 'ambiguous'::text, 'retry_allowed'::text]))),
+    CONSTRAINT deposit_submission_attempts_attempt_count_check CHECK ((attempt_count >= 0)),
+    CONSTRAINT deposit_submission_attempts_attempt_timestamp_check CHECK ((((attempt_count = 0) AND (last_submission_at IS NULL)) OR ((attempt_count > 0) AND (last_submission_at IS NOT NULL)))),
+    CONSTRAINT deposit_submission_attempts_deposit_event_id_check CHECK ((octet_length(deposit_event_id) > 0)),
+    CONSTRAINT deposit_submission_attempts_error_check CHECK (((last_error IS NULL) OR (btrim(last_error) <> ''::text))),
+    CONSTRAINT deposit_submission_attempts_dependency_out_refs_check CHECK ((jsonb_typeof(dependency_out_refs) = 'object'::text) AND (jsonb_typeof((dependency_out_refs -> 'spend'::text)) = 'array'::text) AND (jsonb_typeof((dependency_out_refs -> 'collateral'::text)) = 'array'::text) AND (jsonb_typeof((dependency_out_refs -> 'reference'::text)) = 'array'::text) AND ((dependency_out_refs - ARRAY['spend'::text, 'collateral'::text, 'reference'::text]) = '{}'::jsonb)),
+    CONSTRAINT deposit_submission_attempts_lifecycle_check CHECK (((status = 'prepared'::text) AND (attempt_count = 0) AND (last_submission_at IS NULL) AND (submitted_at IS NULL) AND (provider_acknowledgement IS NULL) AND (confirmed_at IS NULL) AND (last_reconciled_at IS NULL) AND (last_error IS NULL)) OR ((status = 'submission_unknown'::text) AND (attempt_count > 0) AND (last_submission_at IS NOT NULL) AND (submitted_at IS NULL) AND (provider_acknowledgement IS NULL) AND (confirmed_at IS NULL)) OR ((status = 'submitted'::text) AND (attempt_count > 0) AND (last_submission_at IS NOT NULL) AND (submitted_at IS NOT NULL) AND (provider_acknowledgement IS NOT NULL) AND (confirmed_at IS NULL)) OR ((status = 'confirmed'::text) AND (confirmed_at IS NOT NULL) AND (last_error IS NULL)) OR ((status = 'reconciled_after_timeout'::text) AND (confirmed_at IS NOT NULL) AND (last_reconciled_at IS NOT NULL) AND (last_error IS NULL)) OR ((status = 'ambiguous'::text) AND (confirmed_at IS NULL) AND (last_reconciled_at IS NOT NULL) AND (last_error IS NOT NULL)) OR ((status = 'expired'::text) AND (confirmed_at IS NULL) AND (last_reconciled_at IS NOT NULL) AND (last_error IS NOT NULL))),
+    CONSTRAINT deposit_submission_attempts_provider_acknowledgement_check CHECK (((provider_acknowledgement IS NULL) OR (btrim(provider_acknowledgement) <> ''::text))),
+    CONSTRAINT deposit_submission_attempts_provider_timestamp_check CHECK ((((submitted_at IS NULL) AND (provider_acknowledgement IS NULL)) OR ((submitted_at IS NOT NULL) AND (provider_acknowledgement IS NOT NULL)))),
+    CONSTRAINT deposit_submission_attempts_signed_tx_cbor_check CHECK ((octet_length(signed_tx_cbor) > 0)),
+    CONSTRAINT deposit_submission_attempts_status_check CHECK ((status = ANY (ARRAY['prepared'::text, 'submission_unknown'::text, 'submitted'::text, 'confirmed'::text, 'reconciled_after_timeout'::text, 'ambiguous'::text, 'expired'::text]))),
+    CONSTRAINT deposit_submission_attempts_timestamp_check CHECK (((last_submission_at IS NULL) OR (last_submission_at >= prepared_at)) AND ((submitted_at IS NULL) OR ((last_submission_at IS NOT NULL) AND (submitted_at >= last_submission_at))) AND ((confirmed_at IS NULL) OR (confirmed_at >= prepared_at)) AND ((last_reconciled_at IS NULL) OR (last_reconciled_at >= prepared_at)) AND (updated_at >= prepared_at)),
     CONSTRAINT deposit_submission_attempts_tx_hash_check CHECK ((octet_length(tx_hash) = 32))
 );
 
@@ -1104,17 +1119,17 @@ CREATE INDEX idx_da_payloads_created_at ON public.da_payloads USING btree (creat
 
 
 --
--- Name: idx_deposit_submission_attempts_deposit_event_id; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_deposit_submission_attempts_active_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_deposit_submission_attempts_deposit_event_id ON public.deposit_submission_attempts USING btree (deposit_event_id);
+CREATE UNIQUE INDEX idx_deposit_submission_attempts_active_event_id ON public.deposit_submission_attempts USING btree (deposit_event_id) WHERE (status <> 'expired'::text);
 
 
 --
--- Name: idx_deposit_submission_attempts_status_submitted_at; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_deposit_submission_attempts_status_prepared_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_deposit_submission_attempts_status_submitted_at ON public.deposit_submission_attempts USING btree (confirmation_status, submitted_at);
+CREATE INDEX idx_deposit_submission_attempts_status_prepared_at ON public.deposit_submission_attempts USING btree (status, prepared_at);
 
 
 --

--- a/demo/midgard-node/src/index.ts
+++ b/demo/midgard-node/src/index.ts
@@ -4285,7 +4285,7 @@ program
 program
   .command("reconcile-deposit-submission")
   .description(
-    "Reconcile a previously submitted deposit transaction before retrying after a confirmation timeout",
+    "Observe chain and mempool evidence for a durable deposit attempt without submitting it",
   )
   .requiredOption("--tx-hash <hex>", "32-byte Cardano transaction hash")
   .option("--json", "Print machine-readable JSON output", true)
@@ -4304,6 +4304,36 @@ program
 
       const mainEffect = provideDatabaseTxServices(
         SubmitDeposit.reconcileDepositSubmissionAttemptProgram(txHash).pipe(
+          tapJson(),
+        ),
+      );
+
+      runCliEffect(mainEffect);
+    },
+  );
+
+program
+  .command("resume-deposit-submission")
+  .description(
+    "Status-check and, only for a never-claimed prepared row, make its one initial submission from exact signed bytes stored in PostgreSQL",
+  )
+  .requiredOption("--tx-hash <hex>", "32-byte Cardano transaction hash")
+  .option("--json", "Print machine-readable JSON output", true)
+  .action(
+    async (options: { readonly txHash: string; readonly json?: boolean }) => {
+      let txHash: string;
+      try {
+        txHash = normalizeHex(options.txHash, {
+          byteLength: 32,
+          trim: false,
+        });
+      } catch (error) {
+        failCli("resume-deposit-submission: invalid --tx-hash", error);
+        return;
+      }
+
+      const mainEffect = provideDatabaseTxServices(
+        SubmitDeposit.resumeDepositSubmissionAttemptProgram(txHash).pipe(
           tapJson(),
         ),
       );

--- a/demo/midgard-node/src/local-ledger-slot.ts
+++ b/demo/midgard-node/src/local-ledger-slot.ts
@@ -8,6 +8,8 @@ const DEFAULT_OGMIOS_HEALTH_MAX_AGE_MS = 120_000;
 export type SubmitSlotSnapshot = {
   readonly source: "local_ogmios_tip" | "emulator" | "test";
   readonly currentSlot: number;
+  /** Slot of the actual queried chain tip, without wall-clock extrapolation. */
+  readonly chainTipSlot?: number;
   readonly observedAtMs: number;
   readonly slotLengthMs: number;
   readonly health?: {
@@ -319,6 +321,7 @@ export const queryLocalOgmiosSubmitSlotSnapshot = async ({
   return {
     source: "local_ogmios_tip",
     currentSlot: Math.max(queriedTipSlot, derivedLiveSlot),
+    chainTipSlot: queriedTipSlot,
     observedAtMs: nowMs,
     slotLengthMs: SUBMIT_SLOT_LENGTH_MS,
     health,

--- a/demo/midgard-node/src/transactions/deposit-submission-provider.ts
+++ b/demo/midgard-node/src/transactions/deposit-submission-provider.ts
@@ -1,0 +1,578 @@
+import {
+  ChainSynchronization,
+  createInteractionContext,
+  createMempoolMonitoringClient,
+  type ConnectionConfig,
+  type InteractionContext,
+} from "@cardano-ogmios/client";
+import { CML, type LucidEvolution, type UTxO } from "@lucid-evolution/lucid";
+
+import type * as DepositSubmissionAttemptsDB from "@/database/depositSubmissionAttempts.js";
+import { parseExactKupoConfirmationMatch } from "@/kupo-confirmation-metadata.js";
+import { kupmiosKupoUrlFromLucid } from "@/kupmios.js";
+import {
+  queryLocalOgmiosSubmitSlotSnapshot,
+  SUBMIT_SLOT_VALIDITY_BUFFER,
+  type SubmitSlotSnapshot,
+} from "@/local-ledger-slot.js";
+import { inspectSignedTxValidityInterval } from "@/transactions/utils.js";
+
+const PROVIDER_EVIDENCE_TIMEOUT_MS = 10_000;
+
+export type DepositTransactionDependencies = {
+  readonly spend: readonly string[];
+  readonly collateral: readonly string[];
+  readonly reference: readonly string[];
+};
+
+export type HistoricalDepositOutputObservation =
+  | {
+      readonly kind: "committed";
+      readonly slot: number;
+      readonly blockHash: string;
+      readonly kupoCheckpoint: number;
+      readonly kupoCheckpointHash: string;
+    }
+  | {
+      readonly kind: "absent";
+      readonly kupoCheckpoint: number;
+      readonly kupoCheckpointHash: string;
+    };
+
+export type DepositTxObservation =
+  | {
+      readonly kind: "committed";
+      readonly slot: number;
+      readonly blockHash: string;
+      readonly kupoCheckpoint: number;
+    }
+  | {
+      readonly kind: "accepted";
+      readonly mempoolSlot: number;
+    }
+  | {
+      readonly kind: "absent_safe";
+      readonly mempoolSlot: number;
+      readonly kupoCheckpoint: number;
+      readonly currentSlot: number;
+    }
+  | {
+      readonly kind: "expired";
+      readonly mempoolSlot: number;
+      readonly kupoCheckpoint: number;
+      readonly currentSlot: number;
+      readonly invalidHereafterSlot: number;
+    }
+  | {
+      readonly kind: "ambiguous";
+      readonly reason: string;
+    };
+
+export type DepositObservationRuntime = {
+  readonly queryHistoricalOutput: (
+    txHash: string,
+    outputIndex: number,
+  ) => Promise<HistoricalDepositOutputObservation>;
+  readonly queryMempool: (
+    txHash: string,
+  ) => Promise<{ readonly slot: number; readonly contains: boolean }>;
+  readonly queryCanonicalPoint: (point: {
+    readonly slot: number;
+    readonly id: string;
+  }) => Promise<boolean>;
+  readonly queryCurrentSlot: () => Promise<SubmitSlotSnapshot>;
+  readonly queryDependencies: (
+    outRefs: readonly {
+      readonly txHash: string;
+      readonly outputIndex: number;
+    }[],
+  ) => Promise<readonly UTxO[]>;
+};
+
+const outRefList = (
+  list: ReturnType<CML.TransactionBody["inputs"]> | undefined,
+): readonly string[] => {
+  if (list === undefined) return [];
+  const outRefs: string[] = [];
+  for (let index = 0; index < list.len(); index += 1) {
+    const input = list.get(index);
+    outRefs.push(
+      `${input.transaction_id().to_hex()}#${Number(input.index()).toString()}`,
+    );
+  }
+  return [...new Set(outRefs)].sort();
+};
+
+/** Derives every L1 dependency whose identity must survive a crash. */
+export const depositDependenciesFromSignedTx = (
+  tx: CML.Transaction,
+): DepositTransactionDependencies => ({
+  spend: outRefList(tx.body().inputs()),
+  collateral: outRefList(tx.body().collateral_inputs()),
+  reference: outRefList(tx.body().reference_inputs()),
+});
+
+const parseOutRef = (
+  value: string,
+): { readonly txHash: string; readonly outputIndex: number } => {
+  const match = /^([0-9a-f]{64})#(0|[1-9]\d*)$/.exec(value);
+  if (match === null)
+    throw new Error(`Invalid stored Cardano outref: ${value}`);
+  const outputIndex = Number(match[2]);
+  if (!Number.isSafeInteger(outputIndex) || outputIndex > 0xffff) {
+    throw new Error(`Stored Cardano outref index is out of range: ${value}`);
+  }
+  return { txHash: match[1]!, outputIndex };
+};
+
+const dependencyKeys = (
+  dependencies: DepositTransactionDependencies,
+): readonly string[] =>
+  [...dependencies.spend, ...dependencies.collateral, ...dependencies.reference]
+    .filter((value, index, all) => all.indexOf(value) === index)
+    .sort();
+
+const sameDependencies = (
+  left: DepositTransactionDependencies,
+  right: DepositTransactionDependencies,
+): boolean =>
+  JSON.stringify(left.spend) === JSON.stringify(right.spend) &&
+  JSON.stringify(left.collateral) === JSON.stringify(right.collateral) &&
+  JSON.stringify(left.reference) === JSON.stringify(right.reference);
+
+const errorText = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
+
+const withTimeout = async <A>(
+  label: string,
+  operation: () => Promise<A>,
+  timeoutMs = PROVIDER_EVIDENCE_TIMEOUT_MS,
+  onTimeout?: () => void,
+): Promise<A> => {
+  let timeout: NodeJS.Timeout | undefined;
+  const timedOut = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      onTimeout?.();
+      reject(new Error(`${label} timed out after ${timeoutMs.toString()}ms`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation(), timedOut]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+};
+
+const checkpointPoint = (
+  response: Pick<Response, "headers">,
+): { readonly slot: number; readonly id: string } => {
+  const raw = response.headers.get("x-most-recent-checkpoint");
+  if (raw === null || !/^\d+$/.test(raw)) {
+    throw new Error("Kupo response is missing X-Most-Recent-Checkpoint");
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error("Kupo response checkpoint is invalid");
+  }
+  const rawEtag = response.headers.get("etag");
+  const id = rawEtag
+    ?.trim()
+    .replace(/^W\//u, "")
+    .replace(/^"|"$/gu, "")
+    .toLowerCase();
+  if (id === undefined || !/^[0-9a-f]{64}$/u.test(id)) {
+    throw new Error("Kupo response is missing a valid checkpoint ETag");
+  }
+  return { slot: value, id };
+};
+
+type KupoHistoricalFetchResponse = Pick<
+  Response,
+  "ok" | "status" | "statusText" | "headers" | "json"
+>;
+
+type KupoHistoricalFetch = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<KupoHistoricalFetchResponse>;
+
+export const queryHistoricalDepositOutput = async ({
+  kupoUrl,
+  txHash,
+  outputIndex,
+  fetchImpl = fetch,
+  timeoutMs = PROVIDER_EVIDENCE_TIMEOUT_MS,
+}: {
+  readonly kupoUrl: string;
+  readonly txHash: string;
+  readonly outputIndex: number;
+  readonly fetchImpl?: KupoHistoricalFetch;
+  readonly timeoutMs?: number;
+}): Promise<HistoricalDepositOutputObservation> => {
+  const pattern = encodeURIComponent(`${outputIndex.toString()}@${txHash}`);
+  const controller = new AbortController();
+  return withTimeout(
+    "Kupo historical deposit-output query",
+    async () => {
+      const response = await fetchImpl(`${kupoUrl}/matches/${pattern}`, {
+        signal: controller.signal,
+        headers: { accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Kupo returned HTTP ${response.status.toString()} ${response.statusText}`,
+        );
+      }
+      const checkpoint = checkpointPoint(response);
+      const body = (await response.json()) as unknown;
+      if (Array.isArray(body) && body.length === 0) {
+        return {
+          kind: "absent",
+          kupoCheckpoint: checkpoint.slot,
+          kupoCheckpointHash: checkpoint.id,
+        } as const;
+      }
+      const match = parseExactKupoConfirmationMatch({
+        body,
+        txHash,
+        outputIndex,
+      });
+      return {
+        kind: "committed",
+        slot: match.slotNo,
+        blockHash: match.blockHeaderHash,
+        kupoCheckpoint: checkpoint.slot,
+        kupoCheckpointHash: checkpoint.id,
+      } as const;
+    },
+    timeoutMs,
+    () => controller.abort(),
+  );
+};
+
+const ogmiosConnectionConfig = (endpoint: string): ConnectionConfig => {
+  const url = new URL(endpoint);
+  if (
+    !["http:", "https:", "ws:", "wss:"].includes(url.protocol) ||
+    (url.pathname !== "" && url.pathname !== "/") ||
+    url.search.length > 0 ||
+    url.hash.length > 0 ||
+    url.username.length > 0 ||
+    url.password.length > 0
+  ) {
+    throw new Error("Ogmios mempool monitoring requires a root endpoint URL");
+  }
+  const tls = url.protocol === "https:" || url.protocol === "wss:";
+  const port = url.port.length > 0 ? Number(url.port) : tls ? 443 : 80;
+  if (!Number.isSafeInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error("Ogmios endpoint port is invalid");
+  }
+  return { host: url.hostname, port, tls };
+};
+
+const closeInteractionContext = (
+  context: InteractionContext | undefined,
+): void => {
+  if (context === undefined) return;
+  (context.socket as unknown as { close: () => void }).close();
+};
+
+export const queryOgmiosMempool = async ({
+  ogmiosUrl,
+  txHash,
+  timeoutMs = PROVIDER_EVIDENCE_TIMEOUT_MS,
+}: {
+  readonly ogmiosUrl: string;
+  readonly txHash: string;
+  readonly timeoutMs?: number;
+}): Promise<{ readonly slot: number; readonly contains: boolean }> => {
+  let context: InteractionContext | undefined;
+  return withTimeout(
+    "Ogmios mempool observation",
+    async () => {
+      let socketFailure: Error | undefined;
+      context = await createInteractionContext(
+        (error) => {
+          socketFailure = error;
+        },
+        (code, reason) => {
+          if (code !== 1000) {
+            socketFailure = new Error(
+              `Ogmios socket closed code=${code.toString()} reason=${reason}`,
+            );
+          }
+        },
+        { connection: ogmiosConnectionConfig(ogmiosUrl) },
+      );
+      const client = await createMempoolMonitoringClient(context);
+      let acquired = false;
+      try {
+        const slot = Number(await client.acquireMempool());
+        acquired = true;
+        if (!Number.isSafeInteger(slot) || slot < 0) {
+          throw new Error("Ogmios acquired mempool slot is invalid");
+        }
+        const contains = await client.hasTransaction(txHash);
+        if (socketFailure !== undefined) throw socketFailure;
+        return { slot, contains };
+      } finally {
+        if (acquired) await client.releaseMempool().catch(() => undefined);
+        await client.shutdown().catch(() => undefined);
+      }
+    },
+    timeoutMs,
+    () => closeInteractionContext(context),
+  );
+};
+
+export const queryOgmiosCanonicalPoint = async ({
+  ogmiosUrl,
+  point,
+  timeoutMs = PROVIDER_EVIDENCE_TIMEOUT_MS,
+}: {
+  readonly ogmiosUrl: string;
+  readonly point: { readonly slot: number; readonly id: string };
+  readonly timeoutMs?: number;
+}): Promise<boolean> => {
+  let context: InteractionContext | undefined;
+  return withTimeout(
+    "Ogmios canonical-point observation",
+    async () => {
+      let socketFailure: Error | undefined;
+      context = await createInteractionContext(
+        (error) => {
+          socketFailure = error;
+        },
+        (code, reason) => {
+          if (code !== 1000) {
+            socketFailure = new Error(
+              `Ogmios socket closed code=${code.toString()} reason=${reason}`,
+            );
+          }
+        },
+        { connection: ogmiosConnectionConfig(ogmiosUrl) },
+      );
+      try {
+        const result = await ChainSynchronization.findIntersection(context, [
+          point,
+        ]);
+        if (socketFailure !== undefined) throw socketFailure;
+        return (
+          result.intersection !== "origin" &&
+          Number(result.intersection.slot) === point.slot &&
+          result.intersection.id.toLowerCase() === point.id.toLowerCase()
+        );
+      } catch {
+        return false;
+      } finally {
+        closeInteractionContext(context);
+      }
+    },
+    timeoutMs,
+    () => closeInteractionContext(context),
+  );
+};
+
+/**
+ * Combines historical Kupo, a frozen Ogmios mempool snapshot, authoritative
+ * slot evidence, and every signed dependency. Any disagreement fails closed.
+ */
+export const observePreparedDeposit = async ({
+  txHash,
+  signedTxCbor,
+  expectedDepositOutRef,
+  storedDependencies,
+  runtime,
+}: {
+  readonly txHash: string;
+  readonly signedTxCbor: string;
+  readonly expectedDepositOutRef: string;
+  readonly storedDependencies: DepositTransactionDependencies;
+  readonly runtime: DepositObservationRuntime;
+}): Promise<DepositTxObservation> => {
+  try {
+    const tx = CML.Transaction.from_cbor_hex(signedTxCbor);
+    const bodyHash = CML.hash_transaction(tx.body()).to_hex();
+    if (bodyHash !== txHash) {
+      return {
+        kind: "ambiguous",
+        reason: `stored signed CBOR hash mismatch expected=${txHash} actual=${bodyHash}`,
+      };
+    }
+    const signedDependencies = depositDependenciesFromSignedTx(tx);
+    if (!sameDependencies(signedDependencies, storedDependencies)) {
+      return {
+        kind: "ambiguous",
+        reason: "stored dependency set does not match the exact signed body",
+      };
+    }
+    const expected = parseOutRef(expectedDepositOutRef);
+    if (expected.txHash !== txHash) {
+      return {
+        kind: "ambiguous",
+        reason: "expected deposit outref is not bound to the stored tx hash",
+      };
+    }
+    const historical = await runtime.queryHistoricalOutput(
+      expected.txHash,
+      expected.outputIndex,
+    );
+    const checkpointCanonical = await runtime.queryCanonicalPoint({
+      slot: historical.kupoCheckpoint,
+      id: historical.kupoCheckpointHash,
+    });
+    if (!checkpointCanonical) {
+      return {
+        kind: "ambiguous",
+        reason: "Kupo checkpoint is not on the canonical Ogmios chain",
+      };
+    }
+    if (historical.kind === "committed") {
+      const creationPointCanonical = await runtime.queryCanonicalPoint({
+        slot: historical.slot,
+        id: historical.blockHash,
+      });
+      if (!creationPointCanonical) {
+        return {
+          kind: "ambiguous",
+          reason: "Kupo deposit match is not on the canonical Ogmios chain",
+        };
+      }
+      return historical;
+    }
+
+    const mempool = await runtime.queryMempool(txHash);
+    if (mempool.contains) {
+      return { kind: "accepted", mempoolSlot: mempool.slot };
+    }
+    if (historical.kupoCheckpoint < mempool.slot) {
+      return {
+        kind: "ambiguous",
+        reason: `Kupo checkpoint ${historical.kupoCheckpoint.toString()} is behind Ogmios mempool slot ${mempool.slot.toString()}`,
+      };
+    }
+    const slot = await runtime.queryCurrentSlot();
+    const chainTipSlot = slot.chainTipSlot ?? slot.health?.lastKnownTipSlot;
+    if (chainTipSlot === undefined) {
+      return {
+        kind: "ambiguous",
+        reason:
+          "authoritative Ogmios chain-tip slot is unavailable for Kupo coverage proof",
+      };
+    }
+    if (historical.kupoCheckpoint < chainTipSlot) {
+      return {
+        kind: "ambiguous",
+        reason: `Kupo checkpoint ${historical.kupoCheckpoint.toString()} is behind authoritative Ogmios chain tip ${chainTipSlot.toString()}`,
+      };
+    }
+    const keys = dependencyKeys(storedDependencies);
+    const requested = keys.map(parseOutRef);
+    const visible = await runtime.queryDependencies(requested);
+    const visibleKeys = new Set(
+      visible.map((utxo) => `${utxo.txHash}#${utxo.outputIndex.toString()}`),
+    );
+    const missing = keys.filter((key) => !visibleKeys.has(key));
+    if (missing.length > 0) {
+      return {
+        kind: "ambiguous",
+        reason: `signed transaction dependencies are no longer all unspent: ${missing.join(",")}`,
+      };
+    }
+    const validity = inspectSignedTxValidityInterval(signedTxCbor);
+    if (
+      validity.invalidHereafterSlot !== undefined &&
+      slot.currentSlot + SUBMIT_SLOT_VALIDITY_BUFFER >=
+        validity.invalidHereafterSlot
+    ) {
+      return {
+        kind: "expired",
+        mempoolSlot: mempool.slot,
+        kupoCheckpoint: historical.kupoCheckpoint,
+        currentSlot: slot.currentSlot,
+        invalidHereafterSlot: validity.invalidHereafterSlot,
+      };
+    }
+    if (
+      validity.invalidBeforeSlot !== undefined &&
+      slot.currentSlot <
+        validity.invalidBeforeSlot + SUBMIT_SLOT_VALIDITY_BUFFER
+    ) {
+      return {
+        kind: "ambiguous",
+        reason: `authoritative slot ${slot.currentSlot.toString()} has not reached signed validity margin ${(
+          validity.invalidBeforeSlot + SUBMIT_SLOT_VALIDITY_BUFFER
+        ).toString()}`,
+      };
+    }
+    return {
+      kind: "absent_safe",
+      mempoolSlot: mempool.slot,
+      kupoCheckpoint: historical.kupoCheckpoint,
+      currentSlot: slot.currentSlot,
+    };
+  } catch (cause) {
+    return {
+      kind: "ambiguous",
+      reason: `provider evidence unavailable: ${errorText(cause)}`,
+    };
+  }
+};
+
+export const liveDepositObservationRuntime = ({
+  lucid,
+  ogmiosUrl,
+  timeoutMs,
+}: {
+  readonly lucid: LucidEvolution;
+  readonly ogmiosUrl: string;
+  readonly timeoutMs: number;
+}): DepositObservationRuntime => {
+  const kupoUrl = kupmiosKupoUrlFromLucid(lucid);
+  if (kupoUrl === undefined) {
+    throw new Error("Durable deposit recovery requires the local Kupo URL");
+  }
+  return {
+    queryHistoricalOutput: (txHash, outputIndex) =>
+      queryHistoricalDepositOutput({
+        kupoUrl,
+        txHash,
+        outputIndex,
+        timeoutMs,
+      }),
+    queryMempool: (txHash) =>
+      queryOgmiosMempool({ ogmiosUrl, txHash, timeoutMs }),
+    queryCanonicalPoint: (point) =>
+      queryOgmiosCanonicalPoint({ ogmiosUrl, point, timeoutMs }),
+    queryCurrentSlot: () =>
+      queryLocalOgmiosSubmitSlotSnapshot({
+        ogmiosUrl,
+        timeoutMs,
+      }),
+    queryDependencies: (outRefs) =>
+      withTimeout(
+        "L1 dependency lookup",
+        () => lucid.utxosByOutRef([...outRefs]),
+        timeoutMs,
+      ),
+  };
+};
+
+export const observeDepositSubmissionAttempt = async ({
+  lucid,
+  attempt,
+  ogmiosUrl,
+  timeoutMs,
+}: {
+  readonly lucid: LucidEvolution;
+  readonly attempt: DepositSubmissionAttemptsDB.Row;
+  readonly ogmiosUrl: string;
+  readonly timeoutMs: number;
+}): Promise<DepositTxObservation> =>
+  observePreparedDeposit({
+    txHash: attempt.tx_hash.toString("hex"),
+    signedTxCbor: attempt.signed_tx_cbor.toString("hex"),
+    expectedDepositOutRef: attempt.expected_deposit_out_ref,
+    storedDependencies: attempt.dependency_out_refs,
+    runtime: liveDepositObservationRuntime({ lucid, ogmiosUrl, timeoutMs }),
+  });

--- a/demo/midgard-node/src/transactions/submit-deposit.ts
+++ b/demo/midgard-node/src/transactions/submit-deposit.ts
@@ -4,6 +4,7 @@
  * This module owns node/API concerns and delegates production transaction
  * construction to the SDK user-event builders.
  */
+import { formatUnknownError } from "@al-ft/midgard-core/error-format";
 import { normalizeHex as normalizeCoreHex } from "@al-ft/midgard-core/hex";
 import * as SDK from "@al-ft/midgard-sdk";
 import {
@@ -17,7 +18,7 @@ import {
   type TxSignBuilder,
   type UTxO,
 } from "@lucid-evolution/lucid";
-import { Option } from "effect";
+import { Duration, Option } from "effect";
 import { Data as EffectData, Effect } from "effect";
 
 import {
@@ -35,11 +36,17 @@ import {
 } from "@/services/index.js";
 import {
   awaitSubmittedTransactionConfirmation,
-  signSubmitTransaction,
-  TxConfirmError,
+  type SignSubmitContext,
+  type SubmitRecoveryOptions,
+  submitSignedTxWithRecovery,
   TxSignError,
   TxSubmitError,
 } from "@/transactions/utils.js";
+import {
+  depositDependenciesFromSignedTx,
+  type DepositTxObservation,
+  observeDepositSubmissionAttempt,
+} from "@/transactions/deposit-submission-provider.js";
 
 export type SubmitDepositReferenceScripts = SDK.SubmitDepositReferenceScripts;
 export type SubmitDepositConfig = SDK.SubmitDepositConfig;
@@ -62,6 +69,23 @@ export type SubmittedDeposit = {
     | "confirmed"
     | "reconciled_after_timeout"
     | "ambiguous";
+};
+
+/**
+ * A signed deposit checkpoint that is complete enough to persist before any
+ * provider submission. Recovery submits only `signedTxCbor`; it never accepts
+ * a builder or logical deposit config that could synthesize a different tx.
+ */
+export type PreparedDeposit = {
+  readonly txHash: string;
+  readonly signedTxCbor: string;
+  readonly selectedInputOutRefs: readonly string[];
+  readonly metadata: DepositBuildMetadata;
+  readonly submissionAttempt: DepositSubmissionAttemptsDB.InsertPreparedInput;
+};
+
+export type PreparedDepositSubmission = SignSubmitContext & {
+  readonly providerTxHash: string | null;
 };
 
 export class SubmitDepositError extends EffectData.TaggedError(
@@ -154,7 +178,7 @@ export const depositSubmissionAttemptFromSignedTx = ({
   readonly signedTxCbor: string;
   readonly metadata: DepositBuildMetadata;
   readonly config: SubmitDepositConfig;
-}): DepositSubmissionAttemptsDB.InsertSubmittedInput => {
+}): DepositSubmissionAttemptsDB.InsertPreparedInput => {
   const tx = CML.Transaction.from_cbor_hex(signedTxCbor);
   const outputs = tx.body().outputs();
   const matches: Array<{
@@ -206,6 +230,10 @@ export const depositSubmissionAttemptFromSignedTx = ({
 
   return {
     [DepositSubmissionAttemptsDB.Columns.TX_HASH]: Buffer.from(txHash, "hex"),
+    [DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR]: Buffer.from(
+      signedTxCbor,
+      "hex",
+    ),
     [DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID]: Buffer.from(
       metadata.depositEventId,
       "hex",
@@ -226,8 +254,8 @@ export const depositSubmissionAttemptFromSignedTx = ({
       validTo: metadata.validTo,
       inclusionTime: metadata.inclusionTime,
     },
-    [DepositSubmissionAttemptsDB.Columns.FUNDING_OUT_REFS]:
-      inputOutRefsFromSignedTx(tx),
+    [DepositSubmissionAttemptsDB.Columns.DEPENDENCY_OUT_REFS]:
+      depositDependenciesFromSignedTx(tx),
   };
 };
 
@@ -237,6 +265,9 @@ export type DepositSubmissionReconciliationResult = {
   readonly status:
     | "confirmed"
     | "reconciled_after_timeout"
+    | "accepted"
+    | "unseen"
+    | "expired"
     | "ambiguous"
     | "missing_attempt";
   readonly expectedDepositOutRef?: string;
@@ -244,6 +275,10 @@ export type DepositSubmissionReconciliationResult = {
   readonly reconciledCount: number;
   readonly nextSafeAction: string;
 };
+
+export type DepositSubmissionObservationReader = (
+  attempt: DepositSubmissionAttemptsDB.Row,
+) => Promise<DepositTxObservation>;
 
 const findMatchingDepositEntry = (
   rows: readonly DepositsDB.Entry[],
@@ -257,9 +292,12 @@ const findMatchingDepositEntry = (
 
 export const reconcileDepositSubmissionAttemptProgram = (
   txHash: string,
+  options: {
+    readonly observe?: DepositSubmissionObservationReader;
+  } = {},
 ): Effect.Effect<
   DepositSubmissionReconciliationResult,
-  DatabaseError | SDK.LucidError,
+  DatabaseError | SDK.LucidError | SubmitDepositError,
   Database | MidgardContracts | LucidService | NodeConfig
 > =>
   Effect.gen(function* () {
@@ -274,72 +312,155 @@ export const reconcileDepositSubmissionAttemptProgram = (
         depositRowsFound: 0,
         reconciledCount: 0,
         nextSafeAction:
-          "Do not blindly retry; inspect the transaction hash with provider tooling and only rebuild if the submitted transaction is not on-chain.",
+          "The durable journal is missing, so claim history is unknown. Do not resume or rebuild from this result; require explicit operator provenance and positive provider evidence before any new operation.",
       } as const;
     }
 
     const attempt = attemptOption.value;
-    const beforeRows = yield* DepositsDB.retrieveByCardanoTxHash(txHashBuffer);
-    const beforeMatch = findMatchingDepositEntry(beforeRows, attempt);
-    if (beforeMatch !== undefined) {
-      yield* DepositSubmissionAttemptsDB.markReconciled(txHashBuffer);
+    const attemptStatus = attempt[DepositSubmissionAttemptsDB.Columns.STATUS];
+    const depositEventId =
+      attempt[DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID].toString(
+        "hex",
+      );
+    const expectedDepositOutRef =
+      attempt[DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF];
+    if (
+      attemptStatus === DepositSubmissionAttemptsDB.Status.Confirmed ||
+      attemptStatus ===
+        DepositSubmissionAttemptsDB.Status.ReconciledAfterTimeout ||
+      attemptStatus === DepositSubmissionAttemptsDB.Status.Expired
+    ) {
       return {
         txHash,
-        depositEventId:
-          attempt[
-            DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID
-          ].toString("hex"),
-        status: "reconciled_after_timeout",
-        expectedDepositOutRef:
-          attempt[DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF],
-        depositRowsFound: beforeRows.length,
+        depositEventId,
+        status:
+          attemptStatus === DepositSubmissionAttemptsDB.Status.Confirmed
+            ? "confirmed"
+            : attemptStatus ===
+                DepositSubmissionAttemptsDB.Status.ReconciledAfterTimeout
+              ? "reconciled_after_timeout"
+              : "expired",
+        expectedDepositOutRef,
+        depositRowsFound: 0,
         reconciledCount: 0,
         nextSafeAction:
-          "Deposit is already visible in deposits_utxos; continue the flow without resubmitting.",
+          attemptStatus === DepositSubmissionAttemptsDB.Status.Expired
+            ? "The exact transaction is expired and terminal; never submit it."
+            : "The durable attempt is terminal; never resubmit this transaction.",
       } as const;
     }
+    const lucidService = yield* LucidService;
+    const nodeConfig = yield* NodeConfig;
+    const observation = yield* Effect.tryPromise({
+      try: () =>
+        options.observe === undefined
+          ? observeDepositSubmissionAttempt({
+              lucid: lucidService.api,
+              attempt,
+              ogmiosUrl: nodeConfig.L1_OGMIOS_KEY,
+              timeoutMs: nodeConfig.L1_PROVIDER_PREFLIGHT_TIMEOUT_MS,
+            })
+          : options.observe(attempt),
+      catch: (cause) =>
+        new SubmitDepositError({
+          message: "Failed to observe durable deposit submission state",
+          cause,
+        }),
+    });
 
-    const { reconciledCount } = yield* reconcileVisibleDepositUTxOs();
-    const afterRows = yield* DepositsDB.retrieveByCardanoTxHash(txHashBuffer);
-    const afterMatch = findMatchingDepositEntry(afterRows, attempt);
-    if (afterMatch !== undefined) {
-      yield* DepositSubmissionAttemptsDB.markReconciled(txHashBuffer);
+    if (observation.kind === "committed") {
+      const reconciliation = yield* Effect.either(
+        reconcileVisibleDepositUTxOs(),
+      );
+      const reconciledCount =
+        reconciliation._tag === "Right"
+          ? reconciliation.right.reconciledCount
+          : 0;
+      const afterRows = yield* DepositsDB.retrieveByCardanoTxHash(txHashBuffer);
+      const afterMatch = findMatchingDepositEntry(afterRows, attempt);
+      if (afterMatch !== undefined) {
+        yield* DepositSubmissionAttemptsDB.markReconciled(txHashBuffer);
+      } else {
+        yield* DepositSubmissionAttemptsDB.markConfirmed(txHashBuffer);
+      }
       return {
         txHash,
-        depositEventId:
-          attempt[
-            DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID
-          ].toString("hex"),
-        status: "reconciled_after_timeout",
-        expectedDepositOutRef:
-          attempt[DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF],
+        depositEventId,
+        status:
+          afterMatch === undefined ? "confirmed" : "reconciled_after_timeout",
+        expectedDepositOutRef,
         depositRowsFound: afterRows.length,
         reconciledCount,
         nextSafeAction:
-          "Deposit was recovered from visible chain state; continue the flow without resubmitting.",
+          "Historical Kupo evidence proves this exact deposit committed; never resubmit it.",
+      } as const;
+    }
+    if (observation.kind === "accepted") {
+      if (
+        attemptStatus === DepositSubmissionAttemptsDB.Status.SubmissionUnknown
+      ) {
+        yield* DepositSubmissionAttemptsDB.markSubmitted(
+          txHashBuffer,
+          "ogmios_mempool",
+        );
+      }
+      return {
+        txHash,
+        depositEventId,
+        status: "accepted",
+        expectedDepositOutRef,
+        depositRowsFound: 0,
+        reconciledCount: 0,
+        nextSafeAction:
+          "Ogmios has this exact transaction in its acquired mempool snapshot; wait for confirmation without resubmitting.",
+      } as const;
+    }
+    if (observation.kind === "absent_safe") {
+      const neverClaimed =
+        attemptStatus === DepositSubmissionAttemptsDB.Status.Prepared;
+      return {
+        txHash,
+        depositEventId,
+        status: neverClaimed ? "unseen" : "ambiguous",
+        expectedDepositOutRef,
+        depositRowsFound: 0,
+        reconciledCount: 0,
+        nextSafeAction: neverClaimed
+          ? "The durable row proves no provider call has been claimed; one initial exact-byte submission may be claimed."
+          : "The transaction is not currently observed, but a provider call may already have occurred; never resubmit it automatically.",
+      } as const;
+    }
+    if (observation.kind === "expired") {
+      const reason = `Exact signed deposit expired absent from synchronized chain/mempool evidence: current_slot=${observation.currentSlot.toString()},invalid_hereafter=${observation.invalidHereafterSlot.toString()}`;
+      if (attemptStatus === DepositSubmissionAttemptsDB.Status.Prepared) {
+        yield* DepositSubmissionAttemptsDB.markExpired(txHashBuffer, reason);
+      }
+      return {
+        txHash,
+        depositEventId,
+        status:
+          attemptStatus === DepositSubmissionAttemptsDB.Status.Prepared
+            ? "expired"
+            : "ambiguous",
+        expectedDepositOutRef,
+        depositRowsFound: 0,
+        reconciledCount: 0,
+        nextSafeAction:
+          attemptStatus === DepositSubmissionAttemptsDB.Status.Prepared
+            ? "This never-submitted exact transaction is expired and terminal; create a new deposit operation explicitly if still desired."
+            : "The exact transaction expired after a provider call may have occurred; inspect positive chain evidence and never resubmit it.",
       } as const;
     }
 
-    const reason =
-      afterRows.length > 0
-        ? `Cardano tx ${txHash} has deposit rows, but none match expected event ${attempt[
-            DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID
-          ].toString("hex")}.`
-        : `Cardano tx ${txHash} is not visible in deposits_utxos after reconciliation.`;
-    yield* DepositSubmissionAttemptsDB.markAmbiguous(txHashBuffer, reason);
     return {
       txHash,
-      depositEventId:
-        attempt[DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID].toString(
-          "hex",
-        ),
+      depositEventId,
       status: "ambiguous",
-      expectedDepositOutRef:
-        attempt[DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF],
-      depositRowsFound: afterRows.length,
-      reconciledCount,
+      expectedDepositOutRef,
+      depositRowsFound: 0,
+      reconciledCount: 0,
       nextSafeAction:
-        "Do not resubmit yet; inspect provider confirmation and deposit contract UTxOs for this tx hash/event id.",
+        "Provider evidence is incomplete or inconsistent; do not resubmit.",
     } as const;
   });
 
@@ -358,6 +479,172 @@ export const buildUnsignedDepositTxProgram = (
   buildUnsignedDepositTxWithMetadataProgram(lucid, contracts, config).pipe(
     Effect.map(({ tx }) => tx),
   );
+
+const parsePreparedSignedTransaction = ({
+  txHash,
+  signedTxCbor,
+}: Pick<PreparedDeposit, "txHash" | "signedTxCbor">): CML.Transaction => {
+  const parsed = CML.Transaction.from_cbor_hex(signedTxCbor);
+  const recomputedTxHash = CML.hash_transaction(parsed.body()).to_hex();
+  if (recomputedTxHash !== txHash) {
+    throw new Error(
+      `Prepared deposit CBOR hash mismatch: expected=${txHash}, actual=${recomputedTxHash}`,
+    );
+  }
+  return parsed;
+};
+
+/**
+ * Builds and signs a deposit without submitting it. The returned exact signed
+ * CBOR and its derived expected-output identity are the durable recovery
+ * checkpoint.
+ */
+export const prepareDepositWithMetadataProgram = (
+  lucid: LucidEvolution,
+  contracts: SDK.MidgardValidators,
+  config: SubmitDepositConfig,
+  options: {
+    readonly submissionAttemptBuilder?: typeof depositSubmissionAttemptFromSignedTx;
+  } = {},
+): Effect.Effect<
+  PreparedDeposit,
+  | SDK.HubOracleError
+  | SDK.LucidError
+  | SDK.Bech32DeserializationError
+  | SDK.HashingError
+  | SubmitDepositError
+  | TxSignError
+> =>
+  Effect.gen(function* () {
+    const { tx, metadata } = yield* buildUnsignedDepositTxWithMetadataProgram(
+      lucid,
+      contracts,
+      config,
+    );
+    const txHash = tx.toHash();
+    const signed = yield* tx.sign
+      .withWallet()
+      .completeProgram()
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new TxSignError({
+              message: "Failed to sign deposit transaction",
+              cause,
+              txHash,
+            }),
+        ),
+      );
+    const signedTxCbor = signed.toCBOR();
+    const parsedSigned = yield* Effect.try({
+      try: () => parsePreparedSignedTransaction({ txHash, signedTxCbor }),
+      catch: (cause) =>
+        new SubmitDepositError({
+          message: "Prepared signed deposit transaction failed identity checks",
+          cause,
+        }),
+    });
+    const submissionAttempt = yield* Effect.try({
+      try: () =>
+        (
+          options.submissionAttemptBuilder ??
+          depositSubmissionAttemptFromSignedTx
+        )({
+          txHash,
+          signedTxCbor,
+          metadata,
+          config,
+        }),
+      catch: (cause) =>
+        new SubmitDepositError({
+          message:
+            "Failed to derive expected deposit output from the prepared signed transaction",
+          cause,
+        }),
+    });
+    return {
+      txHash,
+      signedTxCbor,
+      selectedInputOutRefs: inputOutRefsFromSignedTx(parsedSigned),
+      metadata,
+      submissionAttempt,
+    };
+  });
+
+/**
+ * Submits one exact persisted signed payload. Generic provider retries are
+ * disabled. The durable one-way claim prevents every later provider call.
+ */
+export const submitPreparedDepositProgram = (
+  lucid: LucidEvolution,
+  prepared: Pick<PreparedDeposit, "txHash" | "signedTxCbor">,
+  options: SubmitRecoveryOptions = {},
+): Effect.Effect<
+  PreparedDepositSubmission,
+  SubmitDepositError | TxSubmitError
+> =>
+  Effect.gen(function* () {
+    yield* Effect.try({
+      try: () => parsePreparedSignedTransaction(prepared),
+      catch: (cause) =>
+        new SubmitDepositError({
+          message: "Prepared signed deposit CBOR is invalid",
+          cause,
+        }),
+    });
+    const provider = lucid.config().provider;
+    if (provider === undefined) {
+      return yield* Effect.fail(
+        new SubmitDepositError({
+          message: "Cannot submit prepared deposit without a Lucid provider",
+          cause: "provider-unavailable",
+        }),
+      );
+    }
+    const walletAddress = yield* Effect.tryPromise({
+      try: () => lucid.wallet().address(),
+      catch: () => "<unknown>",
+    }).pipe(Effect.catchAll(() => Effect.succeed("<unknown>")));
+    let providerTxHash: string | null = null;
+    const exactSigned = {
+      toCBOR: () => prepared.signedTxCbor,
+      submitProgram: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const returnedHash = await provider.submitTx(prepared.signedTxCbor);
+            if (returnedHash !== prepared.txHash) {
+              throw new Error(
+                `Provider returned a mismatched deposit transaction hash: expected=${prepared.txHash}, actual=${returnedHash}`,
+              );
+            }
+            providerTxHash = returnedHash;
+            return returnedHash;
+          },
+          catch: (cause) => cause,
+        }),
+    } as unknown as Awaited<ReturnType<TxSignBuilder["complete"]>>;
+
+    yield* submitSignedTxWithRecovery(lucid, exactSigned, prepared.txHash, {
+      ...options,
+      maxProviderRetryAttempts: 0,
+      maxOutsideValidityRecoveryAttempts: 0,
+    }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new TxSubmitError({
+            message: "Failed to submit prepared deposit transaction",
+            cause,
+            txHash: prepared.txHash,
+          }),
+      ),
+    );
+    return {
+      txHash: prepared.txHash,
+      signedTxCbor: prepared.signedTxCbor,
+      walletAddress,
+      providerTxHash,
+    };
+  });
 
 export const buildUnsignedDepositTxFromFundingContextProgram = (
   lucid: LucidEvolution,
@@ -405,6 +692,301 @@ export const buildUnsignedDepositTxFromFundingContextProgram = (
     return { unsignedTxCbor: tx.toCBOR() };
   });
 
+const preparedIdentityFromRow = (
+  row: DepositSubmissionAttemptsDB.Row,
+): Pick<PreparedDeposit, "txHash" | "signedTxCbor"> => ({
+  txHash: row[DepositSubmissionAttemptsDB.Columns.TX_HASH].toString("hex"),
+  signedTxCbor:
+    row[DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR].toString("hex"),
+});
+
+const retrieveRequiredDepositAttempt = (
+  txHash: string,
+): Effect.Effect<
+  DepositSubmissionAttemptsDB.Row,
+  DatabaseError | SubmitDepositError,
+  Database
+> =>
+  Effect.gen(function* () {
+    const row = yield* DepositSubmissionAttemptsDB.retrieveByTxHash(
+      Buffer.from(txHash, "hex"),
+    );
+    if (Option.isNone(row)) {
+      return yield* Effect.fail(
+        new SubmitDepositError({
+          message: `Durable deposit submission attempt ${txHash} does not exist`,
+          cause: "missing-attempt",
+        }),
+      );
+    }
+    return row.value;
+  });
+
+const submitDurableDepositAttemptProgram = (
+  lucid: LucidEvolution,
+  txHash: string,
+  eligibility: DepositSubmissionReconciliationResult,
+  options: {
+    readonly observe?: DepositSubmissionObservationReader;
+    readonly submitRecovery?: SubmitRecoveryOptions;
+  } = {},
+): Effect.Effect<
+  PreparedDepositSubmission,
+  DatabaseError | SDK.LucidError | SubmitDepositError | TxSubmitError,
+  Database | MidgardContracts | LucidService | NodeConfig
+> =>
+  Effect.gen(function* () {
+    if (eligibility.txHash !== txHash || eligibility.status !== "unseen") {
+      return yield* Effect.fail(
+        new SubmitDepositError({
+          message: `Deposit ${txHash} is not eligible for exact-byte submission after status-first reconciliation`,
+          cause: eligibility,
+        }),
+      );
+    }
+
+    const txHashBuffer = Buffer.from(txHash, "hex");
+    const claimed =
+      yield* DepositSubmissionAttemptsDB.beginSubmission(txHashBuffer);
+    const persisted = preparedIdentityFromRow(claimed);
+    const lucidService = yield* LucidService;
+    const submitted = yield* Effect.either(
+      submitPreparedDepositProgram(lucid, persisted, {
+        slotSnapshot: lucidService.submitSlotSnapshot,
+        requireSlotForBoundedTx: true,
+        ...options.submitRecovery,
+        maxProviderRetryAttempts: 0,
+      }),
+    );
+    if (submitted._tag === "Left") {
+      const reason = `Exact deposit provider submission outcome is unknown: ${formatUnknownError(
+        submitted.left,
+        { includeCause: true },
+      )}`;
+      yield* DepositSubmissionAttemptsDB.markAmbiguous(txHashBuffer, reason);
+      return yield* Effect.fail(submitted.left);
+    }
+    yield* DepositSubmissionAttemptsDB.markSubmitted(
+      txHashBuffer,
+      submitted.right.providerTxHash ?? "already_included_confirmed",
+    );
+    return submitted.right;
+  });
+
+const confirmDurableDepositAttemptProgram = (
+  lucid: LucidEvolution,
+  submission: SignSubmitContext,
+  attempt: DepositSubmissionAttemptsDB.Row,
+  options: {
+    readonly observe?: DepositSubmissionObservationReader;
+  } = {},
+): Effect.Effect<
+  "confirmed" | "reconciled_after_timeout",
+  | DatabaseError
+  | SDK.LucidError
+  | SubmitDepositError
+  | DepositConfirmationUnknownError,
+  Database | MidgardContracts | LucidService | NodeConfig
+> =>
+  awaitSubmittedTransactionConfirmation(lucid, submission).pipe(
+    Effect.tap(() =>
+      DepositSubmissionAttemptsDB.markConfirmed(
+        Buffer.from(submission.txHash, "hex"),
+      ),
+    ),
+    Effect.as("confirmed" as const),
+    Effect.catchTag("TxConfirmError", (error) =>
+      Effect.gen(function* () {
+        yield* Effect.logWarning(
+          `Deposit tx ${submission.txHash} confirmation timed out; reconciling historical chain and mempool evidence.`,
+        );
+        const reconciliation = yield* reconcileDepositSubmissionAttemptProgram(
+          submission.txHash,
+          {
+            observe: options.observe,
+          },
+        );
+        if (
+          reconciliation.status === "reconciled_after_timeout" ||
+          reconciliation.status === "confirmed"
+        ) {
+          return "reconciled_after_timeout" as const;
+        }
+        return yield* Effect.fail(
+          new DepositConfirmationUnknownError({
+            message:
+              "Deposit confirmation remains nonterminal after historical chain and mempool reconciliation.",
+            txHash: submission.txHash,
+            depositEventId:
+              attempt[
+                DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID
+              ].toString("hex"),
+            expectedDepositOutRef:
+              attempt[
+                DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF
+              ],
+            reconciliation,
+            cause: error,
+          }),
+        );
+      }),
+    ),
+  );
+
+export type ResumeDepositSubmissionResult = {
+  readonly txHash: string;
+  readonly status: "confirmed" | "reconciled_after_timeout" | "accepted";
+};
+
+/**
+ * Recovers one durable attempt without a builder or signer. Status is observed
+ * first, accepted/committed transactions are never submitted, and only a
+ * never-claimed prepared row permits its one initial exact-CBOR provider call.
+ */
+export const resumeDepositSubmissionAttemptProgram = (
+  txHash: string,
+  options: {
+    readonly observe?: DepositSubmissionObservationReader;
+    readonly submitRecovery?: SubmitRecoveryOptions;
+  } = {},
+): Effect.Effect<
+  ResumeDepositSubmissionResult,
+  | DatabaseError
+  | SDK.LucidError
+  | SubmitDepositError
+  | TxSubmitError
+  | DepositConfirmationUnknownError,
+  Database | MidgardContracts | LucidService | NodeConfig
+> =>
+  Effect.gen(function* () {
+    const lucidService = yield* LucidService;
+    const reconciled = yield* reconcileDepositSubmissionAttemptProgram(txHash, {
+      observe: options.observe,
+    });
+    if (
+      reconciled.status === "confirmed" ||
+      reconciled.status === "reconciled_after_timeout"
+    ) {
+      return { txHash, status: reconciled.status } as const;
+    }
+    const attempt = yield* retrieveRequiredDepositAttempt(txHash);
+    if (reconciled.status === "accepted") {
+      const confirmationStatus = yield* confirmDurableDepositAttemptProgram(
+        lucidService.api,
+        {
+          ...preparedIdentityFromRow(attempt),
+          walletAddress: "<unknown>",
+        },
+        attempt,
+        { observe: options.observe },
+      );
+      return { txHash, status: confirmationStatus } as const;
+    }
+    if (
+      reconciled.status !== "unseen" ||
+      attempt[DepositSubmissionAttemptsDB.Columns.STATUS] !==
+        DepositSubmissionAttemptsDB.Status.Prepared
+    ) {
+      return yield* Effect.fail(
+        new SubmitDepositError({
+          message: `Deposit ${txHash} recovery is fail-closed in observed status ${reconciled.status} and durable status ${attempt[DepositSubmissionAttemptsDB.Columns.STATUS]}`,
+          cause: reconciled,
+        }),
+      );
+    }
+    const submission = yield* submitDurableDepositAttemptProgram(
+      lucidService.api,
+      txHash,
+      reconciled,
+      options,
+    );
+    const currentAttempt = yield* retrieveRequiredDepositAttempt(txHash);
+    const confirmationStatus = yield* confirmDurableDepositAttemptProgram(
+      lucidService.api,
+      submission,
+      currentAttempt,
+      { observe: options.observe },
+    );
+    return { txHash, status: confirmationStatus } as const;
+  });
+
+export const STARTUP_DEPOSIT_RECONCILIATION_LIMIT = 32;
+export const STARTUP_DEPOSIT_RECONCILIATION_CONCURRENCY = 4;
+export const STARTUP_DEPOSIT_RECONCILIATION_ATTEMPT_TIMEOUT_MS = 15_000;
+
+/**
+ * Best-effort startup observation. The caller runs this concurrently with the
+ * server; this sweep is bounded and never submits a transaction.
+ */
+export const reconcileOpenDepositSubmissionAttemptsProgram = (
+  options: {
+    readonly limit?: number;
+    readonly concurrency?: number;
+    readonly attemptTimeoutMs?: number;
+    readonly observe?: DepositSubmissionObservationReader;
+  } = {},
+) =>
+  Effect.gen(function* () {
+    const attempts = yield* DepositSubmissionAttemptsDB.retrieveOpenAttempts();
+    const limit = Math.max(
+      0,
+      Math.floor(options.limit ?? STARTUP_DEPOSIT_RECONCILIATION_LIMIT),
+    );
+    const concurrency = Math.max(
+      1,
+      Math.floor(
+        options.concurrency ?? STARTUP_DEPOSIT_RECONCILIATION_CONCURRENCY,
+      ),
+    );
+    const attemptTimeoutMs = Math.max(
+      1,
+      Math.floor(
+        options.attemptTimeoutMs ??
+          STARTUP_DEPOSIT_RECONCILIATION_ATTEMPT_TIMEOUT_MS,
+      ),
+    );
+    const selected = attempts.slice(0, limit);
+    const results = yield* Effect.forEach(
+      selected,
+      (attempt) => {
+        const txHash =
+          attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH].toString("hex");
+        return reconcileDepositSubmissionAttemptProgram(txHash, {
+          observe: options.observe,
+        }).pipe(
+          Effect.timeoutOption(Duration.millis(attemptTimeoutMs)),
+          Effect.either,
+          Effect.map((result) => {
+            if (result._tag === "Left") {
+              return {
+                txHash,
+                status: "failed" as const,
+                reason: formatUnknownError(result.left, {
+                  includeCause: true,
+                }),
+              };
+            }
+            if (Option.isNone(result.right)) {
+              return {
+                txHash,
+                status: "timed_out" as const,
+                reason: `observation exceeded ${attemptTimeoutMs.toString()}ms`,
+              };
+            }
+            return result.right.value;
+          }),
+        );
+      },
+      { concurrency },
+    );
+    return {
+      open: attempts.length,
+      inspected: selected.length,
+      deferred: attempts.length - selected.length,
+      results,
+    } as const;
+  });
+
 export const submitDepositWithMetadataProgram = (
   lucid: LucidEvolution,
   contracts: SDK.MidgardValidators,
@@ -417,74 +999,38 @@ export const submitDepositWithMetadataProgram = (
   | SDK.HashingError
   | SubmitDepositError
   | TxSubmitError
-  | TxConfirmError
   | TxSignError
   | DatabaseError
   | DepositConfirmationUnknownError,
   Database | MidgardContracts | LucidService | NodeConfig
 > =>
   Effect.gen(function* () {
-    const { tx, metadata } = yield* buildUnsignedDepositTxWithMetadataProgram(
+    const prepared = yield* prepareDepositWithMetadataProgram(
       lucid,
       contracts,
       config,
     );
-    const submission = yield* signSubmitTransaction(lucid, tx);
-    const attempt = yield* Effect.try({
-      try: () =>
-        depositSubmissionAttemptFromSignedTx({
-          txHash: submission.txHash,
-          signedTxCbor: submission.signedTxCbor,
-          metadata,
-          config,
-        }),
-      catch: (cause) =>
-        new SubmitDepositError({
-          message:
-            "Failed to derive expected deposit output from the submitted transaction",
-          cause,
-        }),
-    });
-    yield* DepositSubmissionAttemptsDB.insertSubmitted(attempt);
-
-    const confirmationStatus = yield* awaitSubmittedTransactionConfirmation(
+    const inserted = yield* DepositSubmissionAttemptsDB.insertPrepared(
+      prepared.submissionAttempt,
+    );
+    const eligibility = yield* reconcileDepositSubmissionAttemptProgram(
+      prepared.txHash,
+    );
+    const submission = yield* submitDurableDepositAttemptProgram(
+      lucid,
+      prepared.txHash,
+      eligibility,
+    );
+    const confirmationStatus = yield* confirmDurableDepositAttemptProgram(
       lucid,
       submission,
-    ).pipe(
-      Effect.tap(() =>
-        DepositSubmissionAttemptsDB.markConfirmed(
-          Buffer.from(submission.txHash, "hex"),
-        ),
-      ),
-      Effect.as("confirmed" as const),
-      Effect.catchTag("TxConfirmError", (error) =>
-        Effect.gen(function* () {
-          yield* Effect.logWarning(
-            `Deposit tx ${submission.txHash} confirmation timed out; reconciling visible deposit state before allowing retry.`,
-          );
-          const reconciliation =
-            yield* reconcileDepositSubmissionAttemptProgram(submission.txHash);
-          if (reconciliation.status === "reconciled_after_timeout") {
-            return reconciliation.status;
-          }
-          return yield* Effect.fail(
-            new DepositConfirmationUnknownError({
-              message:
-                "Deposit transaction confirmation is unknown after timeout and reconciliation did not prove the expected deposit output.",
-              txHash: submission.txHash,
-              depositEventId: metadata.depositEventId,
-              expectedDepositOutRef:
-                attempt[
-                  DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF
-                ],
-              reconciliation,
-              cause: error,
-            }),
-          );
-        }),
-      ),
+      inserted,
     );
-    return { txHash: submission.txHash, metadata, confirmationStatus };
+    return {
+      txHash: prepared.txHash,
+      metadata: prepared.metadata,
+      confirmationStatus,
+    };
   });
 
 type UnknownRecord = Record<string, unknown>;

--- a/demo/midgard-node/src/transactions/utils.ts
+++ b/demo/midgard-node/src/transactions/utils.ts
@@ -472,6 +472,17 @@ export type SubmitRecoveryInlineOptions = {
   readonly slotSnapshot?: () => Effect.Effect<SubmitSlotSnapshot, unknown>;
   readonly requireSlotForBoundedTx?: boolean;
   readonly maxPreSubmitWaitMs?: number;
+  /**
+   * Number of retries permitted after an unclassified provider submission
+   * error. Callers with a durable exact-CBOR journal can set this to zero and
+   * reconcile authoritative chain evidence before any later resubmission.
+   */
+  readonly maxProviderRetryAttempts?: number;
+  /**
+   * Number of retries permitted after an OutsideValidityInterval provider
+   * response. A durable one-call journal sets this to zero.
+   */
+  readonly maxOutsideValidityRecoveryAttempts?: number;
   readonly confirmationTimeoutMs?: number;
   readonly confirmationRetries?: number;
   readonly confirmationPollIntervalMs?: number;
@@ -813,15 +824,36 @@ export const submitSignedTxWithRecovery = (
 ): Effect.Effect<void, unknown> =>
   Effect.gen(function* () {
     const sleep = options.sleep ?? submitRecoverySleep(lucid);
+    const maxProviderRetryAttempts =
+      options.maxProviderRetryAttempts ?? RETRY_ATTEMPTS;
+    if (
+      !Number.isSafeInteger(maxProviderRetryAttempts) ||
+      maxProviderRetryAttempts < 0
+    ) {
+      return yield* Effect.fail(
+        new Error(
+          `Invalid maxProviderRetryAttempts=${maxProviderRetryAttempts.toString()}`,
+        ),
+      );
+    }
     let providerRetryAttempts = 0;
     let outsideValidityRecoveryAttempts = 0;
     let outsideValidityRecoveryWaitedMs = 0;
     const maxOutsideValidityRecoveryWaitMs =
       options.maxPreSubmitWaitMs ?? DEFAULT_SIGNED_TX_INLINE_WAIT_MS;
-    const maxOutsideValidityRecoveryAttempts = Math.max(
-      1,
-      Math.ceil(maxOutsideValidityRecoveryWaitMs / SLOT_LENGTH_MS),
-    );
+    const maxOutsideValidityRecoveryAttempts =
+      options.maxOutsideValidityRecoveryAttempts ??
+      Math.max(1, Math.ceil(maxOutsideValidityRecoveryWaitMs / SLOT_LENGTH_MS));
+    if (
+      !Number.isSafeInteger(maxOutsideValidityRecoveryAttempts) ||
+      maxOutsideValidityRecoveryAttempts < 0
+    ) {
+      return yield* Effect.fail(
+        new Error(
+          `Invalid maxOutsideValidityRecoveryAttempts=${maxOutsideValidityRecoveryAttempts.toString()}`,
+        ),
+      );
+    }
 
     for (;;) {
       const preSubmitValidity = yield* preSubmitValidityCheck(
@@ -1171,11 +1203,11 @@ export const submitSignedTxWithRecovery = (
         );
       }
 
-      if (providerRetryAttempts < RETRY_ATTEMPTS) {
+      if (providerRetryAttempts < maxProviderRetryAttempts) {
         const waitMs = INIT_RETRY_AFTER_MILLIS * 2 ** providerRetryAttempts;
         providerRetryAttempts += 1;
         yield* Effect.logWarning(
-          `Tx ${txHash} submit failed with provider error; waiting ${waitMs}ms before retry ${providerRetryAttempts}/${RETRY_ATTEMPTS}: ${submitError}`,
+          `Tx ${txHash} submit failed with provider error; waiting ${waitMs}ms before retry ${providerRetryAttempts}/${maxProviderRetryAttempts.toString()}: ${submitError}`,
         );
         yield* sleep(waitMs);
         continue;

--- a/demo/midgard-node/tests/database.test.ts
+++ b/demo/midgard-node/tests/database.test.ts
@@ -5416,15 +5416,15 @@ describe("AddressHistoryDB", () => {
 
 describe("DepositSubmissionAttemptsDB", () => {
   it.effect(
-    "stores submitted attempts idempotently and rejects tx hash payload drift",
+    "persists exact signed bytes before submission and rejects immutable payload drift",
     (_) =>
       isolatedDb(
         Effect.gen(function* () {
           const attempt = makeDepositSubmissionAttempt();
           const first =
-            yield* DepositSubmissionAttemptsDB.insertSubmitted(attempt);
+            yield* DepositSubmissionAttemptsDB.insertPrepared(attempt);
           const second =
-            yield* DepositSubmissionAttemptsDB.insertSubmitted(attempt);
+            yield* DepositSubmissionAttemptsDB.insertPrepared(attempt);
 
           expect(
             first[DepositSubmissionAttemptsDB.Columns.TX_HASH].equals(
@@ -5432,18 +5432,50 @@ describe("DepositSubmissionAttemptsDB", () => {
             ),
           ).toEqual(true);
           expect(
-            first[DepositSubmissionAttemptsDB.Columns.CONFIRMATION_STATUS],
-          ).toEqual(
-            DepositSubmissionAttemptsDB.Status.SubmittedConfirmationUnknown,
+            first[DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR].equals(
+              attempt[DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR],
+            ),
+          ).toEqual(true);
+          expect(first[DepositSubmissionAttemptsDB.Columns.STATUS]).toEqual(
+            DepositSubmissionAttemptsDB.Status.Prepared,
           );
+          expect(
+            first[DepositSubmissionAttemptsDB.Columns.ATTEMPT_COUNT],
+          ).toEqual(0);
+          expect(
+            first[DepositSubmissionAttemptsDB.Columns.LAST_SUBMISSION_AT],
+          ).toBeNull();
 
-          const conflict = yield* Effect.either(
-            DepositSubmissionAttemptsDB.insertSubmitted({
+          const signedBytesConflict = yield* Effect.either(
+            DepositSubmissionAttemptsDB.insertPrepared({
+              ...attempt,
+              [DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR]:
+                databaseFixtureBytes("deposit-submission.different-signed", 96),
+            }),
+          );
+          expect(signedBytesConflict._tag).toEqual("Left");
+
+          const payloadConflict = yield* Effect.either(
+            DepositSubmissionAttemptsDB.insertPrepared({
               ...attempt,
               [DepositSubmissionAttemptsDB.Columns.EXPECTED_LOVELACE]: "2",
             }),
           );
-          expect(conflict._tag).toEqual("Left");
+          expect(payloadConflict._tag).toEqual("Left");
+
+          const stored = Option.getOrThrow(
+            yield* DepositSubmissionAttemptsDB.retrieveByTxHash(
+              attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+            ),
+          );
+          expect(
+            stored[DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR].equals(
+              attempt[DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR],
+            ),
+          ).toEqual(true);
+          expect(
+            stored[DepositSubmissionAttemptsDB.Columns.EXPECTED_LOVELACE],
+          ).toEqual("1000000");
         }),
       ),
   );
@@ -5453,24 +5485,23 @@ describe("DepositSubmissionAttemptsDB", () => {
       Effect.gen(function* () {
         const attempt = makeDepositSubmissionAttempt();
         const metadata = attempt[DepositSubmissionAttemptsDB.Columns.METADATA];
-        const bigintAttempt: DepositSubmissionAttemptsDB.InsertSubmittedInput =
-          {
-            ...attempt,
-            [DepositSubmissionAttemptsDB.Columns.METADATA]: {
-              ...metadata,
-              nonceInput: {
-                ...metadata.nonceInput,
-                outputIndex: 1n as unknown as number,
-              },
-              validTo: 1_800_000_000_000n as unknown as number,
-              inclusionTime: 1_800_000_060_000n as unknown as number,
+        const bigintAttempt: DepositSubmissionAttemptsDB.InsertPreparedInput = {
+          ...attempt,
+          [DepositSubmissionAttemptsDB.Columns.METADATA]: {
+            ...metadata,
+            nonceInput: {
+              ...metadata.nonceInput,
+              outputIndex: 1n as unknown as number,
             },
-          };
+            validTo: 1_800_000_000_000n as unknown as number,
+            inclusionTime: 1_800_000_060_000n as unknown as number,
+          },
+        };
 
         const first =
-          yield* DepositSubmissionAttemptsDB.insertSubmitted(bigintAttempt);
+          yield* DepositSubmissionAttemptsDB.insertPrepared(bigintAttempt);
         const second =
-          yield* DepositSubmissionAttemptsDB.insertSubmitted(bigintAttempt);
+          yield* DepositSubmissionAttemptsDB.insertPrepared(bigintAttempt);
         const rawStoredMetadata = first[
           DepositSubmissionAttemptsDB.Columns.METADATA
         ] as unknown;
@@ -5496,11 +5527,80 @@ describe("DepositSubmissionAttemptsDB", () => {
     ),
   );
 
+  it.effect("atomically claims one provider submission attempt", (_) =>
+    isolatedDb(
+      Effect.gen(function* () {
+        const attempt = makeDepositSubmissionAttempt();
+        yield* DepositSubmissionAttemptsDB.insertPrepared(attempt);
+        const txHash = attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH];
+
+        const claims = yield* Effect.all(
+          [
+            DepositSubmissionAttemptsDB.beginSubmission(txHash).pipe(
+              Effect.either,
+            ),
+            DepositSubmissionAttemptsDB.beginSubmission(txHash).pipe(
+              Effect.either,
+            ),
+          ],
+          { concurrency: "unbounded" },
+        );
+        expect(claims.filter((claim) => claim._tag === "Right")).toHaveLength(
+          1,
+        );
+        expect(claims.filter((claim) => claim._tag === "Left")).toHaveLength(1);
+
+        const claimed = Option.getOrThrow(
+          yield* DepositSubmissionAttemptsDB.retrieveByTxHash(txHash),
+        );
+        expect(claimed[DepositSubmissionAttemptsDB.Columns.STATUS]).toEqual(
+          DepositSubmissionAttemptsDB.Status.SubmissionUnknown,
+        );
+        expect(
+          claimed[DepositSubmissionAttemptsDB.Columns.ATTEMPT_COUNT],
+        ).toEqual(1);
+        expect(
+          claimed[DepositSubmissionAttemptsDB.Columns.LAST_SUBMISSION_AT],
+        ).not.toBeNull();
+
+        const submitted = yield* DepositSubmissionAttemptsDB.markSubmitted(
+          txHash,
+          `tx:${txHash.toString("hex")}`,
+        );
+        expect(submitted[DepositSubmissionAttemptsDB.Columns.STATUS]).toEqual(
+          DepositSubmissionAttemptsDB.Status.Submitted,
+        );
+        expect(
+          submitted[
+            DepositSubmissionAttemptsDB.Columns.PROVIDER_ACKNOWLEDGEMENT
+          ],
+        ).toEqual(`tx:${txHash.toString("hex")}`);
+        expect(
+          yield* Effect.either(
+            DepositSubmissionAttemptsDB.beginSubmission(txHash),
+          ),
+        ).toMatchObject({ _tag: "Left" });
+      }),
+    ),
+  );
+
   it.effect(
-    "tracks confirmation, reconciliation, ambiguity, and open attempts",
+    "retrieves every unresolved lifecycle state and excludes terminal states",
     (_) =>
       isolatedDb(
         Effect.gen(function* () {
+          const prepared = makeDepositSubmissionAttempt({
+            txHash: databaseTxHash("deposit-submission.prepared"),
+            eventId: databaseOutputReferenceId("deposit-submission.prepared"),
+          });
+          const unknown = makeDepositSubmissionAttempt({
+            txHash: databaseTxHash("deposit-submission.unknown"),
+            eventId: databaseOutputReferenceId("deposit-submission.unknown"),
+          });
+          const submitted = makeDepositSubmissionAttempt({
+            txHash: databaseTxHash("deposit-submission.submitted"),
+            eventId: databaseOutputReferenceId("deposit-submission.submitted"),
+          });
           const confirmed = makeDepositSubmissionAttempt({
             txHash: databaseTxHash("deposit-submission.confirmed"),
             eventId: databaseOutputReferenceId("deposit-submission.confirmed"),
@@ -5513,11 +5613,44 @@ describe("DepositSubmissionAttemptsDB", () => {
             txHash: databaseTxHash("deposit-submission.ambiguous"),
             eventId: databaseOutputReferenceId("deposit-submission.ambiguous"),
           });
+          const expired = makeDepositSubmissionAttempt({
+            txHash: databaseTxHash("deposit-submission.expired"),
+            eventId: databaseOutputReferenceId("deposit-submission.expired"),
+          });
 
-          yield* DepositSubmissionAttemptsDB.insertSubmitted(confirmed);
-          yield* DepositSubmissionAttemptsDB.insertSubmitted(reconciled);
-          yield* DepositSubmissionAttemptsDB.insertSubmitted(ambiguous);
+          yield* Effect.forEach(
+            [
+              prepared,
+              unknown,
+              submitted,
+              confirmed,
+              reconciled,
+              ambiguous,
+              expired,
+            ],
+            DepositSubmissionAttemptsDB.insertPrepared,
+            { discard: true },
+          );
 
+          yield* DepositSubmissionAttemptsDB.beginSubmission(
+            unknown[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+          );
+          yield* DepositSubmissionAttemptsDB.beginSubmission(
+            submitted[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+          );
+          yield* DepositSubmissionAttemptsDB.beginSubmission(
+            confirmed[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+          );
+          yield* DepositSubmissionAttemptsDB.beginSubmission(
+            reconciled[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+          );
+          yield* DepositSubmissionAttemptsDB.beginSubmission(
+            ambiguous[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+          );
+          yield* DepositSubmissionAttemptsDB.markSubmitted(
+            submitted[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+            "provider accepted",
+          );
           yield* DepositSubmissionAttemptsDB.markConfirmed(
             confirmed[DepositSubmissionAttemptsDB.Columns.TX_HASH],
           );
@@ -5528,13 +5661,159 @@ describe("DepositSubmissionAttemptsDB", () => {
             ambiguous[DepositSubmissionAttemptsDB.Columns.TX_HASH],
             "confirmation timed out",
           );
+          yield* DepositSubmissionAttemptsDB.markExpired(
+            expired[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+            "validity interval expired while transaction remained absent",
+          );
 
           const open =
             yield* DepositSubmissionAttemptsDB.retrieveOpenAttempts();
-          expect(open).toHaveLength(1);
+          expect(open).toHaveLength(4);
           expect(
-            open[0]?.[DepositSubmissionAttemptsDB.Columns.CONFIRMATION_STATUS],
-          ).toEqual(DepositSubmissionAttemptsDB.Status.Ambiguous);
+            new Set(
+              open.map(
+                (attempt) =>
+                  attempt[DepositSubmissionAttemptsDB.Columns.STATUS],
+              ),
+            ),
+          ).toEqual(
+            new Set([
+              DepositSubmissionAttemptsDB.Status.Prepared,
+              DepositSubmissionAttemptsDB.Status.SubmissionUnknown,
+              DepositSubmissionAttemptsDB.Status.Submitted,
+              DepositSubmissionAttemptsDB.Status.Ambiguous,
+            ]),
+          );
+        }),
+      ),
+  );
+
+  it.effect("rejects invalid transitions and malformed durable payloads", (_) =>
+    isolatedDb(
+      Effect.gen(function* () {
+        const prepared = makeDepositSubmissionAttempt();
+        const txHash = prepared[DepositSubmissionAttemptsDB.Columns.TX_HASH];
+        yield* DepositSubmissionAttemptsDB.insertPrepared(prepared);
+
+        expect(
+          yield* Effect.either(
+            DepositSubmissionAttemptsDB.markSubmitted(txHash, "accepted"),
+          ),
+        ).toMatchObject({ _tag: "Left" });
+
+        yield* DepositSubmissionAttemptsDB.markConfirmed(txHash);
+        expect(
+          yield* Effect.either(
+            DepositSubmissionAttemptsDB.beginSubmission(txHash),
+          ),
+        ).toMatchObject({ _tag: "Left" });
+        const preservedConfirmed =
+          yield* DepositSubmissionAttemptsDB.markAmbiguous(
+            txHash,
+            "a stale response-loss writer must preserve stronger evidence",
+          );
+        expect(
+          preservedConfirmed[DepositSubmissionAttemptsDB.Columns.STATUS],
+        ).toBe(DepositSubmissionAttemptsDB.Status.Confirmed);
+
+        const expired = makeDepositSubmissionAttempt({
+          txHash: databaseTxHash("deposit-submission.terminal-expired"),
+          eventId: databaseOutputReferenceId(
+            "deposit-submission.terminal-expired",
+          ),
+        });
+        const expiredTxHash =
+          expired[DepositSubmissionAttemptsDB.Columns.TX_HASH];
+        yield* DepositSubmissionAttemptsDB.insertPrepared(expired);
+        yield* DepositSubmissionAttemptsDB.markExpired(
+          expiredTxHash,
+          "validity interval expired",
+        );
+        expect(
+          yield* Effect.either(
+            DepositSubmissionAttemptsDB.beginSubmission(expiredTxHash),
+          ),
+        ).toMatchObject({ _tag: "Left" });
+        expect(
+          yield* Effect.either(
+            DepositSubmissionAttemptsDB.markConfirmed(expiredTxHash),
+          ),
+        ).toMatchObject({ _tag: "Left" });
+
+        const emptySignedBytes = makeDepositSubmissionAttempt({
+          txHash: databaseTxHash("deposit-submission.empty-signed"),
+          eventId: databaseOutputReferenceId("deposit-submission.empty-signed"),
+        });
+        expect(
+          yield* Effect.either(
+            DepositSubmissionAttemptsDB.insertPrepared({
+              ...emptySignedBytes,
+              [DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR]:
+                Buffer.alloc(0),
+            }),
+          ),
+        ).toMatchObject({ _tag: "Left" });
+
+        const malformedEvent = makeDepositSubmissionAttempt({
+          txHash: databaseTxHash("deposit-submission.bad-event"),
+          eventId: Buffer.alloc(0),
+        });
+        expect(
+          yield* Effect.either(
+            DepositSubmissionAttemptsDB.insertPrepared(malformedEvent),
+          ),
+        ).toMatchObject({ _tag: "Left" });
+      }),
+    ),
+  );
+
+  it.effect(
+    "keeps an event unique while active and permits a new operation after a never-claimed expiry",
+    (_) =>
+      isolatedDb(
+        Effect.gen(function* () {
+          const eventId = databaseOutputReferenceId(
+            "deposit-submission.variable-event",
+            24,
+          );
+          expect(eventId).toHaveLength(40);
+          const first = makeDepositSubmissionAttempt({
+            txHash: databaseTxHash("deposit-submission.active-event.first"),
+            eventId,
+          });
+          const second = makeDepositSubmissionAttempt({
+            txHash: databaseTxHash("deposit-submission.active-event.second"),
+            eventId,
+          });
+
+          yield* DepositSubmissionAttemptsDB.insertPrepared(first);
+          expect(
+            yield* DepositSubmissionAttemptsDB.insertPrepared(second).pipe(
+              Effect.either,
+            ),
+          ).toMatchObject({ _tag: "Left" });
+
+          yield* DepositSubmissionAttemptsDB.markExpired(
+            first[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+            "never-claimed transaction expired",
+          );
+          const replacement =
+            yield* DepositSubmissionAttemptsDB.insertPrepared(second);
+          expect(replacement[DepositSubmissionAttemptsDB.Columns.STATUS]).toBe(
+            DepositSubmissionAttemptsDB.Status.Prepared,
+          );
+
+          const sameEvent =
+            yield* DepositSubmissionAttemptsDB.retrieveByEventId(eventId);
+          expect(sameEvent).toHaveLength(2);
+          expect(
+            sameEvent.map(
+              (attempt) => attempt[DepositSubmissionAttemptsDB.Columns.STATUS],
+            ),
+          ).toEqual([
+            DepositSubmissionAttemptsDB.Status.Expired,
+            DepositSubmissionAttemptsDB.Status.Prepared,
+          ]);
         }),
       ),
   );
@@ -6101,9 +6380,13 @@ const makeDepositSubmissionAttempt = ({
 }: {
   readonly txHash?: Buffer;
   readonly eventId?: Buffer;
-} = {}): DepositSubmissionAttemptsDB.InsertSubmittedInput => ({
+} = {}): DepositSubmissionAttemptsDB.InsertPreparedInput => ({
   [DepositSubmissionAttemptsDB.Columns.TX_HASH]: txHash,
   [DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID]: eventId,
+  [DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR]: databaseFixtureBytes(
+    `deposit-submission.signed.${txHash.toString("hex")}`,
+    96,
+  ),
   [DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF]:
     `${txHash.toString("hex")}#0`,
   [DepositSubmissionAttemptsDB.Columns.EXPECTED_L2_ADDRESS]: address1,
@@ -6123,9 +6406,15 @@ const makeDepositSubmissionAttempt = ({
     validTo: 1_800_000_000_000,
     inclusionTime: 1_800_000_060_000,
   },
-  [DepositSubmissionAttemptsDB.Columns.FUNDING_OUT_REFS]: [
-    `${databaseTxHash("deposit-submission.funding").toString("hex")}#0`,
-  ],
+  [DepositSubmissionAttemptsDB.Columns.DEPENDENCY_OUT_REFS]: {
+    spend: [`${databaseTxHash("deposit-submission.spend").toString("hex")}#0`],
+    collateral: [
+      `${databaseTxHash("deposit-submission.collateral").toString("hex")}#1`,
+    ],
+    reference: [
+      `${databaseTxHash("deposit-submission.reference").toString("hex")}#2`,
+    ],
+  },
 });
 
 describe("Phase 3 MPF durable state", () => {

--- a/demo/midgard-node/tests/deposit-submission-crash-boundaries.test.ts
+++ b/demo/midgard-node/tests/deposit-submission-crash-boundaries.test.ts
@@ -1,0 +1,455 @@
+import { randomBytes } from "node:crypto";
+
+import { SqlClient } from "@effect/sql";
+import { CML } from "@lucid-evolution/lucid";
+import { Effect, Fiber, Option } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+import { DepositSubmissionAttemptsDB } from "@/database/index.js";
+import { MidgardContracts } from "@/services/midgard-contracts.js";
+import { Lucid as LucidService } from "@/services/lucid.js";
+import {
+  depositDependenciesFromSignedTx,
+  observePreparedDeposit,
+} from "@/transactions/deposit-submission-provider.js";
+import {
+  reconcileOpenDepositSubmissionAttemptsProgram,
+  reconcileDepositSubmissionAttemptProgram,
+  resumeDepositSubmissionAttemptProgram,
+  type DepositSubmissionObservationReader,
+} from "@/transactions/submit-deposit.js";
+
+import { provideDatabaseLayers } from "./utils.js";
+
+type PromiseLatch = {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+};
+
+const promiseLatch = (): PromiseLatch => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+};
+
+const withTimeout = async <A>(promise: Promise<A>): Promise<A> =>
+  Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      setTimeout(
+        () => reject(new Error("timed out at deposit crash boundary")),
+        5_000,
+      );
+    }),
+  ]);
+
+const signedTransactionFixture = () => {
+  const inputTxHash = randomBytes(32).toString("hex");
+  const inputs = CML.TransactionInputList.new();
+  inputs.add(
+    CML.TransactionInput.new(CML.TransactionHash.from_hex(inputTxHash), 0n),
+  );
+  const body = CML.TransactionBody.new(
+    inputs,
+    CML.TransactionOutputList.new(),
+    0n,
+  );
+  const transaction = CML.Transaction.new(
+    body,
+    CML.TransactionWitnessSet.new(),
+    true,
+    undefined,
+  );
+  const txHash = CML.hash_transaction(body).to_hex();
+  const signedTxCbor = transaction.to_cbor_hex();
+  const eventId = randomBytes(39);
+  const attempt: DepositSubmissionAttemptsDB.InsertPreparedInput = {
+    [DepositSubmissionAttemptsDB.Columns.TX_HASH]: Buffer.from(txHash, "hex"),
+    [DepositSubmissionAttemptsDB.Columns.DEPOSIT_EVENT_ID]: eventId,
+    [DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR]: Buffer.from(
+      signedTxCbor,
+      "hex",
+    ),
+    [DepositSubmissionAttemptsDB.Columns.EXPECTED_DEPOSIT_OUT_REF]:
+      `${txHash}#0`,
+    [DepositSubmissionAttemptsDB.Columns.EXPECTED_L2_ADDRESS]:
+      "addr_test1_crash_boundary",
+    [DepositSubmissionAttemptsDB.Columns.EXPECTED_LOVELACE]: "1000000",
+    [DepositSubmissionAttemptsDB.Columns.EXPECTED_ASSETS]: {
+      lovelace: "1000000",
+    },
+    [DepositSubmissionAttemptsDB.Columns.METADATA]: {
+      depositAddress: "addr_test1_crash_boundary_deposit",
+      depositEventId: eventId.toString("hex"),
+      depositAssetName: "00".repeat(32),
+      depositAuthUnit: `${"11".repeat(28)}${"00".repeat(32)}`,
+      nonceInput: { txHash: inputTxHash, outputIndex: 0 },
+      validTo: 1_800_000_000_000,
+      inclusionTime: 1_800_000_060_000,
+    },
+    [DepositSubmissionAttemptsDB.Columns.DEPENDENCY_OUT_REFS]: {
+      spend: [`${inputTxHash}#0`],
+      collateral: [],
+      reference: [],
+    },
+  };
+  return { attempt, txHash, signedTxCbor };
+};
+
+const absentObservation: DepositSubmissionObservationReader = async () => ({
+  kind: "absent_safe",
+  mempoolSlot: 100,
+  kupoCheckpoint: 100,
+  currentSlot: 100,
+});
+
+const fakeLucidService = (
+  submitTx: (signedTxCbor: string) => Promise<string>,
+) => {
+  const api = {
+    config: () => ({ provider: { submitTx } }),
+    wallet: () => ({ address: async () => "addr_test1_crash_boundary" }),
+    awaitTx: vi.fn(async () => true),
+  };
+  return {
+    api,
+    referenceScriptsApi: api,
+    operatorMainAddress: "addr_test1_crash_boundary",
+    operatorMergeAddress: "addr_test1_crash_boundary_merge",
+    referenceScriptsWalletAddress: "addr_test1_crash_boundary_reference",
+    referenceScriptsAddress: "addr_test1_crash_boundary_reference",
+    submitSlotSnapshot: () =>
+      Effect.succeed({
+        source: "test" as const,
+        currentSlot: 100,
+        observedAtMs: 1_800_000_000_000,
+        slotLengthMs: 1_000,
+      }),
+    switchToOperatorsMainWallet: Effect.void,
+    switchToOperatorsMergingWallet: Effect.void,
+    switchToReferenceScriptWallet: Effect.void,
+  };
+};
+
+const withRequiredServices = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  submitTx: (signedTxCbor: string) => Promise<string>,
+) =>
+  provideDatabaseLayers(
+    effect.pipe(
+      Effect.provideService(LucidService, fakeLucidService(submitTx) as never),
+      Effect.provideService(MidgardContracts, {} as never),
+    ),
+  );
+
+const deleteAttempts = (txHashes: readonly Buffer[]) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    for (const txHash of txHashes) {
+      yield* sql`DELETE FROM deposit_submission_attempts
+        WHERE tx_hash = ${txHash}`;
+    }
+  }).pipe(Effect.orDie);
+
+describe.sequential("durable deposit crash boundaries", () => {
+  it("does not classify expiry when dependency evidence is absent", async () => {
+    const fixture = signedTransactionFixture();
+    const transaction = CML.Transaction.from_cbor_hex(fixture.signedTxCbor);
+    const expiringBody = transaction.body();
+    expiringBody.set_ttl(100n);
+    const expiringTransaction = CML.Transaction.new(
+      expiringBody,
+      transaction.witness_set(),
+      true,
+      undefined,
+    );
+    const signedTxCbor = expiringTransaction.to_cbor_hex();
+    const txHash = CML.hash_transaction(expiringBody).to_hex();
+
+    await expect(
+      observePreparedDeposit({
+        txHash,
+        signedTxCbor,
+        expectedDepositOutRef: `${txHash}#0`,
+        storedDependencies:
+          depositDependenciesFromSignedTx(expiringTransaction),
+        runtime: {
+          queryHistoricalOutput: async () => ({
+            kind: "absent",
+            kupoCheckpoint: 100,
+            kupoCheckpointHash: "aa".repeat(32),
+          }),
+          queryMempool: async () => ({ slot: 100, contains: false }),
+          queryCanonicalPoint: async () => true,
+          queryCurrentSlot: async () => ({
+            source: "test",
+            currentSlot: 98,
+            chainTipSlot: 100,
+            observedAtMs: 1_800_000_000_000,
+            slotLengthMs: 1_000,
+          }),
+          queryDependencies: async () => [],
+        },
+      }),
+    ).resolves.toEqual({
+      kind: "ambiguous",
+      reason: expect.stringContaining(
+        "signed transaction dependencies are no longer all unspent",
+      ),
+    });
+  });
+
+  it("durably prepares exact bytes before one concurrent claimant can own submission", async () => {
+    const fixture = signedTransactionFixture();
+    const txHashBuffer =
+      fixture.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH];
+
+    await Effect.runPromise(
+      withRequiredServices(
+        Effect.gen(function* () {
+          const prepared = yield* DepositSubmissionAttemptsDB.insertPrepared(
+            fixture.attempt,
+          );
+          expect(prepared[DepositSubmissionAttemptsDB.Columns.STATUS]).toBe(
+            DepositSubmissionAttemptsDB.Status.Prepared,
+          );
+          expect(
+            prepared[
+              DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR
+            ].toString("hex"),
+          ).toBe(fixture.signedTxCbor);
+          expect(
+            prepared[DepositSubmissionAttemptsDB.Columns.ATTEMPT_COUNT],
+          ).toBe(0);
+
+          const claims = yield* Effect.all(
+            [
+              DepositSubmissionAttemptsDB.beginSubmission(txHashBuffer).pipe(
+                Effect.either,
+              ),
+              DepositSubmissionAttemptsDB.beginSubmission(txHashBuffer).pipe(
+                Effect.either,
+              ),
+            ],
+            { concurrency: "unbounded" },
+          );
+          expect(claims.filter((claim) => claim._tag === "Right")).toHaveLength(
+            1,
+          );
+          expect(claims.filter((claim) => claim._tag === "Left")).toHaveLength(
+            1,
+          );
+
+          const claimed = Option.getOrThrow(
+            yield* DepositSubmissionAttemptsDB.retrieveByTxHash(txHashBuffer),
+          );
+          expect(claimed[DepositSubmissionAttemptsDB.Columns.STATUS]).toBe(
+            DepositSubmissionAttemptsDB.Status.SubmissionUnknown,
+          );
+          expect(
+            claimed[DepositSubmissionAttemptsDB.Columns.ATTEMPT_COUNT],
+          ).toBe(1);
+        }).pipe(Effect.ensuring(deleteAttempts([txHashBuffer]))),
+        async () => fixture.txHash,
+      ),
+    );
+  });
+
+  it("claims before the provider call, round-trips exact DB bytes, and never resubmits after response loss", async () => {
+    const fixture = signedTransactionFixture();
+    const txHashBuffer =
+      fixture.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH];
+    const providerEntered = promiseLatch();
+    const releaseProvider = promiseLatch();
+    const submittedBytes: string[] = [];
+    const submitTx = vi.fn(async (signedTxCbor: string) => {
+      submittedBytes.push(signedTxCbor);
+      providerEntered.resolve();
+      await releaseProvider.promise;
+      throw new Error("provider response lost after accepting exact bytes");
+    });
+
+    await Effect.runPromise(
+      withRequiredServices(
+        Effect.gen(function* () {
+          yield* DepositSubmissionAttemptsDB.insertPrepared(fixture.attempt);
+          expect(submitTx).not.toHaveBeenCalled();
+
+          const recoveryFiber = yield* Effect.fork(
+            resumeDepositSubmissionAttemptProgram(fixture.txHash, {
+              observe: absentObservation,
+              submitRecovery: { sleep: () => Effect.void },
+            }),
+          );
+          yield* Effect.promise(() => withTimeout(providerEntered.promise));
+
+          const duringProviderCall = Option.getOrThrow(
+            yield* DepositSubmissionAttemptsDB.retrieveByTxHash(txHashBuffer),
+          );
+          expect(
+            duringProviderCall[DepositSubmissionAttemptsDB.Columns.STATUS],
+          ).toBe(DepositSubmissionAttemptsDB.Status.SubmissionUnknown);
+          expect(
+            duringProviderCall[
+              DepositSubmissionAttemptsDB.Columns.ATTEMPT_COUNT
+            ],
+          ).toBe(1);
+          expect(
+            duringProviderCall[
+              DepositSubmissionAttemptsDB.Columns.SIGNED_TX_CBOR
+            ].toString("hex"),
+          ).toBe(fixture.signedTxCbor);
+          expect(submittedBytes).toEqual([fixture.signedTxCbor]);
+
+          releaseProvider.resolve();
+          expect(
+            (yield* Fiber.join(recoveryFiber).pipe(Effect.either))._tag,
+          ).toBe("Left");
+
+          const afterResponseLoss = Option.getOrThrow(
+            yield* DepositSubmissionAttemptsDB.retrieveByTxHash(txHashBuffer),
+          );
+          expect(
+            afterResponseLoss[DepositSubmissionAttemptsDB.Columns.STATUS],
+          ).toBe(DepositSubmissionAttemptsDB.Status.Ambiguous);
+          expect(
+            afterResponseLoss[DepositSubmissionAttemptsDB.Columns.LAST_ERROR],
+          ).toContain("provider submission outcome is unknown");
+
+          const resumed = yield* resumeDepositSubmissionAttemptProgram(
+            fixture.txHash,
+            { observe: absentObservation },
+          ).pipe(Effect.either);
+          expect(resumed._tag).toBe("Left");
+          expect(submitTx).toHaveBeenCalledTimes(1);
+          expect(submittedBytes).toEqual([fixture.signedTxCbor]);
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(releaseProvider.resolve).pipe(
+              Effect.andThen(deleteAttempts([txHashBuffer])),
+            ),
+          ),
+        ),
+        submitTx,
+      ),
+    );
+  });
+
+  it("never reopens claimed states when synchronized evidence reports the transaction unseen", async () => {
+    const unknown = signedTransactionFixture();
+    const submitted = signedTransactionFixture();
+    const ambiguous = signedTransactionFixture();
+    const fixtures = [unknown, submitted, ambiguous] as const;
+    const txHashes = fixtures.map(
+      (fixture) => fixture.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+    );
+    const submitTx = vi.fn(async () => {
+      throw new Error("provider must not be called for a claimed state");
+    });
+
+    await Effect.runPromise(
+      withRequiredServices(
+        Effect.gen(function* () {
+          for (const fixture of fixtures) {
+            yield* DepositSubmissionAttemptsDB.insertPrepared(fixture.attempt);
+            yield* DepositSubmissionAttemptsDB.beginSubmission(
+              fixture.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+            );
+          }
+          yield* DepositSubmissionAttemptsDB.markSubmitted(
+            submitted.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+            submitted.txHash,
+          );
+          yield* DepositSubmissionAttemptsDB.markAmbiguous(
+            ambiguous.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+            "provider response was lost",
+          );
+
+          for (const fixture of fixtures) {
+            const reconciliation =
+              yield* reconcileDepositSubmissionAttemptProgram(fixture.txHash, {
+                observe: absentObservation,
+              });
+            expect(reconciliation.status).toBe("ambiguous");
+
+            const resumed = yield* resumeDepositSubmissionAttemptProgram(
+              fixture.txHash,
+              {
+                observe: absentObservation,
+              },
+            ).pipe(Effect.either);
+            expect(resumed._tag).toBe("Left");
+            expect(
+              yield* DepositSubmissionAttemptsDB.beginSubmission(
+                fixture.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+              ).pipe(Effect.either),
+            ).toMatchObject({ _tag: "Left" });
+          }
+          expect(submitTx).not.toHaveBeenCalled();
+        }).pipe(Effect.ensuring(deleteAttempts(txHashes))),
+        submitTx,
+      ),
+    );
+  });
+
+  it("bounds background startup observation, continues on ambiguity, and never submits", async () => {
+    const fixtures = [
+      signedTransactionFixture(),
+      signedTransactionFixture(),
+      signedTransactionFixture(),
+    ] as const;
+    const txHashes = fixtures.map(
+      (fixture) => fixture.attempt[DepositSubmissionAttemptsDB.Columns.TX_HASH],
+    );
+    const observe = vi.fn(async () => ({
+      kind: "ambiguous" as const,
+      reason: "provider evidence unavailable during startup",
+    }));
+    const submitTx = vi.fn(async () => {
+      throw new Error("startup reconciliation must never submit");
+    });
+
+    await Effect.runPromise(
+      withRequiredServices(
+        Effect.gen(function* () {
+          const openBefore =
+            (yield* DepositSubmissionAttemptsDB.retrieveOpenAttempts()).length;
+          yield* Effect.forEach(
+            fixtures,
+            (fixture) =>
+              DepositSubmissionAttemptsDB.insertPrepared(fixture.attempt),
+            { discard: true },
+          );
+
+          const result = yield* reconcileOpenDepositSubmissionAttemptsProgram({
+            limit: 2,
+            concurrency: 2,
+            attemptTimeoutMs: 1_000,
+            observe,
+          });
+          expect(result.open).toBe(openBefore + 3);
+          expect(result.inspected).toBe(2);
+          expect(result.deferred).toBe(openBefore + 1);
+          expect(result.results.map((entry) => entry.status)).toEqual([
+            "ambiguous",
+            "ambiguous",
+          ]);
+          expect(observe).toHaveBeenCalledTimes(2);
+          expect(submitTx).not.toHaveBeenCalled();
+
+          for (const txHash of txHashes) {
+            const row = Option.getOrThrow(
+              yield* DepositSubmissionAttemptsDB.retrieveByTxHash(txHash),
+            );
+            expect(row[DepositSubmissionAttemptsDB.Columns.STATUS]).toBe(
+              DepositSubmissionAttemptsDB.Status.Prepared,
+            );
+          }
+        }).pipe(Effect.ensuring(deleteAttempts(txHashes))),
+        submitTx,
+      ),
+    );
+  });
+});

--- a/demo/midgard-node/tests/deposit-submission-provider.test.ts
+++ b/demo/midgard-node/tests/deposit-submission-provider.test.ts
@@ -1,0 +1,408 @@
+import { CML, type UTxO } from "@lucid-evolution/lucid";
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  depositDependenciesFromSignedTx,
+  type DepositObservationRuntime,
+  observePreparedDeposit,
+  queryHistoricalDepositOutput,
+} from "@/transactions/deposit-submission-provider.js";
+import { submitPreparedDepositProgram } from "@/transactions/submit-deposit.js";
+
+const SPEND_TX_HASH = "11".repeat(32);
+const CHECKPOINT_HASH = "cc".repeat(32);
+
+const signedDepositFixture = ({
+  invalidBeforeSlot,
+  invalidHereafterSlot,
+}: {
+  readonly invalidBeforeSlot?: number;
+  readonly invalidHereafterSlot?: number;
+} = {}) => {
+  const inputs = CML.TransactionInputList.new();
+  inputs.add(
+    CML.TransactionInput.new(CML.TransactionHash.from_hex(SPEND_TX_HASH), 0n),
+  );
+  const outputs = CML.TransactionOutputList.new();
+  const body = CML.TransactionBody.new(inputs, outputs, 0n);
+  if (invalidBeforeSlot !== undefined) {
+    body.set_validity_interval_start(BigInt(invalidBeforeSlot));
+  }
+  if (invalidHereafterSlot !== undefined) {
+    body.set_ttl(BigInt(invalidHereafterSlot));
+  }
+  const transaction = CML.Transaction.new(
+    body,
+    CML.TransactionWitnessSet.new(),
+    true,
+    undefined,
+  );
+  const txHash = CML.hash_transaction(body).to_hex();
+  return {
+    transaction,
+    txHash,
+    signedTxCbor: transaction.to_cbor_hex(),
+    expectedDepositOutRef: `${txHash}#0`,
+    dependencies: depositDependenciesFromSignedTx(transaction),
+  };
+};
+
+const visibleDependency = (): UTxO =>
+  ({ txHash: SPEND_TX_HASH, outputIndex: 0 }) as UTxO;
+
+const runtime = (
+  overrides: Partial<DepositObservationRuntime> = {},
+): DepositObservationRuntime => ({
+  queryHistoricalOutput: vi.fn(async () => ({
+    kind: "absent" as const,
+    kupoCheckpoint: 100,
+    kupoCheckpointHash: CHECKPOINT_HASH,
+  })),
+  queryMempool: vi.fn(async () => ({ slot: 100, contains: false })),
+  queryCanonicalPoint: vi.fn(async () => true),
+  queryCurrentSlot: vi.fn(async () => ({
+    source: "test" as const,
+    currentSlot: 50,
+    chainTipSlot: 100,
+    observedAtMs: 1_800_000_000_000,
+    slotLengthMs: 1_000,
+  })),
+  queryDependencies: vi.fn(async () => [visibleDependency()]),
+  ...overrides,
+});
+
+describe("durable deposit provider evidence", () => {
+  it("queries the exact historical Kupo outref without an unspent-only filter", async () => {
+    const txHash = "33".repeat(32);
+    const fetchImpl = vi.fn<
+      (input: string | URL, init?: RequestInit) => Promise<Response>
+    >(
+      async () =>
+        new Response(
+          JSON.stringify([
+            {
+              transaction_id: txHash,
+              output_index: 0,
+              created_at: {
+                slot_no: 90,
+                header_hash: "44".repeat(32),
+              },
+              spent_at: {
+                slot_no: 100,
+                header_hash: "55".repeat(32),
+              },
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "x-most-recent-checkpoint": "120",
+              etag: `"${CHECKPOINT_HASH}"`,
+            },
+          },
+        ),
+    );
+
+    await expect(
+      queryHistoricalDepositOutput({
+        kupoUrl: "http://127.0.0.1:1442",
+        txHash,
+        outputIndex: 0,
+        fetchImpl: fetchImpl as never,
+      }),
+    ).resolves.toEqual({
+      kind: "committed",
+      slot: 90,
+      blockHash: "44".repeat(32),
+      kupoCheckpoint: 120,
+      kupoCheckpointHash: CHECKPOINT_HASH,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const requestedUrl = fetchImpl.mock.calls[0]?.[0];
+    expect(requestedUrl).toBe(`http://127.0.0.1:1442/matches/0%40${txHash}`);
+    expect(requestedUrl).not.toContain("unspent");
+  });
+
+  it("recognizes a historical deposit as committed even after its output and dependencies are spent", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+    const queryMempool = vi.fn<DepositObservationRuntime["queryMempool"]>();
+    const queryDependencies =
+      vi.fn<DepositObservationRuntime["queryDependencies"]>();
+    const observationRuntime = runtime({
+      queryHistoricalOutput: vi.fn(async () => ({
+        kind: "committed" as const,
+        slot: 80,
+        blockHash: "aa".repeat(32),
+        kupoCheckpoint: 100,
+        kupoCheckpointHash: CHECKPOINT_HASH,
+      })),
+      queryMempool,
+      queryDependencies,
+    });
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: fixture.dependencies,
+        runtime: observationRuntime,
+      }),
+    ).resolves.toEqual({
+      kind: "committed",
+      slot: 80,
+      blockHash: "aa".repeat(32),
+      kupoCheckpoint: 100,
+      kupoCheckpointHash: CHECKPOINT_HASH,
+    });
+    expect(queryMempool).not.toHaveBeenCalled();
+    expect(queryDependencies).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Kupo match whose creation point is not canonical in Ogmios", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+    const queryCanonicalPoint = vi
+      .fn<DepositObservationRuntime["queryCanonicalPoint"]>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: fixture.dependencies,
+        runtime: runtime({
+          queryHistoricalOutput: vi.fn(async () => ({
+            kind: "committed" as const,
+            slot: 80,
+            blockHash: "aa".repeat(32),
+            kupoCheckpoint: 100,
+            kupoCheckpointHash: CHECKPOINT_HASH,
+          })),
+          queryCanonicalPoint,
+        }),
+      }),
+    ).resolves.toEqual({
+      kind: "ambiguous",
+      reason: "Kupo deposit match is not on the canonical Ogmios chain",
+    });
+    expect(queryCanonicalPoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("recognizes the exact transaction in a frozen mempool snapshot as accepted", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+    const queryDependencies =
+      vi.fn<DepositObservationRuntime["queryDependencies"]>();
+    const observationRuntime = runtime({
+      queryMempool: vi.fn(async () => ({ slot: 90, contains: true })),
+      queryDependencies,
+    });
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: fixture.dependencies,
+        runtime: observationRuntime,
+      }),
+    ).resolves.toEqual({ kind: "accepted", mempoolSlot: 90 });
+    expect(queryDependencies).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Kupo has not synchronized through the mempool snapshot", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: fixture.dependencies,
+        runtime: runtime({
+          queryHistoricalOutput: vi.fn(async () => ({
+            kind: "absent" as const,
+            kupoCheckpoint: 89,
+            kupoCheckpointHash: CHECKPOINT_HASH,
+          })),
+          queryMempool: vi.fn(async () => ({ slot: 90, contains: false })),
+        }),
+      }),
+    ).resolves.toEqual({
+      kind: "ambiguous",
+      reason: "Kupo checkpoint 89 is behind Ogmios mempool slot 90",
+    });
+  });
+
+  it("fails closed when Kupo absence does not cover the final authoritative chain tip", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: fixture.dependencies,
+        runtime: runtime({
+          queryCurrentSlot: vi.fn(async () => ({
+            source: "test" as const,
+            currentSlot: 102,
+            chainTipSlot: 101,
+            observedAtMs: 1_800_000_000_000,
+            slotLengthMs: 1_000,
+          })),
+        }),
+      }),
+    ).resolves.toEqual({
+      kind: "ambiguous",
+      reason:
+        "Kupo checkpoint 100 is behind authoritative Ogmios chain tip 101",
+    });
+  });
+
+  it("fails closed before provider queries when stored dependencies differ from the signed body", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+    const queryHistoricalOutput =
+      vi.fn<DepositObservationRuntime["queryHistoricalOutput"]>();
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: {
+          spend: [`${"22".repeat(32)}#0`],
+          collateral: [],
+          reference: [],
+        },
+        runtime: runtime({ queryHistoricalOutput }),
+      }),
+    ).resolves.toEqual({
+      kind: "ambiguous",
+      reason: "stored dependency set does not match the exact signed body",
+    });
+    expect(queryHistoricalOutput).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when any signed transaction dependency is no longer unspent", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: fixture.dependencies,
+        runtime: runtime({ queryDependencies: vi.fn(async () => []) }),
+      }),
+    ).resolves.toEqual({
+      kind: "ambiguous",
+      reason: `signed transaction dependencies are no longer all unspent: ${SPEND_TX_HASH}#0`,
+    });
+  });
+
+  it("allows one initial claim only after synchronized absence and exact dependency visibility", async () => {
+    const fixture = signedDepositFixture({
+      invalidBeforeSlot: 40,
+      invalidHereafterSlot: 100,
+    });
+    const jsonbOrderedDependencies = JSON.parse(
+      JSON.stringify({
+        reference: fixture.dependencies.reference,
+        collateral: fixture.dependencies.collateral,
+        spend: fixture.dependencies.spend,
+      }),
+    ) as typeof fixture.dependencies;
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: jsonbOrderedDependencies,
+        runtime: runtime(),
+      }),
+    ).resolves.toEqual({
+      kind: "absent_safe",
+      mempoolSlot: 100,
+      kupoCheckpoint: 100,
+      currentSlot: 50,
+    });
+  });
+
+  it("marks an absent exact transaction expired at the signed validity margin", async () => {
+    const fixture = signedDepositFixture({ invalidHereafterSlot: 100 });
+
+    await expect(
+      observePreparedDeposit({
+        ...fixture,
+        storedDependencies: fixture.dependencies,
+        runtime: runtime({
+          queryCurrentSlot: vi.fn(async () => ({
+            source: "test" as const,
+            currentSlot: 98,
+            chainTipSlot: 100,
+            observedAtMs: 1_800_000_000_000,
+            slotLengthMs: 1_000,
+          })),
+        }),
+      }),
+    ).resolves.toEqual({
+      kind: "expired",
+      mempoolSlot: 100,
+      kupoCheckpoint: 100,
+      currentSlot: 98,
+      invalidHereafterSlot: 100,
+    });
+  });
+});
+
+describe("exact prepared deposit submission", () => {
+  const fakeLucid = (submitTx: (cbor: string) => Promise<string>) =>
+    ({
+      config: () => ({ provider: { submitTx } }),
+      wallet: () => ({ address: async () => "addr_test1prepared" }),
+    }) as never;
+
+  it("submits the exact persisted bytes once", async () => {
+    const fixture = signedDepositFixture();
+    const submitTx = vi.fn(async () => fixture.txHash);
+
+    await expect(
+      Effect.runPromise(
+        submitPreparedDepositProgram(fakeLucid(submitTx), fixture),
+      ),
+    ).resolves.toMatchObject({
+      txHash: fixture.txHash,
+      signedTxCbor: fixture.signedTxCbor,
+      providerTxHash: fixture.txHash,
+    });
+    expect(submitTx).toHaveBeenCalledTimes(1);
+    expect(submitTx).toHaveBeenCalledWith(fixture.signedTxCbor);
+  });
+
+  it("rejects a provider hash mismatch without resubmitting", async () => {
+    const fixture = signedDepositFixture();
+    const submitTx = vi.fn(async () => "ff".repeat(32));
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        submitPreparedDepositProgram(fakeLucid(submitTx), fixture, {
+          sleep: () => Effect.void,
+        }),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    expect(submitTx).toHaveBeenCalledTimes(1);
+    expect(submitTx).toHaveBeenCalledWith(fixture.signedTxCbor);
+  });
+
+  it("does not retry an OutsideValidityInterval response after the one durable claim", async () => {
+    const fixture = signedDepositFixture();
+    const submitTx = vi.fn(async () => {
+      throw new Error(
+        "OutsideValidityIntervalUTxO (ValidityInterval {invalidBefore = SJust (SlotNo 10), invalidHereafter = SJust (SlotNo 20)}) (SlotNo 7)",
+      );
+    });
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        submitPreparedDepositProgram(fakeLucid(submitTx), fixture, {
+          sleep: () => Effect.void,
+        }),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    expect(submitTx).toHaveBeenCalledTimes(1);
+    expect(submitTx).toHaveBeenCalledWith(fixture.signedTxCbor);
+  });
+});

--- a/demo/midgard-node/tests/transactions-utils.test.ts
+++ b/demo/midgard-node/tests/transactions-utils.test.ts
@@ -279,6 +279,30 @@ describe("validity-window submit recovery", () => {
     expect(waits).toEqual([2_000]);
   });
 
+  it("performs no generic provider retry when the caller owns durable recovery", async () => {
+    const waits: number[] = [];
+    const submitProgram = vi.fn(() => Effect.fail(new Error("fetch failed")));
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        submitSignedTxWithRecovery(
+          fakeLucid as never,
+          { submitProgram } as never,
+          "tx-durable-recovery",
+          {
+            maxProviderRetryAttempts: 0,
+            sleep: (milliseconds) =>
+              Effect.sync(() => waits.push(milliseconds)),
+          },
+        ),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    expect(submitProgram).toHaveBeenCalledTimes(1);
+    expect(waits).toEqual([]);
+  });
+
   it("recovers lower-bound-only Ogmios 3118 without generic provider retry", async () => {
     const waits: number[] = [];
     let calls = 0;

--- a/demo/pnpm-lock.yaml
+++ b/demo/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@al-ft/midgard-validation':
         specifier: workspace:*
         version: link:../midgard-validation
+      '@cardano-ogmios/client':
+        specifier: 6.9.0
+        version: 6.9.0(encoding@0.1.13)
       '@chainsafe/libp2p-noise':
         specifier: 17.0.0
         version: 17.0.0

--- a/docs-site/content/docs/operators/node/cli-reference.mdx
+++ b/docs-site/content/docs/operators/node/cli-reference.mdx
@@ -4,7 +4,7 @@ description: "The midgard-node command-line interface, grouped by function."
 ---
 
 `midgard-node` is a Commander CLI (`bin: midgard-node`). Run `midgard-node --help`
-for the authoritative, version-specific list. The 69 commands below are grouped
+for the authoritative, version-specific list. The 70 commands below are grouped
 by function.
 
 <Callout type="info" title="The server">
@@ -34,7 +34,7 @@ by function.
 `submit-l2-transfer` · `submit-deposit` · `submit-withdrawal` ·
 `withdrawal-status` · `project-deposits-once` · `deposit-projected` ·
 `fetch-withdrawals-once` · `absorb-confirmed-deposit-to-reserve` ·
-`reconcile-deposit-submission`, see
+`reconcile-deposit-submission` · `resume-deposit-submission`, see
 [Deposits &amp; Withdrawals](/docs/operators/node/deposits-withdrawals).
 
 ## Blocks, attestation & settlement


### PR DESCRIPTION
## Summary

- persist exact signed deposit CBOR and immutable semantic identity before any provider call
- enforce a one-way `Prepared -> SubmissionUnknown` claim so only a never-claimed row can make one initial exact-byte submission
- reconcile canonical Kupo and Ogmios evidence without rebuilding, re-signing, or automatically resubmitting post-call states
- add bounded observation-only startup reconciliation and operator reconcile/resume commands
- fold the lifecycle schema into the fresh baseline

## Safety model

Accepted or committed evidence blocks submission. `SubmissionUnknown`, `Submitted`, and `Ambiguous` are observation-only and never reopen. Provider disagreement, stale indexer coverage, missing dependencies, response loss, and pruned historical evidence fail closed.

## Verification

- frozen offline install with pnpm 9.15.4
- Node 22 typecheck, Prettier, production build, and compiled CLI help
- 44 provider and submission-utility tests
- 6 real PostgreSQL lifecycle and schema tests
- 5 real PostgreSQL crash-boundary tests
- real-contract fresh-schema deposit and emulator regressions
- independent final differential review
