### PR TITLE
feat: add safe reference-script pre-submit capture

### DIFF
--- a/demo/midgard-node/README.md
+++ b/demo/midgard-node/README.md
@@ -443,6 +443,12 @@ publishing reference scripts or running `init`.
 node dist/index.js deploy-reference-script-node-runtime
 ```
 
+To inspect the exact signed publication CBOR without submitting it, use the
+explicit diagnostic capture mode documented in
+[`REFERENCE_SCRIPT_PRE_SUBMIT_CAPTURE.md`](REFERENCE_SCRIPT_PRE_SUBMIT_CAPTURE.md).
+The mode binds to an existing persisted deployment identity, writes private and
+durable artifacts, and never updates the live deployment manifest.
+
 Before publishing or republishing reference scripts, inspect the deploy wallet:
 
 ```sh

--- a/demo/midgard-node/REFERENCE_SCRIPT_PRE_SUBMIT_CAPTURE.md
+++ b/demo/midgard-node/REFERENCE_SCRIPT_PRE_SUBMIT_CAPTURE.md
@@ -1,0 +1,93 @@
+# Reference-script diagnostic pre-submit capture
+
+The reference-script deployment command has an explicit diagnostic mode that
+builds and signs the normal publication transactions, durably records their
+exact signed CBOR and reference-script payloads, and then stops without calling
+a provider submit API.
+
+This mode is for inspecting the exact transactions that the configured
+deployment identity would produce. It is not a deployment, dry-run estimate,
+or transaction recovery mechanism. Some captured transactions are independently
+submit-ready, so keep the capture directory private and never broadcast its
+contents as a batch.
+
+## Preconditions
+
+- Build the Aiken `testnet` blueprint and the node with Node 22.
+- Use the deployment's existing run-state file. Its persisted network, hub
+  one-shot out-ref, and reference-script auth policy must match the resolved
+  node configuration exactly.
+- Fund the reference-script wallet before capture. Diagnostic mode refuses to
+  run the automatic funding-wallet top-up path.
+- Create the parent of the capture directory, but leave the capture directory
+  itself absent. The command creates it with mode `0700` and refuses to reuse an
+  existing or non-canonical path.
+
+For example:
+
+```sh
+cd demo/midgard-node
+MIDGARD_REAL_BLUEPRINT_PATH=/absolute/path/to/onchain/aiken/plutus.json \
+  node dist/index.js deploy-reference-script-node-runtime \
+  --run-state /absolute/path/to/deployment-run-state.json \
+  --capture-signed-tx-pre-submit /absolute/path/to/new-capture-directory
+```
+
+Capture mode cannot be combined with `--plan-only` or `--fresh-redeploy`.
+Unlike normal publication, it does not persist deployment run-state changes,
+query for newly published reference scripts, or write a deployment manifest.
+
+## Safety boundary
+
+The capture path is separate from the generic sign-and-submit helper:
+
+1. The normal reference-script builder completes each transaction with its
+   existing strict local-evaluation behavior.
+2. `signTransactionForPreSubmitCapture` signs once and extracts that signed
+   object's exact CBOR. Every vkey witness signature is verified over the exact
+   transaction body hash. The helper has no provider submit or confirmation
+   branch.
+3. The generic submit helper rejects diagnostic capture options, preventing a
+   captured-not-submitted result from being treated as a successful submit.
+4. Multi-batch publication uses an in-memory wallet shadow. Later batches
+   identify inputs derived from earlier unsubmitted batches as
+   `synthetic_change`; no live provider resolution is attempted for them.
+5. Any required wallet replenishment, identity mismatch, malformed script,
+   missing lineage, duplicate coverage, or artifact-write failure aborts the
+   command without a completion marker.
+
+The CLI and transaction helper both enforce the aborting diagnostic invocation.
+This duplication is intentional: callers cannot bypass the safety boundary by
+calling the lower-level helper directly.
+
+## Artifacts and completion
+
+Each captured transaction produces files with mode `0600`:
+
+- `.CAPTURE_SESSION.json`: the prepared directory, run-state, blueprint hash,
+  network, one-shot, auth policy, and command identity;
+- `signed-<tx-hash>.cbor`: the binary exact signed transaction CBOR;
+- `signed-<tx-hash>.cbor.json`: transaction, session, target, input-lineage,
+  output, payload-hash, and signed-CBOR hash metadata;
+- `payload-<tx-hash>-<output-index>.cbor`: the exact ledger-serialized script
+  payload for each declared reference-script output.
+
+Every artifact is flushed and atomically installed without overwriting an
+existing path before it is reported. Finalization re-reads all signed CBOR and
+payload files, recomputes their hashes and transaction body hashes, re-verifies
+vkey signatures, re-inspects canonical CBOR and complete Flat decoding, checks
+script hashes, reconstructs the synthetic-change dependency graph, requires
+contiguous batch ordinals and exact target coverage, rejects orphan or temporary
+files, and verifies the same persisted session identity across the bundle.
+
+Only after those checks pass does the command atomically install
+`COMPLETE.json`, fsync it, and fsync the directory. A directory without that
+marker is incomplete and must not be treated as an accepted capture bundle.
+
+## What capture does not prove
+
+Capture proves what was signed, the declared script/payload identities, and the
+internal batch lineage. It does not prove provider acceptance, ledger inclusion,
+or that the synthetic multi-batch chain was submitted. Use the normal deployment
+and confirmation path for publication. Never rename or add a completion marker
+manually.

--- a/demo/midgard-node/src/index.ts
+++ b/demo/midgard-node/src/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 
 import { formatUnknownError } from "@al-ft/midgard-core/error-format";
 import { normalizeHex } from "@al-ft/midgard-core/hex";
@@ -85,6 +86,13 @@ import * as Services from "@/services/index.js";
 import * as DaAttestation from "@/transactions/da-attestation.js";
 import * as Initialization from "@/transactions/initialization.js";
 import * as PhasMembershipRegistration from "@/transactions/phas-membership-registration.js";
+import {
+  assertPersistedSignedTxPreSubmitCaptureIdentity,
+  assertSignedTxPreSubmitCaptureCliSafety,
+  finalizeSignedTxPreSubmitCapture,
+  prepareSignedTxPreSubmitCaptureDirectory,
+  type SignedTxPreSubmitCapture,
+} from "@/transactions/pre-submit-capture.js";
 import {
   fetchReferenceScriptUtxosProgram,
   planReferenceScriptCommandProgram,
@@ -3770,13 +3778,31 @@ for (const commandName of RegisterActiveOperator.REFERENCE_SCRIPT_COMMAND_NAMES)
       "--fresh-redeploy-reason <text>",
       "Required reason when --fresh-redeploy is used",
     )
+    .option(
+      "--capture-signed-tx-pre-submit <directory>",
+      "Explicit diagnostic mode: capture every signed publication batch into a fresh directory without provider submit",
+    )
     .action(async (_args, options) => {
       const commandOptions = options.opts();
       const { contractDeploymentInfoOutput, planOnly } = commandOptions;
+      const captureOutputDirectory =
+        typeof commandOptions.captureSignedTxPreSubmit === "string"
+          ? resolve(commandOptions.captureSignedTxPreSubmit)
+          : undefined;
       const runOptions =
         DeploymentRunStateCommand.resolveDeploymentRunCliOptions(
           commandOptions,
         );
+      if (captureOutputDirectory !== undefined && runOptions.freshRedeploy) {
+        throw new Error(
+          "--capture-signed-tx-pre-submit cannot be combined with --fresh-redeploy because capture must use an already-persisted auth policy identity",
+        );
+      }
+      if (captureOutputDirectory !== undefined && planOnly === true) {
+        throw new Error(
+          "--capture-signed-tx-pre-submit cannot be combined with --plan-only",
+        );
+      }
       const mainEffect = provideReferenceScriptDeploymentServices(
         Effect.gen(function* () {
           const nodeConfig = yield* Services.NodeConfig;
@@ -3799,9 +3825,57 @@ for (const commandName of RegisterActiveOperator.REFERENCE_SCRIPT_COMMAND_NAMES)
                 timelockDurationMs:
                   nodeConfig.REFERENCE_SCRIPT_AUTH_TIMELOCK_MS,
                 manifestOutputPath,
-                persistRunState: planOnly !== true,
+                persistRunState:
+                  planOnly !== true && captureOutputDirectory === undefined,
               },
             );
+          const preSubmitDiagnosticCapture =
+            captureOutputDirectory === undefined
+              ? undefined
+              : yield* Effect.tryPromise({
+                  try: async (): Promise<SignedTxPreSubmitCapture> => {
+                    const blueprintPath = resolve(
+                      process.env.MIDGARD_REAL_BLUEPRINT_PATH?.trim() ||
+                        resolve(
+                          import.meta.dirname,
+                          "../../../onchain/aiken/plutus.json",
+                        ),
+                    );
+                    const blueprintBytes = await readFile(blueprintPath);
+                    const capture: SignedTxPreSubmitCapture = {
+                      outputDirectory: captureOutputDirectory,
+                      invocation: "phase4-live-pre-submit-capture",
+                      abortBeforeSubmit: true,
+                      session: {
+                        commandName,
+                        runStatePath: resolve(runOptions.runStatePath),
+                        blueprintPath,
+                        blueprintSha256: createHash("sha256")
+                          .update(blueprintBytes)
+                          .digest("hex"),
+                        network: nodeConfig.NETWORK,
+                        hubOracleOneShotOutRef: `${nodeConfig.HUB_ORACLE_ONE_SHOT_TX_HASH}#${nodeConfig.HUB_ORACLE_ONE_SHOT_OUTPUT_INDEX.toString()}`,
+                        referenceScriptAuthPolicyId: authPolicy.policyId,
+                      },
+                    };
+                    assertSignedTxPreSubmitCaptureCliSafety({
+                      capture,
+                      freshRedeploy: runOptions.freshRedeploy,
+                      planOnly: planOnly === true,
+                    });
+                    await assertPersistedSignedTxPreSubmitCaptureIdentity(
+                      capture,
+                    );
+                    await prepareSignedTxPreSubmitCaptureDirectory(capture);
+                    return capture;
+                  },
+                  catch: (cause) =>
+                    cause instanceof Error
+                      ? cause
+                      : new Error(
+                          `Failed to prepare pre-submit diagnostic capture: ${String(cause)}`,
+                        ),
+                });
           const baseContracts = yield* Services.AlwaysSucceedsContract;
           const contracts =
             yield* Services.withRealStateQueueAndOperatorContracts(
@@ -3857,7 +3931,30 @@ for (const commandName of RegisterActiveOperator.REFERENCE_SCRIPT_COMMAND_NAMES)
               new Set([
                 `${nodeConfig.HUB_ORACLE_ONE_SHOT_TX_HASH}#${nodeConfig.HUB_ORACLE_ONE_SHOT_OUTPUT_INDEX.toString()}`,
               ]),
+              preSubmitDiagnosticCapture,
             );
+          if (preSubmitDiagnosticCapture !== undefined) {
+            const captureComplete = yield* Effect.tryPromise({
+              try: () =>
+                finalizeSignedTxPreSubmitCapture({
+                  capture: preSubmitDiagnosticCapture,
+                  expectedTargetNames: referenceScriptTargetsByCommand(
+                    contracts,
+                  )[commandName].map(({ name }) => name),
+                }),
+              catch: (cause) =>
+                cause instanceof Error
+                  ? cause
+                  : new Error(
+                      `Failed to finalize pre-submit diagnostic capture: ${String(cause)}`,
+                    ),
+            });
+            return {
+              mode: "diagnostic-capture" as const,
+              published,
+              captureComplete,
+            };
+          }
           const liveReferenceScripts = yield* fetchReferenceScriptUtxosProgram(
             lucidService.referenceScriptsApi,
             lucidService.referenceScriptsAddress,
@@ -3894,6 +3991,11 @@ for (const commandName of RegisterActiveOperator.REFERENCE_SCRIPT_COMMAND_NAMES)
             if (result.mode === "plan") {
               return Effect.logInfo(
                 `deploy-reference-script-${commandName} plan-only completed: ${formatJson(result.plan)}`,
+              );
+            }
+            if (result.mode === "diagnostic-capture") {
+              return Effect.logInfo(
+                `deploy-reference-script-${commandName} diagnostic capture completed without provider submission: ${formatJson(result.captureComplete)}`,
               );
             }
             return Effect.logInfo(

--- a/demo/midgard-node/src/transactions/pre-submit-capture.ts
+++ b/demo/midgard-node/src/transactions/pre-submit-capture.ts
@@ -1,0 +1,1320 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join } from "node:path";
+
+import { compileUPLC, parseUPLC } from "@harmoniclabs/uplc";
+import { CML, getAddressDetails } from "@lucid-evolution/lucid";
+
+type ByteStringLayer = {
+  readonly headerHex: string;
+  readonly payloadHex: string;
+  readonly payloadLength: number;
+  readonly totalLength: number;
+  readonly rawPrefix: string;
+};
+
+type CmlScript = {
+  readonly to_cbor_hex?: () => string;
+  readonly to_raw_bytes?: () => Uint8Array;
+  readonly hash?: () => { to_hex: () => string };
+};
+
+type InspectedScript = {
+  readonly location: string;
+  readonly cmlType: string;
+  readonly languageTag?: number;
+  readonly cborHexPrefix?: string;
+  readonly cborBytes?: number;
+  readonly nestedCborLayers?: ReturnType<typeof inspectByteStringLayers>;
+  readonly rawBytes?: number;
+  readonly rawPrefix?: string;
+  readonly rawHex: string;
+  readonly canonicalDecodeValid: boolean;
+  readonly canonicalDecodeError?: string;
+  readonly flatDecodeValid?: boolean;
+  readonly flatDecodeError?: string;
+  readonly computedHash?: string;
+};
+
+const hexByte = (hex: string, offset: number): number =>
+  Number.parseInt(hex.slice(offset, offset + 2), 16);
+
+const readByteStringLayer = (inputHex: string): ByteStringLayer | undefined => {
+  const hex = inputHex.toLowerCase();
+  if (hex.length < 2 || !/^[0-9a-f]+$/.test(hex)) return undefined;
+  const first = hexByte(hex, 0);
+  if (first >> 5 !== 2) return undefined;
+  const additional = first & 0x1f;
+  let headerLength = 1;
+  let payloadLength: number;
+  if (additional < 24) {
+    payloadLength = additional;
+  } else if (additional >= 24 && additional <= 27) {
+    const lengthBytes = 2 ** (additional - 24);
+    if (hex.length < (1 + lengthBytes) * 2) return undefined;
+    headerLength += lengthBytes;
+    const lengthHex = hex.slice(2, (1 + lengthBytes) * 2);
+    payloadLength = Number.parseInt(lengthHex, 16);
+    if (!Number.isSafeInteger(payloadLength)) return undefined;
+  } else {
+    return undefined;
+  }
+  const payloadStart = headerLength * 2;
+  const payloadEnd = payloadStart + payloadLength * 2;
+  if (hex.length < payloadEnd) return undefined;
+  return {
+    headerHex: hex.slice(0, payloadStart),
+    payloadHex: hex.slice(payloadStart, payloadEnd),
+    payloadLength,
+    totalLength: headerLength + payloadLength,
+    rawPrefix: hex.slice(payloadStart, Math.min(payloadEnd, payloadStart + 16)),
+  };
+};
+
+const inspectByteStringLayers = (cborHex: string) => {
+  const layers: ByteStringLayer[] = [];
+  let remainder = cborHex.toLowerCase();
+  let trailingHex = "";
+  while (true) {
+    const layer = readByteStringLayer(remainder);
+    if (layer === undefined) break;
+    layers.push(layer);
+    const suffix = remainder.slice(layer.totalLength * 2);
+    if (suffix.length !== 0) {
+      trailingHex = suffix;
+      break;
+    }
+    remainder = layer.payloadHex;
+    if (remainder.length === 0) break;
+  }
+  return {
+    layerCount: layers.length,
+    layers: layers.map((layer) => ({
+      headerHex: layer.headerHex,
+      payloadLength: layer.payloadLength,
+      rawPrefix: layer.rawPrefix,
+    })),
+    trailingHex,
+  };
+};
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Buffer.from(bytes).toString("hex");
+
+const expectedUplcVersion = (languageTag: number): string => {
+  switch (languageTag) {
+    case 1:
+    case 2:
+      return "1.0.0";
+    case 3:
+      return "1.1.0";
+    default:
+      throw new Error(`Unsupported Plutus language tag ${languageTag}`);
+  }
+};
+
+export const validateLedgerSerializedFlat = (
+  ledgerSerializedHex: string,
+  languageTag: number,
+): void => {
+  const layer = readByteStringLayer(ledgerSerializedHex);
+  if (layer === undefined) {
+    throw new Error(
+      "Ledger serialized script must contain exactly one definite CBOR byte-string layer",
+    );
+  }
+  if (layer.totalLength * 2 !== ledgerSerializedHex.length) {
+    throw new Error("Ledger serialized script has trailing bytes");
+  }
+  if (layer.payloadLength === 0) {
+    throw new Error("Ledger serialized script contains an empty Flat program");
+  }
+  const extraLayer = readByteStringLayer(layer.payloadHex);
+  if (
+    extraLayer !== undefined &&
+    extraLayer.totalLength * 2 === layer.payloadHex.length
+  ) {
+    throw new Error("Ledger serialized script contains an extra CBOR layer");
+  }
+
+  const flatBytes = Buffer.from(layer.payloadHex, "hex");
+  const program = parseUPLC(flatBytes, "flat");
+  const actualVersion = program.version.toString();
+  const requiredVersion = expectedUplcVersion(languageTag);
+  if (actualVersion !== requiredVersion) {
+    throw new Error(
+      `PlutusV${languageTag} script uses unsupported UPLC version ${actualVersion}; expected ${requiredVersion}`,
+    );
+  }
+
+  const reencoded = compileUPLC(program, {
+    trivialOptimization: false,
+  }).toBuffer();
+  if (
+    reencoded.nZeroesAsEndPadding !== 0 ||
+    bytesToHex(reencoded.buffer) !== layer.payloadHex
+  ) {
+    throw new Error(
+      "Flat decoder did not consume the complete canonical program encoding",
+    );
+  }
+};
+
+const inspectPlutusScript = (
+  script: CmlScript,
+  cmlType: string,
+  languageTag: number,
+  location: string,
+): InspectedScript => {
+  const cborHex = script.to_cbor_hex?.() ?? "";
+  const layers = inspectByteStringLayers(cborHex);
+  const rawBytes = script.to_raw_bytes?.();
+  const rawHex = rawBytes === undefined ? undefined : bytesToHex(rawBytes);
+  let canonicalDecodeValid = false;
+  let canonicalDecodeError: string | undefined;
+  let flatDecodeValid = false;
+  let flatDecodeError: string | undefined;
+  try {
+    parseUPLC(Buffer.from(cborHex, "hex"), "cbor");
+    canonicalDecodeValid = true;
+  } catch (error) {
+    canonicalDecodeError = String(error);
+  }
+  if (rawHex !== undefined) {
+    try {
+      validateLedgerSerializedFlat(rawHex, languageTag);
+      flatDecodeValid = true;
+    } catch (error) {
+      flatDecodeError = String(error);
+    }
+  }
+  return {
+    location,
+    cmlType,
+    languageTag,
+    cborHexPrefix: cborHex.slice(0, 24),
+    cborBytes: cborHex.length / 2,
+    nestedCborLayers: layers,
+    rawBytes: rawHex === undefined ? undefined : rawHex.length / 2,
+    rawPrefix: rawHex?.slice(0, 24),
+    rawHex: rawHex ?? "",
+    canonicalDecodeValid,
+    canonicalDecodeError,
+    flatDecodeValid,
+    flatDecodeError,
+    computedHash: script.hash?.().to_hex(),
+  };
+};
+
+const inspectNativeScript = (
+  script: CmlScript,
+  location: string,
+): InspectedScript => {
+  const cborHex = script.to_cbor_hex?.() ?? "";
+  const rawHex =
+    script.to_raw_bytes === undefined
+      ? cborHex
+      : bytesToHex(script.to_raw_bytes());
+  return {
+    location,
+    cmlType: "NativeScript",
+    cborHexPrefix: cborHex.slice(0, 24),
+    cborBytes: cborHex.length / 2,
+    rawBytes: rawHex.length / 2,
+    rawPrefix: rawHex.slice(0, 24),
+    rawHex,
+    canonicalDecodeValid: cborHex.length > 0,
+    computedHash: script.hash?.().to_hex(),
+  };
+};
+
+const collectionEntries = (collection: unknown): unknown[] => {
+  if (collection === null || collection === undefined) return [];
+  const value = collection as {
+    len?: () => number;
+    get?: (i: number) => unknown;
+  };
+  if (typeof value.len !== "function" || typeof value.get !== "function")
+    return [];
+  return Array.from({ length: value.len() }, (_, index) => value.get!(index));
+};
+
+const inspectTransaction = (signedTxCbor: string) => {
+  const tx = CML.Transaction.from_cbor_hex(signedTxCbor);
+  const body = tx.body();
+  const scriptRefs = [];
+  const outputs = body.outputs();
+  for (let index = 0; index < outputs.len(); index += 1) {
+    const scriptRef = outputs.get(index).script_ref();
+    if (scriptRef === null || scriptRef === undefined) continue;
+    const native = scriptRef.as_native();
+    if (native !== undefined && native !== null) {
+      scriptRefs.push(
+        inspectNativeScript(native, `body.outputs[${index}].script_ref`),
+      );
+      continue;
+    }
+    const v1 = scriptRef.as_plutus_v1();
+    const v2 =
+      v1 === undefined || v1 === null ? scriptRef.as_plutus_v2() : undefined;
+    const v3 =
+      v1 === undefined || v1 === null
+        ? v2 === undefined || v2 === null
+          ? scriptRef.as_plutus_v3()
+          : undefined
+        : undefined;
+    const languageTag =
+      v1 !== undefined && v1 !== null
+        ? 1
+        : v2 !== undefined && v2 !== null
+          ? 2
+          : 3;
+    const plutus = v1 ?? v2 ?? v3;
+    if (plutus === undefined || plutus === null) continue;
+    scriptRefs.push(
+      inspectPlutusScript(
+        plutus,
+        "ScriptRef",
+        languageTag,
+        `body.outputs[${index}].script_ref`,
+      ),
+    );
+  }
+  const witnesses = tx.witness_set();
+  const witnessScripts = [
+    ...collectionEntries(witnesses.plutus_v1_scripts()).map((script, index) =>
+      inspectPlutusScript(
+        script as CmlScript,
+        "PlutusV1Script",
+        1,
+        `witness.plutus_v1_scripts[${index}]`,
+      ),
+    ),
+    ...collectionEntries(witnesses.plutus_v2_scripts()).map((script, index) =>
+      inspectPlutusScript(
+        script as CmlScript,
+        "PlutusV2Script",
+        2,
+        `witness.plutus_v2_scripts[${index}]`,
+      ),
+    ),
+    ...collectionEntries(witnesses.plutus_v3_scripts()).map((script, index) =>
+      inspectPlutusScript(
+        script as CmlScript,
+        "PlutusV3Script",
+        3,
+        `witness.plutus_v3_scripts[${index}]`,
+      ),
+    ),
+    ...collectionEntries(witnesses.native_scripts()).map((script, index) =>
+      inspectNativeScript(
+        script as CmlScript,
+        `witness.native_scripts[${index}]`,
+      ),
+    ),
+  ];
+  const inputs = body.inputs();
+  const bodyInputs = Array.from({ length: inputs.len() }, (_, index) => {
+    const input = inputs.get(index);
+    return `${input.transaction_id().to_hex()}#${Number(input.index()).toString()}`;
+  });
+  const outputAddresses = Array.from({ length: outputs.len() }, (_, index) =>
+    outputs.get(index).address().to_bech32(),
+  );
+  const bodyHash = CML.hash_transaction(body);
+  const signerKeyHashes = collectionEntries(witnesses.vkeywitnesses()).map(
+    (witness, index) => {
+      const vkeyWitness = witness as CML.Vkeywitness;
+      const vkey = vkeyWitness.vkey();
+      if (
+        !vkey.verify(bodyHash.to_raw_bytes(), vkeyWitness.ed25519_signature())
+      ) {
+        throw new Error(
+          `Captured transaction has an invalid vkey witness signature at index ${index.toString()}`,
+        );
+      }
+      return vkey.hash().to_hex();
+    },
+  );
+  return {
+    cmlTransactionType: "Transaction",
+    bodyHash: bodyHash.to_hex(),
+    bodyInputs,
+    outputCount: outputs.len(),
+    outputAddresses,
+    signerKeyHashes,
+    bodyScriptRefs: scriptRefs,
+    witnessScripts,
+  };
+};
+
+export type SignedTxPreSubmitCapture = {
+  readonly outputDirectory: string;
+  readonly invocation: "phase4-live-pre-submit-capture";
+  readonly abortBeforeSubmit: true;
+  readonly session: {
+    readonly commandName: string;
+    readonly runStatePath: string;
+    readonly blueprintPath: string;
+    readonly blueprintSha256: string;
+    readonly network: string;
+    readonly hubOracleOneShotOutRef: string;
+    readonly referenceScriptAuthPolicyId: string;
+  };
+};
+
+export type SignedTxPreSubmitBatchContext = {
+  readonly ordinal: number;
+  readonly plannedBatchIndex: number;
+  readonly splitPath: string;
+  readonly targets: readonly {
+    readonly name: string;
+    readonly scriptHash: string;
+    readonly outputIndex: number;
+  }[];
+  readonly inputs: readonly {
+    readonly outRef: string;
+    readonly lineage: "live_seed" | "synthetic_change";
+  }[];
+  readonly walletChangeOutputIndexes: readonly number[];
+};
+
+export type CapturedSignedTxNotSubmitted = {
+  readonly status: "captured_not_submitted";
+  readonly txHash: string;
+  readonly signedTxCbor: string;
+  readonly walletAddress: string;
+  readonly cborPath: string;
+  readonly metadataPath: string;
+};
+
+export type SignedTxPreSubmitCaptureComplete = {
+  readonly schemaVersion: 1;
+  readonly status: "complete";
+  readonly completePath: string;
+  readonly expectedTargetCount: number;
+  readonly captureCount: number;
+  readonly targetNames: readonly string[];
+};
+
+const assertCaptureConfig = (capture: SignedTxPreSubmitCapture): void => {
+  if (!isAbsolute(capture.outputDirectory)) {
+    throw new Error("Pre-submit capture output directory must be absolute");
+  }
+  if (
+    capture.invocation !== "phase4-live-pre-submit-capture" ||
+    capture.abortBeforeSubmit !== true
+  ) {
+    throw new Error(
+      "Pre-submit capture requires the explicit aborting diagnostic invocation",
+    );
+  }
+  if (
+    !isAbsolute(capture.session.runStatePath) ||
+    !isAbsolute(capture.session.blueprintPath) ||
+    !/^[0-9a-f]{64}$/i.test(capture.session.blueprintSha256) ||
+    !/^[0-9a-f]{56}$/i.test(capture.session.referenceScriptAuthPolicyId) ||
+    !/^[0-9a-f]{64}#\d+$/i.test(capture.session.hubOracleOneShotOutRef) ||
+    capture.session.commandName.length === 0 ||
+    capture.session.network.length === 0
+  ) {
+    throw new Error("Pre-submit capture session identity is incomplete");
+  }
+};
+
+export const assertSignedTxPreSubmitCaptureCliSafety = ({
+  capture,
+  freshRedeploy,
+  planOnly,
+}: {
+  readonly capture: SignedTxPreSubmitCapture;
+  readonly freshRedeploy: boolean;
+  readonly planOnly: boolean;
+}): void => {
+  assertCaptureConfig(capture);
+  if (freshRedeploy) {
+    throw new Error(
+      "--capture-signed-tx-pre-submit cannot be combined with --fresh-redeploy because diagnostic mode must bind an already-persisted auth policy identity",
+    );
+  }
+  if (planOnly) {
+    throw new Error(
+      "--capture-signed-tx-pre-submit cannot be combined with --plan-only",
+    );
+  }
+};
+
+export const assertPersistedSignedTxPreSubmitCaptureIdentity = async (
+  capture: SignedTxPreSubmitCapture,
+): Promise<void> => {
+  assertCaptureConfig(capture);
+  const runStateStats = await lstat(capture.session.runStatePath);
+  if (!runStateStats.isFile() || runStateStats.isSymbolicLink()) {
+    throw new Error(
+      "Pre-submit capture run-state must be a regular non-symlink file",
+    );
+  }
+  const parsed = JSON.parse(
+    await readFile(capture.session.runStatePath, "utf8"),
+  ) as {
+    readonly schemaVersion?: unknown;
+    readonly identity?: {
+      readonly network?: unknown;
+      readonly hubOracleOneShot?: {
+        readonly txHash?: unknown;
+        readonly outputIndex?: unknown;
+      };
+      readonly referenceScriptAuthPolicyId?: unknown;
+      readonly referenceScriptAuthPolicy?: {
+        readonly policyId?: unknown;
+      };
+    };
+  };
+  const identity = parsed.identity;
+  const persistedOutRef =
+    typeof identity?.hubOracleOneShot?.txHash === "string" &&
+    Number.isSafeInteger(identity.hubOracleOneShot.outputIndex)
+      ? `${identity.hubOracleOneShot.txHash}#${String(identity.hubOracleOneShot.outputIndex)}`
+      : undefined;
+  if (
+    parsed.schemaVersion !== "midgard-deployment-run-state-v1" ||
+    identity?.network !== capture.session.network ||
+    persistedOutRef !== capture.session.hubOracleOneShotOutRef ||
+    identity?.referenceScriptAuthPolicyId !==
+      capture.session.referenceScriptAuthPolicyId ||
+    identity?.referenceScriptAuthPolicy?.policyId !==
+      capture.session.referenceScriptAuthPolicyId
+  ) {
+    throw new Error(
+      "Pre-submit capture requires persisted run-state network, hub one-shot, and reference-script auth identity to exactly match the resolved capture session",
+    );
+  }
+};
+
+const CAPTURE_SESSION_FILE = ".CAPTURE_SESSION.json";
+
+type PreparedCaptureMarker = {
+  readonly schemaVersion: 1;
+  readonly status: "prepared_not_submitted";
+  readonly outputDirectory: string;
+  readonly directory: {
+    readonly device: number;
+    readonly inode: number;
+    readonly owner: number;
+  };
+  readonly session: SignedTxPreSubmitCapture["session"];
+};
+
+const sameSession = (
+  left: SignedTxPreSubmitCapture["session"],
+  right: SignedTxPreSubmitCapture["session"],
+): boolean => JSON.stringify(left) === JSON.stringify(right);
+
+const syncDirectory = async (path: string): Promise<void> => {
+  const handle = await open(path, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+};
+
+const assertPrivateRegularFile = async (path: string): Promise<void> => {
+  const file = await lstat(path);
+  const expectedOwner = process.getuid?.();
+  if (
+    !file.isFile() ||
+    file.isSymbolicLink() ||
+    (file.mode & 0o777) !== 0o600 ||
+    (expectedOwner !== undefined && file.uid !== expectedOwner)
+  ) {
+    throw new Error(
+      `Pre-submit capture artifact is not a private owner-controlled regular file: ${path}`,
+    );
+  }
+};
+
+const writePrivateFileAtomic = async (
+  path: string,
+  content: string | Buffer,
+): Promise<void> => {
+  const temporaryPath = join(
+    dirname(path),
+    `.${basename(path)}.${process.pid.toString()}.${randomUUID()}.tmp`,
+  );
+  try {
+    const handle = await open(temporaryPath, "wx", 0o600);
+    try {
+      await handle.writeFile(content);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await chmod(temporaryPath, 0o600);
+    await link(temporaryPath, path);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+};
+
+const assertBlueprintIdentity = async (
+  capture: SignedTxPreSubmitCapture,
+): Promise<void> => {
+  const blueprintStats = await lstat(capture.session.blueprintPath);
+  if (!blueprintStats.isFile() || blueprintStats.isSymbolicLink()) {
+    throw new Error(
+      "Pre-submit capture blueprint must be a regular non-symlink file",
+    );
+  }
+  const blueprintHash = createHash("sha256")
+    .update(await readFile(capture.session.blueprintPath))
+    .digest("hex");
+  if (blueprintHash !== capture.session.blueprintSha256) {
+    throw new Error(
+      "Pre-submit capture blueprint hash does not match the prepared session identity",
+    );
+  }
+};
+
+const readPreparedCaptureMarker = async (
+  capture: SignedTxPreSubmitCapture,
+): Promise<PreparedCaptureMarker> => {
+  const markerPath = join(capture.outputDirectory, CAPTURE_SESSION_FILE);
+  await assertPrivateRegularFile(markerPath);
+  const parsed = JSON.parse(await readFile(markerPath, "utf8")) as unknown;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { schemaVersion?: unknown }).schemaVersion !== 1 ||
+    (parsed as { status?: unknown }).status !== "prepared_not_submitted"
+  ) {
+    throw new Error("Invalid pre-submit capture preparation marker");
+  }
+  return parsed as PreparedCaptureMarker;
+};
+
+const assertPreparedCaptureDirectory = async (
+  capture: SignedTxPreSubmitCapture,
+): Promise<void> => {
+  assertCaptureConfig(capture);
+  await assertPersistedSignedTxPreSubmitCaptureIdentity(capture);
+  await assertBlueprintIdentity(capture);
+  const directory = await lstat(capture.outputDirectory);
+  const canonicalDirectory = await realpath(capture.outputDirectory);
+  const expectedOwner = process.getuid?.();
+  if (
+    !directory.isDirectory() ||
+    directory.isSymbolicLink() ||
+    canonicalDirectory !== capture.outputDirectory ||
+    (directory.mode & 0o777) !== 0o700 ||
+    (expectedOwner !== undefined && directory.uid !== expectedOwner)
+  ) {
+    throw new Error(
+      "Pre-submit capture directory must remain a canonical private owner-controlled directory",
+    );
+  }
+  const marker = await readPreparedCaptureMarker(capture);
+  if (
+    marker.outputDirectory !== capture.outputDirectory ||
+    marker.directory.device !== directory.dev ||
+    marker.directory.inode !== directory.ino ||
+    marker.directory.owner !== directory.uid ||
+    !sameSession(marker.session, capture.session)
+  ) {
+    throw new Error(
+      "Pre-submit capture directory identity no longer matches its preparation marker",
+    );
+  }
+};
+
+export const prepareSignedTxPreSubmitCaptureDirectory = async (
+  capture: SignedTxPreSubmitCapture,
+): Promise<void> => {
+  assertCaptureConfig(capture);
+  await assertPersistedSignedTxPreSubmitCaptureIdentity(capture);
+  await assertBlueprintIdentity(capture);
+  await mkdir(capture.outputDirectory, { recursive: false, mode: 0o700 });
+  await chmod(capture.outputDirectory, 0o700);
+  const directory = await lstat(capture.outputDirectory);
+  const canonicalDirectory = await realpath(capture.outputDirectory);
+  const expectedOwner = process.getuid?.();
+  if (
+    !directory.isDirectory() ||
+    directory.isSymbolicLink() ||
+    canonicalDirectory !== capture.outputDirectory ||
+    (directory.mode & 0o777) !== 0o700 ||
+    (expectedOwner !== undefined && directory.uid !== expectedOwner)
+  ) {
+    throw new Error(
+      "Pre-submit capture output path must resolve to a new canonical private owner-controlled directory",
+    );
+  }
+  const marker: PreparedCaptureMarker = {
+    schemaVersion: 1,
+    status: "prepared_not_submitted",
+    outputDirectory: capture.outputDirectory,
+    directory: {
+      device: directory.dev,
+      inode: directory.ino,
+      owner: directory.uid,
+    },
+    session: capture.session,
+  };
+  await writePrivateFileAtomic(
+    join(capture.outputDirectory, CAPTURE_SESSION_FILE),
+    `${JSON.stringify(marker, null, 2)}\n`,
+  );
+  await syncDirectory(capture.outputDirectory);
+  await syncDirectory(dirname(capture.outputDirectory));
+};
+
+const assertBatchContext = (batch: SignedTxPreSubmitBatchContext): void => {
+  if (
+    !Number.isSafeInteger(batch.ordinal) ||
+    batch.ordinal < 0 ||
+    !Number.isSafeInteger(batch.plannedBatchIndex) ||
+    batch.plannedBatchIndex < 0 ||
+    batch.splitPath.length === 0 ||
+    batch.targets.length === 0
+  ) {
+    throw new Error("Pre-submit capture batch context is incomplete");
+  }
+  const targetNames = batch.targets.map(({ name }) => name);
+  const outputIndexes = batch.targets.map(({ outputIndex }) => outputIndex);
+  if (
+    new Set(targetNames).size !== targetNames.length ||
+    new Set(outputIndexes).size !== outputIndexes.length ||
+    batch.targets.some(
+      ({ name, scriptHash, outputIndex }) =>
+        name.length === 0 ||
+        !/^[0-9a-f]{56}$/i.test(scriptHash) ||
+        !Number.isSafeInteger(outputIndex) ||
+        outputIndex < 0,
+    )
+  ) {
+    throw new Error(
+      "Pre-submit capture batch has missing or duplicate target identity",
+    );
+  }
+  if (
+    batch.inputs.length === 0 ||
+    new Set(batch.inputs.map(({ outRef }) => outRef)).size !==
+      batch.inputs.length ||
+    batch.inputs.some(
+      ({ outRef, lineage }) =>
+        !/^[0-9a-f]{64}#\d+$/i.test(outRef) ||
+        (lineage !== "live_seed" && lineage !== "synthetic_change"),
+    ) ||
+    new Set(batch.walletChangeOutputIndexes).size !==
+      batch.walletChangeOutputIndexes.length ||
+    batch.walletChangeOutputIndexes.some(
+      (outputIndex) =>
+        !Number.isSafeInteger(outputIndex) ||
+        outputIndex < 0 ||
+        outputIndexes.includes(outputIndex),
+    )
+  ) {
+    throw new Error(
+      "Pre-submit capture batch input lineage is missing or duplicated",
+    );
+  }
+};
+
+const assertBatchMatchesSignedTransaction = (
+  tx: ReturnType<typeof inspectTransaction>,
+  batch: SignedTxPreSubmitBatchContext,
+  walletAddress: string,
+): void => {
+  const declaredInputs = new Set(batch.inputs.map(({ outRef }) => outRef));
+  const signedInputs = new Set(tx.bodyInputs);
+  if (
+    declaredInputs.size !== signedInputs.size ||
+    [...declaredInputs].some((outRef) => !signedInputs.has(outRef))
+  ) {
+    throw new Error(
+      "Pre-submit capture input lineage does not exactly match the signed transaction body inputs",
+    );
+  }
+
+  const paymentCredential = getAddressDetails(walletAddress).paymentCredential;
+  if (
+    paymentCredential?.type !== "Key" ||
+    !tx.signerKeyHashes.includes(paymentCredential.hash)
+  ) {
+    throw new Error(
+      "Pre-submit capture signing wallet is not authenticated by the signed transaction witnesses",
+    );
+  }
+
+  const declaredOutputIndexes = new Set([
+    ...batch.targets.map(({ outputIndex }) => outputIndex),
+    ...batch.walletChangeOutputIndexes,
+  ]);
+  if (
+    declaredOutputIndexes.size !== tx.outputCount ||
+    Array.from({ length: tx.outputCount }, (_, index) => index).some(
+      (index) => !declaredOutputIndexes.has(index),
+    )
+  ) {
+    throw new Error(
+      "Pre-submit capture target and wallet-change indexes do not exactly cover the signed transaction outputs",
+    );
+  }
+  for (const outputIndex of batch.walletChangeOutputIndexes) {
+    if (tx.outputAddresses[outputIndex] !== walletAddress) {
+      throw new Error(
+        `Pre-submit capture wallet-change output ${outputIndex.toString()} is not controlled by the signing wallet`,
+      );
+    }
+  }
+};
+
+const inspectedScriptOutputIndex = (script: InspectedScript): number => {
+  const match = /^body\.outputs\[(\d+)]\.script_ref$/.exec(script.location);
+  if (match === null) {
+    throw new Error(
+      `Captured body reference script has an invalid location: ${script.location}`,
+    );
+  }
+  return Number(match[1]);
+};
+
+const assertInspectedScriptsValid = (
+  tx: ReturnType<typeof inspectTransaction>,
+  batch: SignedTxPreSubmitBatchContext,
+): void => {
+  const inspectedByOutput = new Map(
+    tx.bodyScriptRefs.map((script) => [
+      inspectedScriptOutputIndex(script),
+      script,
+    ]),
+  );
+  if (inspectedByOutput.size !== tx.bodyScriptRefs.length) {
+    throw new Error(
+      "Captured transaction contains duplicate script-ref outputs",
+    );
+  }
+  const expectedOutputs = new Set(
+    batch.targets.map(({ outputIndex }) => outputIndex),
+  );
+  if (
+    inspectedByOutput.size !== expectedOutputs.size ||
+    [...inspectedByOutput.keys()].some((index) => !expectedOutputs.has(index))
+  ) {
+    throw new Error(
+      "Captured transaction body reference scripts do not exactly match the declared batch targets",
+    );
+  }
+  const allScripts = [...tx.bodyScriptRefs, ...tx.witnessScripts];
+  for (const script of allScripts) {
+    if (
+      !script.canonicalDecodeValid ||
+      script.rawHex.length === 0 ||
+      script.computedHash === undefined ||
+      (script.cmlType !== "NativeScript" && script.flatDecodeValid !== true)
+    ) {
+      throw new Error(
+        `Captured script validation failed at ${script.location}: canonical=${String(script.canonicalDecodeValid)},flat=${String(script.flatDecodeValid)},hash=${script.computedHash ?? "missing"},canonical_error=${script.canonicalDecodeError ?? "none"},flat_error=${script.flatDecodeError ?? "none"}`,
+      );
+    }
+  }
+  for (const target of batch.targets) {
+    const script = inspectedByOutput.get(target.outputIndex);
+    if (script?.computedHash !== target.scriptHash) {
+      throw new Error(
+        `Captured script hash mismatch for ${target.name}: expected=${target.scriptHash},actual=${script?.computedHash ?? "missing"}`,
+      );
+    }
+  }
+};
+
+export const captureSignedTxPreSubmit = async ({
+  signedTxCbor,
+  txHash,
+  walletAddress,
+  label,
+  capture,
+  batch,
+}: {
+  readonly signedTxCbor: string;
+  readonly txHash: string;
+  readonly walletAddress: string;
+  readonly label?: string;
+  readonly capture: SignedTxPreSubmitCapture;
+  readonly batch: SignedTxPreSubmitBatchContext;
+}): Promise<CapturedSignedTxNotSubmitted> => {
+  await assertPreparedCaptureDirectory(capture);
+  assertBatchContext(batch);
+  if ((await readdir(capture.outputDirectory)).includes("COMPLETE.json")) {
+    throw new Error("Pre-submit capture directory is already complete");
+  }
+  if (!/^[0-9a-f]+$/i.test(signedTxCbor) || signedTxCbor.length % 2 !== 0) {
+    throw new Error(
+      "Signed transaction CBOR must be an even-length hexadecimal string",
+    );
+  }
+  const bytes = Buffer.from(signedTxCbor, "hex");
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const tx = inspectTransaction(signedTxCbor);
+  if (tx.bodyHash !== txHash) {
+    throw new Error(
+      `Signed transaction body hash ${tx.bodyHash} does not match precomputed txHash ${txHash}`,
+    );
+  }
+  assertBatchMatchesSignedTransaction(tx, batch, walletAddress);
+  assertInspectedScriptsValid(tx, batch);
+  const captureBasename = `signed-${txHash}.cbor`;
+  const cborPath = join(capture.outputDirectory, captureBasename);
+  const metadataPath = join(capture.outputDirectory, `${captureBasename}.json`);
+  const payloads: Array<{
+    readonly targetName: string;
+    readonly outputIndex: number;
+    readonly languageTag?: number;
+    readonly cmlType: string;
+    readonly computedHash: string;
+    readonly payloadPath: string;
+    readonly payloadSha256: string;
+    readonly payloadBytes: number;
+    readonly payload: Buffer;
+  }> = [];
+  for (const target of batch.targets) {
+    const script = tx.bodyScriptRefs.find(
+      (candidate) =>
+        inspectedScriptOutputIndex(candidate) === target.outputIndex,
+    )!;
+    const payloadBytes = Buffer.from(script.rawHex, "hex");
+    const payloadSha256 = createHash("sha256")
+      .update(payloadBytes)
+      .digest("hex");
+    const payloadPath = join(
+      capture.outputDirectory,
+      `payload-${txHash}-${target.outputIndex.toString()}.cbor`,
+    );
+    payloads.push({
+      targetName: target.name,
+      outputIndex: target.outputIndex,
+      languageTag: script.languageTag,
+      cmlType: script.cmlType,
+      computedHash: script.computedHash!,
+      payloadPath,
+      payloadSha256,
+      payloadBytes: payloadBytes.length,
+      payload: payloadBytes,
+    });
+  }
+  const metadata = {
+    schemaVersion: 2,
+    status: "captured_not_submitted",
+    capturedAt: new Date().toISOString(),
+    invocation: capture.invocation,
+    abortBeforeSubmit: true,
+    txHash,
+    signedTxSha256: sha256,
+    cborBytes: bytes.length,
+    walletAddress,
+    label,
+    session: capture.session,
+    batch,
+    outputs: {
+      referenceScripts: batch.targets.map(
+        ({ name, scriptHash, outputIndex }) => ({
+          targetName: name,
+          scriptHash,
+          outputIndex,
+          outRef: `${txHash}#${outputIndex.toString()}`,
+        }),
+      ),
+      walletChange: batch.walletChangeOutputIndexes.map((outputIndex) => ({
+        outputIndex,
+        outRef: `${txHash}#${outputIndex.toString()}`,
+      })),
+    },
+    payloads: payloads.map(({ payload: _, ...entry }) => entry),
+    cborPath,
+    ...{
+      ...tx,
+      bodyScriptRefs: tx.bodyScriptRefs.map(
+        ({ rawHex: _, ...script }) => script,
+      ),
+      witnessScripts: tx.witnessScripts.map(
+        ({ rawHex: _, ...script }) => script,
+      ),
+    },
+  };
+  for (let index = 0; index < payloads.length; index += 1) {
+    await writePrivateFileAtomic(
+      payloads[index]!.payloadPath,
+      payloads[index]!.payload,
+    );
+  }
+  await writePrivateFileAtomic(cborPath, bytes);
+  // Keep the CBOR if metadata persistence fails: it is the primary forensic artifact.
+  await writePrivateFileAtomic(
+    metadataPath,
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
+  await syncDirectory(capture.outputDirectory);
+  return {
+    status: "captured_not_submitted",
+    txHash,
+    signedTxCbor,
+    walletAddress,
+    cborPath,
+    metadataPath,
+  };
+};
+
+type PersistedCaptureMetadata = {
+  readonly schemaVersion: 2;
+  readonly status: "captured_not_submitted";
+  readonly invocation: "phase4-live-pre-submit-capture";
+  readonly abortBeforeSubmit: true;
+  readonly txHash: string;
+  readonly bodyHash: string;
+  readonly bodyInputs: readonly string[];
+  readonly outputCount: number;
+  readonly outputAddresses: readonly string[];
+  readonly signerKeyHashes: readonly string[];
+  readonly signedTxSha256: string;
+  readonly cborPath: string;
+  readonly walletAddress: string;
+  readonly session: SignedTxPreSubmitCapture["session"];
+  readonly batch: SignedTxPreSubmitBatchContext;
+  readonly outputs: {
+    readonly referenceScripts: readonly {
+      readonly targetName: string;
+      readonly scriptHash: string;
+      readonly outputIndex: number;
+      readonly outRef: string;
+    }[];
+    readonly walletChange: readonly {
+      readonly outputIndex: number;
+      readonly outRef: string;
+    }[];
+  };
+  readonly payloads: readonly {
+    readonly targetName: string;
+    readonly outputIndex: number;
+    readonly languageTag?: number;
+    readonly cmlType: string;
+    readonly computedHash: string;
+    readonly payloadPath: string;
+    readonly payloadSha256: string;
+    readonly payloadBytes: number;
+  }[];
+};
+
+const readCaptureMetadata = async (
+  path: string,
+): Promise<PersistedCaptureMetadata> => {
+  await assertPrivateRegularFile(path);
+  const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { schemaVersion?: unknown }).schemaVersion !== 2 ||
+    (parsed as { status?: unknown }).status !== "captured_not_submitted" ||
+    (parsed as { abortBeforeSubmit?: unknown }).abortBeforeSubmit !== true ||
+    (parsed as { invocation?: unknown }).invocation !==
+      "phase4-live-pre-submit-capture"
+  ) {
+    throw new Error(`Invalid pre-submit capture metadata: ${path}`);
+  }
+  return parsed as PersistedCaptureMetadata;
+};
+
+export const finalizeSignedTxPreSubmitCapture = async ({
+  capture,
+  expectedTargetNames,
+}: {
+  readonly capture: SignedTxPreSubmitCapture;
+  readonly expectedTargetNames: readonly string[];
+}): Promise<SignedTxPreSubmitCaptureComplete> => {
+  await assertPreparedCaptureDirectory(capture);
+  if (
+    expectedTargetNames.length === 0 ||
+    new Set(expectedTargetNames).size !== expectedTargetNames.length
+  ) {
+    throw new Error(
+      "Pre-submit capture completion requires unique expected targets",
+    );
+  }
+  const entries = await readdir(capture.outputDirectory);
+  if (entries.includes("COMPLETE.json")) {
+    throw new Error("Pre-submit capture directory is already complete");
+  }
+  const metadataPaths = entries
+    .filter((entry) => /^signed-[0-9a-f]{64}\.cbor\.json$/i.test(entry))
+    .sort()
+    .map((entry) => join(capture.outputDirectory, entry));
+  if (metadataPaths.length === 0) {
+    throw new Error("Pre-submit capture has no captured transactions");
+  }
+  const metadata = await Promise.all(metadataPaths.map(readCaptureMetadata));
+  const seenTxHashes = new Set<string>();
+  const seenOrdinals = new Set<number>();
+  const targetCounts = new Map<string, number>();
+  const completeCaptures = [];
+  for (let index = 0; index < metadata.length; index += 1) {
+    const entry = metadata[index]!;
+    assertBatchContext(entry.batch);
+    if (!sameSession(entry.session, capture.session)) {
+      throw new Error(
+        `Pre-submit capture session mismatch in ${metadataPaths[index]}`,
+      );
+    }
+    if (
+      !/^[0-9a-f]{64}$/i.test(entry.txHash) ||
+      entry.bodyHash !== entry.txHash ||
+      metadataPaths[index] !==
+        join(capture.outputDirectory, `signed-${entry.txHash}.cbor.json`) ||
+      seenTxHashes.has(entry.txHash) ||
+      seenOrdinals.has(entry.batch.ordinal)
+    ) {
+      throw new Error(
+        `Pre-submit capture has invalid or duplicate transaction identity in ${metadataPaths[index]}`,
+      );
+    }
+    seenTxHashes.add(entry.txHash);
+    seenOrdinals.add(entry.batch.ordinal);
+    await assertPrivateRegularFile(entry.cborPath);
+    const signedBytes = await readFile(entry.cborPath);
+    const expectedCborPath = join(
+      capture.outputDirectory,
+      `signed-${entry.txHash}.cbor`,
+    );
+    if (
+      entry.cborPath !== expectedCborPath ||
+      createHash("sha256").update(signedBytes).digest("hex") !==
+        entry.signedTxSha256
+    ) {
+      throw new Error(
+        `Pre-submit capture signed CBOR hash/path mismatch for ${entry.txHash}`,
+      );
+    }
+    const reinspected = inspectTransaction(signedBytes.toString("hex"));
+    if (reinspected.bodyHash !== entry.txHash) {
+      throw new Error(
+        `Pre-submit capture body hash changed before completion for ${entry.txHash}`,
+      );
+    }
+    assertBatchMatchesSignedTransaction(
+      reinspected,
+      entry.batch,
+      entry.walletAddress,
+    );
+    if (
+      JSON.stringify(reinspected.bodyInputs) !==
+        JSON.stringify(entry.bodyInputs) ||
+      reinspected.outputCount !== entry.outputCount ||
+      JSON.stringify(reinspected.outputAddresses) !==
+        JSON.stringify(entry.outputAddresses) ||
+      JSON.stringify(reinspected.signerKeyHashes) !==
+        JSON.stringify(entry.signerKeyHashes)
+    ) {
+      throw new Error(
+        `Pre-submit capture transaction structure metadata changed for ${entry.txHash}`,
+      );
+    }
+    assertInspectedScriptsValid(reinspected, entry.batch);
+    if (
+      entry.payloads.length !== entry.batch.targets.length ||
+      entry.outputs.referenceScripts.length !== entry.batch.targets.length ||
+      entry.outputs.walletChange.length !==
+        entry.batch.walletChangeOutputIndexes.length ||
+      entry.batch.walletChangeOutputIndexes.some((outputIndex) =>
+        entry.outputs.walletChange.every(
+          (output) =>
+            output.outputIndex !== outputIndex ||
+            output.outRef !== `${entry.txHash}#${outputIndex.toString()}`,
+        ),
+      )
+    ) {
+      throw new Error(
+        `Pre-submit capture payload/output coverage mismatch for ${entry.txHash}`,
+      );
+    }
+    for (const target of entry.batch.targets) {
+      targetCounts.set(target.name, (targetCounts.get(target.name) ?? 0) + 1);
+      const payload = entry.payloads.find(
+        (candidate) =>
+          candidate.targetName === target.name &&
+          candidate.outputIndex === target.outputIndex,
+      );
+      const output = entry.outputs.referenceScripts.find(
+        (candidate) =>
+          candidate.targetName === target.name &&
+          candidate.outputIndex === target.outputIndex,
+      );
+      if (
+        payload === undefined ||
+        output === undefined ||
+        payload.computedHash !== target.scriptHash ||
+        output.scriptHash !== target.scriptHash ||
+        output.outRef !== `${entry.txHash}#${target.outputIndex.toString()}` ||
+        payload.payloadPath !==
+          join(
+            capture.outputDirectory,
+            `payload-${entry.txHash}-${target.outputIndex.toString()}.cbor`,
+          )
+      ) {
+        throw new Error(
+          `Pre-submit capture target identity mismatch for ${target.name}`,
+        );
+      }
+      await assertPrivateRegularFile(payload.payloadPath);
+      const payloadBytes = await readFile(payload.payloadPath);
+      const reinspectedScript = reinspected.bodyScriptRefs.find(
+        (candidate) =>
+          inspectedScriptOutputIndex(candidate) === target.outputIndex,
+      )!;
+      if (
+        payloadBytes.length !== payload.payloadBytes ||
+        createHash("sha256").update(payloadBytes).digest("hex") !==
+          payload.payloadSha256 ||
+        payloadBytes.toString("hex") !== reinspectedScript.rawHex
+      ) {
+        throw new Error(
+          `Pre-submit capture payload hash mismatch for ${target.name}`,
+        );
+      }
+    }
+    completeCaptures.push({
+      ordinal: entry.batch.ordinal,
+      plannedBatchIndex: entry.batch.plannedBatchIndex,
+      splitPath: entry.batch.splitPath,
+      txHash: entry.txHash,
+      signedTxSha256: entry.signedTxSha256,
+      cborPath: entry.cborPath,
+      inputs: entry.batch.inputs,
+      outputs: entry.outputs,
+      targets: entry.batch.targets.map((target) => {
+        const payload = entry.payloads.find(
+          (candidate) => candidate.targetName === target.name,
+        )!;
+        return {
+          ...target,
+          languageTag: payload.languageTag,
+          cmlType: payload.cmlType,
+          payloadPath: payload.payloadPath,
+          payloadSha256: payload.payloadSha256,
+          payloadBytes: payload.payloadBytes,
+        };
+      }),
+    });
+  }
+  const ordinals = [...seenOrdinals].sort((left, right) => left - right);
+  if (ordinals.some((ordinal, index) => ordinal !== index)) {
+    throw new Error("Pre-submit capture ordinals are not contiguous from zero");
+  }
+  const orderedMetadata = [...metadata].sort(
+    (left, right) => left.batch.ordinal - right.batch.ordinal,
+  );
+  const syntheticChangeProducer = new Map<string, number>();
+  for (const entry of orderedMetadata) {
+    for (const output of entry.outputs.walletChange) {
+      if (syntheticChangeProducer.has(output.outRef)) {
+        throw new Error(
+          `Pre-submit capture has duplicate synthetic change output ${output.outRef}`,
+        );
+      }
+      syntheticChangeProducer.set(output.outRef, entry.batch.ordinal);
+    }
+  }
+  const consumedInputs = new Set<string>();
+  for (const entry of orderedMetadata) {
+    for (const input of entry.batch.inputs) {
+      if (consumedInputs.has(input.outRef)) {
+        throw new Error(
+          `Pre-submit capture input is consumed by more than one batch: ${input.outRef}`,
+        );
+      }
+      consumedInputs.add(input.outRef);
+      const producerOrdinal = syntheticChangeProducer.get(input.outRef);
+      if (
+        input.lineage === "synthetic_change" &&
+        (producerOrdinal === undefined ||
+          producerOrdinal >= entry.batch.ordinal)
+      ) {
+        throw new Error(
+          `Pre-submit capture synthetic input is not an earlier wallet-change output: ${input.outRef}`,
+        );
+      }
+      if (input.lineage === "live_seed" && producerOrdinal !== undefined) {
+        throw new Error(
+          `Pre-submit capture live input is actually produced inside the capture bundle: ${input.outRef}`,
+        );
+      }
+    }
+  }
+  const expected = new Set(expectedTargetNames);
+  const missingOrDuplicate = expectedTargetNames.filter(
+    (name) => targetCounts.get(name) !== 1,
+  );
+  const unexpected = [...targetCounts.keys()].filter(
+    (name) => !expected.has(name),
+  );
+  if (missingOrDuplicate.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `Pre-submit capture target coverage is incomplete: missing_or_duplicate=[${missingOrDuplicate.join(",")}],unexpected=[${unexpected.join(",")}]`,
+    );
+  }
+  const expectedArtifactNames = new Set<string>([CAPTURE_SESSION_FILE]);
+  for (let index = 0; index < metadata.length; index += 1) {
+    const entry = metadata[index]!;
+    expectedArtifactNames.add(basename(metadataPaths[index]!));
+    expectedArtifactNames.add(basename(entry.cborPath));
+    for (const payload of entry.payloads) {
+      expectedArtifactNames.add(basename(payload.payloadPath));
+    }
+  }
+  const orphanedOrUnexpected = entries.filter(
+    (entry) => !expectedArtifactNames.has(entry),
+  );
+  const missingArtifacts = [...expectedArtifactNames].filter(
+    (entry) => !entries.includes(entry),
+  );
+  if (orphanedOrUnexpected.length > 0 || missingArtifacts.length > 0) {
+    throw new Error(
+      `Pre-submit capture artifact set is not exact: orphaned_or_unexpected=[${orphanedOrUnexpected.join(",")}],missing=[${missingArtifacts.join(",")}]`,
+    );
+  }
+  const completePath = join(capture.outputDirectory, "COMPLETE.json");
+  const complete = {
+    schemaVersion: 1 as const,
+    status: "complete" as const,
+    completedAt: new Date().toISOString(),
+    invocation: capture.invocation,
+    abortBeforeSubmit: true,
+    session: capture.session,
+    expectedTargetCount: expectedTargetNames.length,
+    captureCount: completeCaptures.length,
+    targetNames: [...expectedTargetNames],
+    captures: completeCaptures.sort(
+      (left, right) => left.ordinal - right.ordinal,
+    ),
+  };
+  await writePrivateFileAtomic(
+    completePath,
+    `${JSON.stringify(complete, null, 2)}\n`,
+  );
+  await syncDirectory(capture.outputDirectory);
+  return {
+    schemaVersion: 1,
+    status: "complete",
+    completePath,
+    expectedTargetCount: expectedTargetNames.length,
+    captureCount: completeCaptures.length,
+    targetNames: [...expectedTargetNames],
+  };
+};

--- a/demo/midgard-node/src/transactions/reference-scripts.ts
+++ b/demo/midgard-node/src/transactions/reference-scripts.ts
@@ -20,6 +20,9 @@ import { loadPhasMembershipWithdrawalScript } from "@/phas-membership.js";
 import { runProviderStepWithRetry } from "@/provider-retry.js";
 import {
   handleSignSubmit,
+  type SignedTxPreSubmitBatchContext,
+  type SignedTxPreSubmitCapture,
+  signTransactionForPreSubmitCapture,
   TxConfirmError,
   TxSignError,
   TxSubmitError,
@@ -1216,6 +1219,7 @@ const ensureReferenceScriptWalletWorkingCapital = (
   scopeName: string,
   requiredPlainBalance: bigint,
   reservedFundingOutRefKeys: ReadonlySet<string> = new Set<string>(),
+  preSubmitDiagnosticCapture?: SignedTxPreSubmitCapture,
 ): Effect.Effect<
   void,
   | SDK.StateQueueError
@@ -1241,6 +1245,18 @@ const ensureReferenceScriptWalletWorkingCapital = (
         : REFERENCE_SCRIPT_WALLET_WORKING_CAPITAL_LOVELACE;
     if (currentPlainBalance >= targetPlainBalance) {
       return;
+    }
+
+    if (preSubmitDiagnosticCapture !== undefined) {
+      return yield* Effect.fail(
+        new SDK.StateQueueError({
+          message:
+            "Pre-submit diagnostic capture refuses automatic reference-script wallet replenishment",
+          cause: `scope=${scopeName},current_plain_balance=${currentPlainBalance.toString()},required_plain_balance=${targetPlainBalance.toString()},top_up_lovelace=${(
+            targetPlainBalance - currentPlainBalance
+          ).toString()},abort_before_submit=${String(preSubmitDiagnosticCapture.abortBeforeSubmit)}`,
+        }),
+      );
     }
 
     const referenceScriptAddress = yield* Effect.tryPromise({
@@ -1333,6 +1349,19 @@ const ensureReferenceScriptWalletWorkingCapital = (
     );
   });
 
+type ReferenceScriptDiagnosticPublicationContext = {
+  readonly capture: SignedTxPreSubmitCapture;
+  readonly ordinal: number;
+  readonly plannedBatchIndex: number;
+  readonly splitPath: string;
+  readonly syntheticOutRefKeys: ReadonlySet<string>;
+  readonly updateWalletShadow: (args: {
+    readonly walletUtxos: readonly UTxO[];
+    readonly spentFundingInputs: readonly UTxO[];
+    readonly txHash: string;
+  }) => void;
+};
+
 const publishMissingReferenceScriptTargets = (
   lucid: LucidEvolution,
   walletAddress: string,
@@ -1341,6 +1370,7 @@ const publishMissingReferenceScriptTargets = (
   fundingCandidateUtxos: readonly UTxO[],
   missingTargets: readonly ReferenceScriptTarget[],
   authPolicy: ReferenceScriptAuthMintingPolicy,
+  diagnostic?: ReferenceScriptDiagnosticPublicationContext,
 ): Effect.Effect<
   readonly ReferenceScriptResolved[],
   | SDK.StateQueueError
@@ -1384,11 +1414,83 @@ const publishMissingReferenceScriptTargets = (
                   missingTargets,
                   authPolicy,
                 });
-              const txHash = yield* handleSignSubmit(
-                lucid,
-                unsigned,
-                REFERENCE_SCRIPT_CONFIRMATION_OPTIONS,
-              );
+              const label = `reference-script publication: ${missingTargets
+                .map(({ name }) => name)
+                .join(", ")}`;
+              const txHash =
+                diagnostic === undefined
+                  ? yield* handleSignSubmit(
+                      lucid,
+                      unsigned,
+                      REFERENCE_SCRIPT_CONFIRMATION_OPTIONS,
+                    )
+                  : yield* Effect.gen(function* () {
+                      const targets = yield* Effect.forEach(
+                        missingTargets,
+                        (target) => {
+                          const output = layout.localReferenceOutputs.get(
+                            target.name,
+                          );
+                          return output === undefined
+                            ? Effect.fail(
+                                new SDK.StateQueueError({
+                                  message:
+                                    "Diagnostic reference-script transaction layout is missing a target output",
+                                  cause: target.name,
+                                }),
+                              )
+                            : Effect.succeed({
+                                name: target.name,
+                                scriptHash: validatorToScriptHash(
+                                  target.script,
+                                ),
+                                outputIndex: output.outputIndex,
+                              });
+                        },
+                      );
+                      const batch: SignedTxPreSubmitBatchContext = {
+                        ordinal: diagnostic.ordinal,
+                        plannedBatchIndex: diagnostic.plannedBatchIndex,
+                        splitPath: diagnostic.splitPath,
+                        targets,
+                        inputs: selectedFundingInputs.map((utxo) => ({
+                          outRef: utxoOutRefKey(utxo),
+                          lineage: diagnostic.syntheticOutRefKeys.has(
+                            utxoOutRefKey(utxo),
+                          )
+                            ? ("synthetic_change" as const)
+                            : ("live_seed" as const),
+                        })),
+                        walletChangeOutputIndexes: layout.walletOutputs
+                          .map(({ outputIndex }) => outputIndex)
+                          .filter(
+                            (outputIndex) =>
+                              !targets.some(
+                                (target) => target.outputIndex === outputIndex,
+                              ),
+                          ),
+                      };
+                      const captured =
+                        yield* signTransactionForPreSubmitCapture(
+                          lucid,
+                          unsigned,
+                          {
+                            capture: diagnostic.capture,
+                            batch,
+                            label,
+                          },
+                        );
+                      if (captured.status !== "captured_not_submitted") {
+                        return yield* Effect.fail(
+                          new SDK.StateQueueError({
+                            message:
+                              "Diagnostic reference-script publication returned an unexpected submit outcome",
+                            cause: String(captured),
+                          }),
+                        );
+                      }
+                      return captured.txHash;
+                    });
               return [
                 txHash,
                 layout.localReferenceOutputs,
@@ -1442,6 +1544,15 @@ const publishMissingReferenceScriptTargets = (
       })),
     ];
     yield* Effect.sync(() => lucid.overrideUTxOs(restoredWalletUtxos));
+    if (diagnostic !== undefined) {
+      yield* Effect.sync(() =>
+        diagnostic.updateWalletShadow({
+          walletUtxos: restoredWalletUtxos,
+          spentFundingInputs: selectedFundingInputs,
+          txHash,
+        }),
+      );
+    }
     return yield* Effect.forEach(missingTargets, (target) =>
       Effect.gen(function* () {
         const localReferenceOutput = localReferenceOutputs.get(target.name);
@@ -1458,6 +1569,15 @@ const publishMissingReferenceScriptTargets = (
           txHash,
           ...localReferenceOutput,
         };
+        if (diagnostic !== undefined) {
+          return {
+            name: target.name,
+            utxo: {
+              ...localReferenceUtxo,
+              scriptRef: target.script,
+            },
+          };
+        }
         const liveReference = yield* Effect.either(
           resolveLiveWalletUtxo(lucid, localReferenceUtxo),
         );
@@ -1800,6 +1920,7 @@ export const ensureReferenceScriptTargetsProgram = (
   configuredReferenceScriptsAddress?: string,
   minAuthPolicyRemainingMs: number = REFERENCE_SCRIPT_AUTH_MIN_REMAINING_MS,
   reservedFundingOutRefKeys: ReadonlySet<string> = new Set<string>(),
+  preSubmitDiagnosticCapture?: SignedTxPreSubmitCapture,
 ): Effect.Effect<
   readonly ReferenceScriptResolved[],
   | SDK.StateQueueError
@@ -1809,6 +1930,20 @@ export const ensureReferenceScriptTargetsProgram = (
   | TxSubmitError
 > =>
   Effect.gen(function* () {
+    if (
+      preSubmitDiagnosticCapture !== undefined &&
+      (preSubmitDiagnosticCapture.session.commandName !== scopeName ||
+        preSubmitDiagnosticCapture.session.referenceScriptAuthPolicyId !==
+          authPolicy.policyId)
+    ) {
+      return yield* Effect.fail(
+        new SDK.StateQueueError({
+          message:
+            "Pre-submit diagnostic capture session does not match the reference-script command or auth policy",
+          cause: `capture_command=${preSubmitDiagnosticCapture.session.commandName},scope=${scopeName},capture_auth_policy=${preSubmitDiagnosticCapture.session.referenceScriptAuthPolicyId},resolved_auth_policy=${authPolicy.policyId}`,
+        }),
+      );
+    }
     const walletAddress = yield* Effect.tryPromise({
       try: () => referenceScriptsLucid.wallet().address(),
       catch: (cause) =>
@@ -1819,14 +1954,28 @@ export const ensureReferenceScriptTargetsProgram = (
     });
     const referenceScriptsAddress =
       configuredReferenceScriptsAddress ?? walletAddress;
+    let diagnosticWalletShadow: readonly UTxO[] | undefined;
+    let diagnosticSyntheticOutRefKeys = new Set<string>();
+    let diagnosticCaptureOrdinal = 0;
     const fetchReferenceScriptWalletUtxos = (): Effect.Effect<
       readonly UTxO[],
       SDK.StateQueueError
     > =>
-      refreshWalletUtxosFromOwnAddress(referenceScriptsLucid, {
-        scopeName: `${scopeName} reference scripts`,
-        failureMessage: `Failed to fetch wallet UTxOs while resolving ${scopeName} reference scripts`,
-      });
+      preSubmitDiagnosticCapture !== undefined &&
+      diagnosticWalletShadow !== undefined
+        ? Effect.succeed(diagnosticWalletShadow)
+        : refreshWalletUtxosFromOwnAddress(referenceScriptsLucid, {
+            scopeName: `${scopeName} reference scripts`,
+            failureMessage: `Failed to fetch wallet UTxOs while resolving ${scopeName} reference scripts`,
+          }).pipe(
+            Effect.tap((utxos) =>
+              preSubmitDiagnosticCapture === undefined
+                ? Effect.void
+                : Effect.sync(() => {
+                    diagnosticWalletShadow = utxos;
+                  }),
+            ),
+          );
     const fetchReferenceScriptPublicationUtxos = (): Effect.Effect<
       readonly UTxO[],
       SDK.StateQueueError
@@ -1843,6 +1992,8 @@ export const ensureReferenceScriptTargetsProgram = (
     const publishMissingTargetsInBatches = (
       missingTargets: readonly ReferenceScriptTarget[],
       ensureWorkingCapital: boolean,
+      plannedBatchIndex: number,
+      splitPath: string,
     ): Effect.Effect<
       readonly ReferenceScriptResolved[],
       | SDK.StateQueueError
@@ -1874,13 +2025,17 @@ export const ensureReferenceScriptTargetsProgram = (
         let requiredPlainBalance =
           resolveReferenceScriptPublicationFundingTarget(missingTargets.length);
         while (true) {
-          if (ensureWorkingCapital) {
+          if (
+            ensureWorkingCapital &&
+            preSubmitDiagnosticCapture === undefined
+          ) {
             yield* ensureReferenceScriptWalletWorkingCapital(
               fundingLucid,
               referenceScriptsLucid,
               scopeName,
               requiredPlainBalance,
               reservedFundingOutRefKeys,
+              preSubmitDiagnosticCapture,
             );
           }
           const walletUtxos = yield* fetchReferenceScriptWalletUtxos();
@@ -1927,6 +2082,35 @@ export const ensureReferenceScriptTargetsProgram = (
               plainFundingCandidateUtxos,
               missingTargets,
               authPolicy,
+              preSubmitDiagnosticCapture === undefined
+                ? undefined
+                : {
+                    capture: preSubmitDiagnosticCapture,
+                    ordinal: diagnosticCaptureOrdinal,
+                    plannedBatchIndex,
+                    splitPath,
+                    syntheticOutRefKeys: diagnosticSyntheticOutRefKeys,
+                    updateWalletShadow: ({
+                      walletUtxos,
+                      spentFundingInputs,
+                      txHash,
+                    }) => {
+                      const nextSynthetic = new Set(
+                        diagnosticSyntheticOutRefKeys,
+                      );
+                      for (const spent of spentFundingInputs) {
+                        nextSynthetic.delete(utxoOutRefKey(spent));
+                      }
+                      for (const utxo of walletUtxos) {
+                        if (utxo.txHash === txHash) {
+                          nextSynthetic.add(utxoOutRefKey(utxo));
+                        }
+                      }
+                      diagnosticSyntheticOutRefKeys = nextSynthetic;
+                      diagnosticWalletShadow = walletUtxos;
+                      diagnosticCaptureOrdinal += 1;
+                    },
+                  },
             ),
           );
           if (publishAttempt._tag === "Right") {
@@ -1977,16 +2161,23 @@ export const ensureReferenceScriptTargetsProgram = (
           const leftPublications = yield* publishMissingTargetsInBatches(
             leftTargets,
             ensureWorkingCapital,
+            plannedBatchIndex,
+            `${splitPath}.L`,
           );
           const rightPublications = yield* publishMissingTargetsInBatches(
             rightTargets,
             ensureWorkingCapital,
+            plannedBatchIndex,
+            `${splitPath}.R`,
           );
           return [...leftPublications, ...rightPublications];
         }
       });
 
-    const walletUtxos = yield* fetchReferenceScriptPublicationUtxos();
+    const walletUtxos =
+      preSubmitDiagnosticCapture === undefined
+        ? yield* fetchReferenceScriptPublicationUtxos()
+        : [];
     const existingPublications = yield* Effect.forEach(targets, (target) =>
       resolveExistingReferenceScriptPublication(
         referenceScriptsLucid,
@@ -2018,13 +2209,27 @@ export const ensureReferenceScriptTargetsProgram = (
       yield* Effect.logInfo(
         `Reference-script deployment plan for ${scopeName}: existing=${deploymentPlan.existingTargetNames.length.toString()},missing=${deploymentPlan.missingTargetNames.length.toString()},batches=${deploymentPlan.batches.length.toString()},submit_count=${deploymentPlan.submitCount.toString()},current_plain_lovelace=${deploymentPlan.currentPlainBalance.toString()},required_plain_lovelace=${deploymentPlan.requiredPlainBalance.toString()},top_up_lovelace=${deploymentPlan.topUpLovelace.toString()},max_targets_per_batch=${deploymentPlan.maxTargetsPerBatch.toString()}`,
       );
-      yield* ensureReferenceScriptWalletWorkingCapital(
-        fundingLucid,
-        referenceScriptsLucid,
-        scopeName,
-        deploymentPlan.requiredPlainBalance,
-        reservedFundingOutRefKeys,
-      );
+      if (
+        preSubmitDiagnosticCapture !== undefined &&
+        deploymentPlan.topUpLovelace > 0n
+      ) {
+        return yield* Effect.fail(
+          new SDK.StateQueueError({
+            message:
+              "Pre-submit diagnostic capture refuses automatic reference-script wallet replenishment",
+            cause: `scope=${scopeName},current_plain_balance=${deploymentPlan.currentPlainBalance.toString()},required_plain_balance=${deploymentPlan.requiredPlainBalance.toString()},top_up_lovelace=${deploymentPlan.topUpLovelace.toString()},abort_before_submit=true`,
+          }),
+        );
+      }
+      if (preSubmitDiagnosticCapture === undefined) {
+        yield* ensureReferenceScriptWalletWorkingCapital(
+          fundingLucid,
+          referenceScriptsLucid,
+          scopeName,
+          deploymentPlan.requiredPlainBalance,
+          reservedFundingOutRefKeys,
+        );
+      }
       const created: ReferenceScriptResolved[] = [];
       for (const batch of deploymentPlan.batches) {
         const batchTargetNames = new Set(batch.targetNames);
@@ -2035,7 +2240,12 @@ export const ensureReferenceScriptTargetsProgram = (
           `Publishing planned reference-script batch for ${scopeName}: batch_index=${batch.batchIndex.toString()},target_count=${batch.targetCount.toString()},targets=[${batch.targetNames.join(",")}]`,
         );
         created.push(
-          ...(yield* publishMissingTargetsInBatches(batchTargets, true)),
+          ...(yield* publishMissingTargetsInBatches(
+            batchTargets,
+            true,
+            batch.batchIndex,
+            `batch-${batch.batchIndex.toString()}`,
+          )),
         );
       }
       createdByName = new Map(
@@ -2068,6 +2278,7 @@ export const deployReferenceScriptCommandProgram = (
   referenceScriptsAddress?: string,
   minAuthPolicyRemainingMs: number = REFERENCE_SCRIPT_AUTH_MIN_REMAINING_MS,
   reservedFundingOutRefKeys: ReadonlySet<string> = new Set<string>(),
+  preSubmitDiagnosticCapture?: SignedTxPreSubmitCapture,
 ): Effect.Effect<
   readonly ReferenceScriptResolved[],
   | SDK.StateQueueError
@@ -2085,6 +2296,7 @@ export const deployReferenceScriptCommandProgram = (
     referenceScriptsAddress,
     minAuthPolicyRemainingMs,
     reservedFundingOutRefKeys,
+    preSubmitDiagnosticCapture,
   );
 
 export const planReferenceScriptCommandProgram = (

--- a/demo/midgard-node/src/transactions/utils.ts
+++ b/demo/midgard-node/src/transactions/utils.ts
@@ -20,6 +20,17 @@ import {
 } from "@/local-ledger-slot.js";
 import { Database } from "@/services/index.js";
 import {
+  type CapturedSignedTxNotSubmitted,
+  captureSignedTxPreSubmit,
+  type SignedTxPreSubmitBatchContext,
+  type SignedTxPreSubmitCapture,
+} from "@/transactions/pre-submit-capture.js";
+export type {
+  CapturedSignedTxNotSubmitted,
+  SignedTxPreSubmitBatchContext,
+  SignedTxPreSubmitCapture,
+} from "@/transactions/pre-submit-capture.js";
+import {
   type InlineWaitPolicy,
   planSubmitTiming,
   planSubmitTimingAfterInlineWait,
@@ -392,6 +403,12 @@ export type SignSubmitContext = {
   readonly walletAddress: string;
 };
 
+export type CaptureSignedTransactionOptions = {
+  readonly capture: SignedTxPreSubmitCapture;
+  readonly batch: SignedTxPreSubmitBatchContext;
+  readonly label?: string;
+};
+
 /**
  * Formats an outref into a stable map key.
  */
@@ -477,6 +494,8 @@ export type SubmitRecoveryInlineOptions = {
   readonly confirmationPollIntervalMs?: number;
   readonly inlineWaitPolicy?: Extract<InlineWaitPolicy, "allow_inline_wait">;
   readonly noInlineSubmitDefer?: never;
+  /** Explicit diagnostic mode. It always aborts before provider submit. */
+  readonly preSubmitDiagnosticCapture?: SignedTxPreSubmitCapture;
 };
 
 export type NoInlineSubmitDeferKind =
@@ -1399,6 +1418,59 @@ export function signSubmitTransaction(
   return signSubmitTransactionWithDefer(lucid, signBuilder, options);
 }
 
+/**
+ * Signs and durably captures one explicitly described reference-script
+ * publication transaction. This function has no provider submit or
+ * confirmation branch; callers must handle the captured-not-submitted result.
+ */
+export const signTransactionForPreSubmitCapture = (
+  lucid: LucidEvolution,
+  signBuilder: TxSignBuilder,
+  options: CaptureSignedTransactionOptions,
+): Effect.Effect<CapturedSignedTxNotSubmitted, TxSubmitError | TxSignError> =>
+  Effect.gen(function* () {
+    const walletAddr = yield* Effect.tryPromise(() =>
+      lucid.wallet().address(),
+    ).pipe(Effect.catchAll(() => Effect.succeed("<unknown>")));
+    yield* Effect.logInfo(`✍  Signing diagnostic tx with ${walletAddr}`);
+    const txHash = signBuilder.toHash();
+    const signed = yield* signBuilder.sign
+      .withWallet()
+      .completeProgram()
+      .pipe(
+        Effect.tapError((error) => Effect.logError(error)),
+        Effect.mapError(
+          (cause) =>
+            new TxSignError({
+              message: "Failed to sign diagnostic transaction",
+              cause,
+              txHash,
+            }),
+        ),
+      );
+    const signedTxCbor = signed.toCBOR();
+    yield* Effect.logInfo(
+      `✍  Signed diagnostic tx prepared: txHash=${txHash}, cborBytes=${signedTxCbor.length / 2}`,
+    );
+    return yield* Effect.tryPromise({
+      try: () =>
+        captureSignedTxPreSubmit({
+          signedTxCbor,
+          txHash,
+          walletAddress: walletAddr,
+          label: options.label,
+          capture: options.capture,
+          batch: options.batch,
+        }),
+      catch: (cause) =>
+        new TxSubmitError({
+          message: `Pre-submit diagnostic capture failed closed: ${formatUnknownError(cause, { includeCause: true })}`,
+          cause,
+          txHash,
+        }),
+    });
+  });
+
 const signSubmitTransactionWithDefer = (
   lucid: LucidEvolution,
   signBuilder: TxSignBuilder,
@@ -1408,6 +1480,16 @@ const signSubmitTransactionWithDefer = (
   TxSubmitError | TxSignError | NoInlineSubmitDefer
 > =>
   Effect.gen(function* () {
+    if (options.preSubmitDiagnosticCapture !== undefined) {
+      return yield* Effect.fail(
+        new TxSubmitError({
+          message:
+            "Generic submit helpers reject captured-not-submitted outcomes; use the explicit reference-script diagnostic capture path",
+          cause: "pre_submit_diagnostic_capture_not_supported_here",
+          txHash: signBuilder.toHash(),
+        }),
+      );
+    }
     const walletAddr = yield* Effect.tryPromise(() =>
       lucid.wallet().address(),
     ).pipe(Effect.catchAll((_e) => Effect.succeed("<unknown>")));

--- a/demo/midgard-node/tests/pre-submit-capture.test.ts
+++ b/demo/midgard-node/tests/pre-submit-capture.test.ts
@@ -1,0 +1,842 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { parseUPLC } from "@harmoniclabs/uplc";
+import {
+  applyParamsToScript,
+  CML,
+  Constr,
+  Emulator,
+  fromText,
+  generateEmulatorAccount,
+  Lucid,
+  mintingPolicyToId,
+  validatorToScriptHash,
+} from "@lucid-evolution/lucid";
+import { Effect } from "effect";
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  assertPersistedSignedTxPreSubmitCaptureIdentity,
+  assertSignedTxPreSubmitCaptureCliSafety,
+  captureSignedTxPreSubmit,
+  finalizeSignedTxPreSubmitCapture,
+  prepareSignedTxPreSubmitCaptureDirectory,
+  type SignedTxPreSubmitBatchContext,
+  type SignedTxPreSubmitCapture,
+  validateLedgerSerializedFlat,
+} from "@/transactions/pre-submit-capture.js";
+import {
+  signSubmitTransaction,
+  signTransactionForPreSubmitCapture,
+} from "@/transactions/utils.js";
+
+const testTempRoot = resolve(import.meta.dirname, "../.tmp-pre-submit");
+const blueprintPath = resolve(
+  import.meta.dirname,
+  "../../../onchain/aiken/plutus.json",
+);
+
+const capture: SignedTxPreSubmitCapture = {
+  outputDirectory: "/tmp/unused",
+  invocation: "phase4-live-pre-submit-capture",
+  abortBeforeSubmit: true,
+  session: {
+    commandName: "node-runtime",
+    runStatePath: join(testTempRoot, "deployment-run-state.json"),
+    blueprintPath,
+    blueprintSha256: createHash("sha256")
+      .update(readFileSync(blueprintPath))
+      .digest("hex"),
+    network: "Preprod",
+    hubOracleOneShotOutRef: `${"22".repeat(32)}#0`,
+    referenceScriptAuthPolicyId: "33".repeat(28),
+  },
+};
+
+const matchingRunState = (target: SignedTxPreSubmitCapture = capture) => ({
+  schemaVersion: "midgard-deployment-run-state-v1",
+  identity: {
+    network: target.session.network,
+    hubOracleOneShot: {
+      txHash: target.session.hubOracleOneShotOutRef.split("#")[0],
+      outputIndex: Number(target.session.hubOracleOneShotOutRef.split("#")[1]),
+    },
+    referenceScriptAuthPolicyId: target.session.referenceScriptAuthPolicyId,
+    referenceScriptAuthPolicy: {
+      policyId: target.session.referenceScriptAuthPolicyId,
+    },
+  },
+});
+
+const freshCaptureDirectory = async (prefix: string): Promise<string> => {
+  await mkdir(testTempRoot, { recursive: true });
+  await writeFile(
+    capture.session.runStatePath,
+    JSON.stringify(matchingRunState()),
+  );
+  const outputDirectory = await mkdtemp(join(testTempRoot, prefix));
+  await rm(outputDirectory, { recursive: true });
+  await prepareSignedTxPreSubmitCaptureDirectory({
+    ...capture,
+    outputDirectory,
+  });
+  return outputDirectory;
+};
+
+const decodeDefiniteByteString = (cborHex: string): string | undefined => {
+  if (!/^[0-9a-f]+$/i.test(cborHex) || cborHex.length < 2) return undefined;
+  const first = Number.parseInt(cborHex.slice(0, 2), 16);
+  if (first >> 5 !== 2) return undefined;
+  const additional = first & 0x1f;
+  const lengthBytes =
+    additional < 24
+      ? 0
+      : additional >= 24 && additional <= 27
+        ? 2 ** (additional - 24)
+        : undefined;
+  if (lengthBytes === undefined) return undefined;
+  const headerBytes = 1 + lengthBytes;
+  if (cborHex.length < headerBytes * 2) return undefined;
+  const payloadBytes =
+    lengthBytes === 0
+      ? additional
+      : Number.parseInt(cborHex.slice(2, headerBytes * 2), 16);
+  if (!Number.isSafeInteger(payloadBytes)) return undefined;
+  const payloadHex = cborHex.slice(headerBytes * 2);
+  return payloadHex.length === payloadBytes * 2
+    ? payloadHex.toLowerCase()
+    : undefined;
+};
+
+describe("pre-submit signed transaction capture", () => {
+  afterAll(async () => {
+    await rm(testTempRoot, { recursive: true, force: true });
+  });
+  it("captures exact post-sign CBOR, reports script refs and Flat validity, and refuses submission", async () => {
+    const account = generateEmulatorAccount({ lovelace: 30_000_000n });
+    const lucid = await Lucid(new Emulator([account]), "Custom");
+    lucid.selectWallet.fromSeed(account.seedPhrase);
+    const blueprint = JSON.parse(readFileSync(blueprintPath, "utf8")) as {
+      validators: Array<{ title: string; compiledCode: string }>;
+    };
+    const compiled = blueprint.validators.find(
+      (validator) => validator.title === "hub_oracle.mint.mint",
+    )?.compiledCode;
+    if (compiled === undefined) throw new Error("missing hub oracle blueprint");
+    const oneShot = new Constr(0, [
+      "9e045c840775e7a879e73c336c74abf1c14b1201edeeeaa379dd59923e9aeb6b",
+      0n,
+    ]);
+    const parameterized = applyParamsToScript(compiled, [
+      oneShot,
+      fromText("MIDGARD_HUB_ORACLE"),
+    ]);
+    const ledgerScript = decodeDefiniteByteString(parameterized);
+    if (ledgerScript === undefined) {
+      throw new Error("parameterized hub oracle is not CBOR wrapped");
+    }
+    const policy = {
+      type: "PlutusV3" as const,
+      script: ledgerScript,
+    };
+    const nativePolicy = {
+      type: "Native" as const,
+      script:
+        CML.NativeScript.new_script_invalid_hereafter(999_999n).to_cbor_hex(),
+    };
+    const unit = `${mintingPolicyToId(nativePolicy)}00`;
+    const builder = await lucid
+      .newTx()
+      .mintAssets({ [unit]: 1n })
+      .attach.MintingPolicy(nativePolicy)
+      .attach.MintingPolicy(policy)
+      .pay.ToAddressWithData(
+        account.address,
+        undefined,
+        { lovelace: 2_000_000n },
+        policy,
+      )
+      .complete();
+    const signed = await Effect.runPromise(
+      builder.sign.withWallet().completeProgram(),
+    );
+    const signedTxCbor = signed.toCBOR();
+    const txHash = builder.toHash();
+    const normalizedFlat = decodeDefiniteByteString(policy.script);
+    expect(normalizedFlat).toBeDefined();
+    expect(decodeDefiniteByteString(normalizedFlat!)).toBeUndefined();
+    expect(() =>
+      parseUPLC(Buffer.from(policy.script, "hex"), "cbor"),
+    ).not.toThrow();
+    expect(() =>
+      parseUPLC(Buffer.from(normalizedFlat!, "hex"), "flat"),
+    ).not.toThrow();
+
+    const transaction = CML.Transaction.from_cbor_hex(signedTxCbor);
+    const signedInputs = transaction.body().inputs();
+    const outputs = transaction.body().outputs();
+    let cmlReferenceScript: CML.PlutusV3Script | undefined;
+    let referenceScriptOutputIndex: number | undefined;
+    for (let index = 0; index < outputs.len(); index += 1) {
+      const scriptRef = outputs.get(index).script_ref();
+      const plutusV3 = scriptRef?.as_plutus_v3();
+      if (plutusV3 !== undefined && plutusV3 !== null) {
+        cmlReferenceScript = plutusV3;
+        referenceScriptOutputIndex = index;
+        break;
+      }
+    }
+    expect(cmlReferenceScript).toBeDefined();
+    const ledgerPayloadHex = Buffer.from(
+      cmlReferenceScript!.to_raw_bytes(),
+    ).toString("hex");
+    const wireScriptHex = cmlReferenceScript!.to_cbor_hex();
+    expect(ledgerPayloadHex).toBe(policy.script);
+    expect(decodeDefiniteByteString(wireScriptHex)).toBe(policy.script);
+    expect(decodeDefiniteByteString(ledgerPayloadHex)).toBe(normalizedFlat);
+    expect(cmlReferenceScript!.hash().to_hex()).toBe(
+      validatorToScriptHash(policy),
+    );
+    expect(referenceScriptOutputIndex).toBeDefined();
+    const walletChangeOutputIndexes = Array.from(
+      { length: outputs.len() },
+      (_, outputIndex) => outputIndex,
+    ).filter((outputIndex) => outputIndex !== referenceScriptOutputIndex);
+    expect(walletChangeOutputIndexes.length).toBeGreaterThan(0);
+    const outputDirectory = await freshCaptureDirectory("capture-");
+    expect((await stat(outputDirectory)).mode & 0o777).toBe(0o700);
+    const batch: SignedTxPreSubmitBatchContext = {
+      ordinal: 0,
+      plannedBatchIndex: 0,
+      splitPath: "batch-0",
+      targets: [
+        {
+          name: "hub-oracle minting",
+          scriptHash: validatorToScriptHash(policy),
+          outputIndex: referenceScriptOutputIndex!,
+        },
+      ],
+      inputs: Array.from({ length: signedInputs.len() }, (_, index) => {
+        const input = signedInputs.get(index);
+        return {
+          outRef: `${input.transaction_id().to_hex()}#${Number(input.index()).toString()}`,
+          lineage: "live_seed" as const,
+        };
+      }),
+      walletChangeOutputIndexes,
+    };
+
+    let submitCalls = 0;
+    const fakeBuilder = {
+      toHash: () => txHash,
+      sign: {
+        withWallet: () => ({
+          completeProgram: () =>
+            Effect.succeed({
+              toCBOR: () => signedTxCbor,
+              submitProgram: () => {
+                submitCalls += 1;
+                return Effect.succeed(txHash);
+              },
+            }),
+        }),
+      },
+    } as never;
+    await expect(
+      Effect.runPromise(
+        signTransactionForPreSubmitCapture(lucid, fakeBuilder, {
+          capture: { ...capture, outputDirectory },
+          batch,
+        }),
+      ),
+    ).resolves.toMatchObject({ status: "captured_not_submitted", txHash });
+    expect(submitCalls).toBe(0);
+
+    const cborPath = resolve(outputDirectory, `signed-${txHash}.cbor`);
+    const metadataPath = `${cborPath}.json`;
+    expect((await readFile(cborPath)).toString("hex")).toBe(signedTxCbor);
+    const originalMetadataText = await readFile(metadataPath, "utf8");
+    const metadata = JSON.parse(originalMetadataText) as {
+      bodyHash: string;
+      signedTxSha256: string;
+      batch: SignedTxPreSubmitBatchContext;
+      bodyScriptRefs: Array<{
+        flatDecodeValid: boolean;
+        nestedCborLayers: { layerCount: number };
+      }>;
+      witnessScripts: Array<{ cmlType: string; flatDecodeValid?: boolean }>;
+      payloads: Array<{
+        targetName: string;
+        payloadPath: string;
+        payloadSha256: string;
+      }>;
+    };
+    expect(metadata.bodyHash).toBe(txHash);
+    expect(metadata.signedTxSha256).toBe(
+      createHash("sha256")
+        .update(Buffer.from(signedTxCbor, "hex"))
+        .digest("hex"),
+    );
+    expect(metadata.bodyScriptRefs).toHaveLength(1);
+    expect(metadata.bodyScriptRefs[0]?.nestedCborLayers.layerCount).toBe(2);
+    expect(metadata.bodyScriptRefs[0]?.flatDecodeValid).toBe(true);
+    expect(
+      metadata.witnessScripts.some(
+        (script) => script.cmlType === "NativeScript",
+      ),
+    ).toBe(true);
+    expect((await stat(cborPath)).mode & 0o777).toBe(0o600);
+    expect((await stat(metadataPath)).mode & 0o777).toBe(0o600);
+    expect(metadata.payloads).toHaveLength(1);
+    expect(metadata.payloads[0]?.targetName).toBe("hub-oracle minting");
+    const payloadBytes = await readFile(metadata.payloads[0]!.payloadPath);
+    expect((await stat(metadata.payloads[0]!.payloadPath)).mode & 0o777).toBe(
+      0o600,
+    );
+    expect(createHash("sha256").update(payloadBytes).digest("hex")).toBe(
+      metadata.payloads[0]?.payloadSha256,
+    );
+
+    await writeFile(
+      metadataPath,
+      `${JSON.stringify(
+        {
+          ...metadata,
+          batch: {
+            ...metadata.batch,
+            inputs: metadata.batch.inputs.map((input) => ({
+              ...input,
+              lineage: "synthetic_change",
+            })),
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await expect(
+      finalizeSignedTxPreSubmitCapture({
+        capture: { ...capture, outputDirectory },
+        expectedTargetNames: ["hub-oracle minting"],
+      }),
+    ).rejects.toThrow(/synthetic input is not an earlier wallet-change output/);
+    await writeFile(metadataPath, originalMetadataText);
+
+    const renamedMetadataPath = join(
+      outputDirectory,
+      `signed-${"aa".repeat(32)}.cbor.json`,
+    );
+    await rename(metadataPath, renamedMetadataPath);
+    await expect(
+      finalizeSignedTxPreSubmitCapture({
+        capture: { ...capture, outputDirectory },
+        expectedTargetNames: ["hub-oracle minting"],
+      }),
+    ).rejects.toThrow(/invalid or duplicate transaction identity/);
+    await rename(renamedMetadataPath, metadataPath);
+
+    const orphanPath = join(outputDirectory, "orphan-payload.cbor");
+    await writeFile(orphanPath, "orphan", { mode: 0o600 });
+    await expect(
+      finalizeSignedTxPreSubmitCapture({
+        capture: { ...capture, outputDirectory },
+        expectedTargetNames: ["hub-oracle minting"],
+      }),
+    ).rejects.toThrow(/artifact set is not exact/);
+    await rm(orphanPath);
+
+    await expect(
+      finalizeSignedTxPreSubmitCapture({
+        capture: { ...capture, outputDirectory },
+        expectedTargetNames: ["hub-oracle minting", "missing target"],
+      }),
+    ).rejects.toThrow(/coverage is incomplete/);
+    expect(await readdir(outputDirectory)).not.toContain("COMPLETE.json");
+
+    const complete = await finalizeSignedTxPreSubmitCapture({
+      capture: { ...capture, outputDirectory },
+      expectedTargetNames: ["hub-oracle minting"],
+    });
+    expect(complete).toMatchObject({
+      status: "complete",
+      expectedTargetCount: 1,
+      captureCount: 1,
+    });
+    expect((await stat(complete.completePath)).mode & 0o777).toBe(0o600);
+
+    await expect(
+      captureSignedTxPreSubmit({
+        signedTxCbor,
+        txHash,
+        walletAddress: account.address,
+        capture: { ...capture, outputDirectory },
+        batch,
+      }),
+    ).rejects.toThrow(/EEXIST|already exists|already complete/);
+  });
+
+  it("rejects a one-layer payload that the old direct Flat parse false-accepts", () => {
+    const falseGreenLedgerPayload = `5901e20160${"00".repeat(480)}`;
+    const falseGreenProgram = parseUPLC(
+      Buffer.from(falseGreenLedgerPayload, "hex"),
+      "flat",
+    );
+    expect(falseGreenProgram.version.toString()).toBe("89.1.226");
+
+    expect(() =>
+      validateLedgerSerializedFlat(falseGreenLedgerPayload, 3),
+    ).toThrow();
+  });
+
+  it("rejects missing, empty, extra, and malformed ledger CBOR layers", () => {
+    expect(() => validateLedgerSerializedFlat("010100", 3)).toThrow(
+      /exactly one definite CBOR byte-string layer/,
+    );
+    expect(() => validateLedgerSerializedFlat("40", 3)).toThrow(
+      /empty Flat program/,
+    );
+    expect(() => validateLedgerSerializedFlat("4140", 3)).toThrow(
+      /extra CBOR layer/,
+    );
+    expect(() => validateLedgerSerializedFlat("42010100", 3)).toThrow(
+      /trailing bytes/,
+    );
+    expect(() => validateLedgerSerializedFlat("4201", 3)).toThrow(
+      /exactly one definite CBOR byte-string layer/,
+    );
+  });
+
+  it("requires the language UPLC version and complete canonical Flat input", () => {
+    expect(() => validateLedgerSerializedFlat("4401010061", 3)).not.toThrow();
+    expect(() => validateLedgerSerializedFlat("4401000061", 2)).not.toThrow();
+    expect(() => validateLedgerSerializedFlat("4401000061", 3)).toThrow(
+      /unsupported UPLC version 1\.0\.0; expected 1\.1\.0/,
+    );
+    expect(() => validateLedgerSerializedFlat("450101006100", 3)).toThrow(
+      /did not consume the complete canonical program encoding/,
+    );
+    expect(() => validateLedgerSerializedFlat("4401010060", 3)).toThrow(
+      /did not consume the complete canonical program encoding/,
+    );
+  });
+
+  it("makes the generic submit path reject diagnostic capture instead of silently succeeding", async () => {
+    const account = generateEmulatorAccount({ lovelace: 30_000_000n });
+    const lucid = await Lucid(new Emulator([account]), "Custom");
+    lucid.selectWallet.fromSeed(account.seedPhrase);
+    const builder = await lucid
+      .newTx()
+      .pay.ToAddress(account.address, { lovelace: 2_000_000n })
+      .complete();
+    const signed = await Effect.runPromise(
+      builder.sign.withWallet().completeProgram(),
+    );
+    const signedTxCbor = signed.toCBOR();
+    const txHash = builder.toHash();
+    const outputDirectory = join(testTempRoot, "generic-rejected");
+    let submitCalls = 0;
+    const fakeBuilder = {
+      toHash: () => txHash,
+      sign: {
+        withWallet: () => ({
+          completeProgram: () =>
+            Effect.succeed({
+              toCBOR: () => signedTxCbor,
+              submitProgram: () => {
+                submitCalls += 1;
+                return Effect.succeed(txHash);
+              },
+            }),
+        }),
+      },
+    } as never;
+    try {
+      await expect(
+        Effect.runPromise(
+          signSubmitTransaction(lucid, fakeBuilder, {
+            preSubmitDiagnosticCapture: {
+              ...capture,
+              outputDirectory,
+            },
+          }),
+        ),
+      ).rejects.toThrow(/Generic submit helpers reject/);
+      expect(submitCalls).toBe(0);
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects body-hash mismatches before writing", async () => {
+    const account = generateEmulatorAccount({ lovelace: 10_000_000n });
+    const lucid = await Lucid(new Emulator([account]), "Custom");
+    lucid.selectWallet.fromSeed(account.seedPhrase);
+    const builder = await lucid
+      .newTx()
+      .pay.ToAddress(account.address, { lovelace: 2_000_000n })
+      .complete();
+    const signed = await Effect.runPromise(
+      builder.sign.withWallet().completeProgram(),
+    );
+    const outputDirectory = await freshCaptureDirectory("mismatch-");
+    try {
+      await expect(
+        captureSignedTxPreSubmit({
+          signedTxCbor: signed.toCBOR(),
+          txHash: "00".repeat(32),
+          walletAddress: account.address,
+          capture: { ...capture, outputDirectory },
+          batch: {
+            ordinal: 0,
+            plannedBatchIndex: 0,
+            splitPath: "batch-0",
+            targets: [
+              {
+                name: "mismatch",
+                scriptHash: "44".repeat(28),
+                outputIndex: 0,
+              },
+            ],
+            inputs: [{ outRef: `${"55".repeat(32)}#0`, lineage: "live_seed" }],
+            walletChangeOutputIndexes: [],
+          },
+        }),
+      ).rejects.toThrow(/does not match precomputed txHash/);
+      expect(await readdir(outputDirectory)).toEqual([".CAPTURE_SESSION.json"]);
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("binds declared input lineage and output indexes to the exact signed body", async () => {
+    const account = generateEmulatorAccount({ lovelace: 10_000_000n });
+    const lucid = await Lucid(new Emulator([account]), "Custom");
+    lucid.selectWallet.fromSeed(account.seedPhrase);
+    const builder = await lucid
+      .newTx()
+      .pay.ToAddress(account.address, { lovelace: 2_000_000n })
+      .complete();
+    const signed = await Effect.runPromise(
+      builder.sign.withWallet().completeProgram(),
+    );
+    const signedTxCbor = signed.toCBOR();
+    const transaction = CML.Transaction.from_cbor_hex(signedTxCbor);
+    const inputs = transaction.body().inputs();
+    const exactInputs = Array.from({ length: inputs.len() }, (_, index) => {
+      const input = inputs.get(index);
+      return {
+        outRef: `${input.transaction_id().to_hex()}#${Number(input.index()).toString()}`,
+        lineage: "live_seed" as const,
+      };
+    });
+    const outputCount = transaction.body().outputs().len();
+    expect(outputCount).toBeGreaterThan(1);
+    const outputDirectory = await freshCaptureDirectory("body-binding-");
+    const baseBatch: SignedTxPreSubmitBatchContext = {
+      ordinal: 0,
+      plannedBatchIndex: 0,
+      splitPath: "batch-0",
+      targets: [
+        {
+          name: "shape-only target",
+          scriptHash: "44".repeat(28),
+          outputIndex: 0,
+        },
+      ],
+      inputs: exactInputs,
+      walletChangeOutputIndexes: Array.from(
+        { length: outputCount - 1 },
+        (_, index) => index + 1,
+      ),
+    };
+    try {
+      await expect(
+        captureSignedTxPreSubmit({
+          signedTxCbor,
+          txHash: builder.toHash(),
+          walletAddress: account.address,
+          capture: { ...capture, outputDirectory },
+          batch: {
+            ...baseBatch,
+            inputs: [{ outRef: `${"ff".repeat(32)}#0`, lineage: "live_seed" }],
+          },
+        }),
+      ).rejects.toThrow(/does not exactly match the signed transaction body/);
+
+      await expect(
+        captureSignedTxPreSubmit({
+          signedTxCbor,
+          txHash: builder.toHash(),
+          walletAddress: account.address,
+          capture: { ...capture, outputDirectory },
+          batch: {
+            ...baseBatch,
+            walletChangeOutputIndexes: [outputCount + 1],
+          },
+        }),
+      ).rejects.toThrow(/do not exactly cover the signed transaction outputs/);
+      expect(await readdir(outputDirectory)).toEqual([".CAPTURE_SESSION.json"]);
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a matching wallet vkey with a forged transaction signature", async () => {
+    const account = generateEmulatorAccount({ lovelace: 10_000_000n });
+    const lucid = await Lucid(new Emulator([account]), "Custom");
+    lucid.selectWallet.fromSeed(account.seedPhrase);
+    const builder = await lucid
+      .newTx()
+      .pay.ToAddress(account.address, { lovelace: 2_000_000n })
+      .complete();
+    const signed = await Effect.runPromise(
+      builder.sign.withWallet().completeProgram(),
+    );
+    const transaction = CML.Transaction.from_cbor_hex(signed.toCBOR());
+    const witnesses = transaction.witness_set();
+    const originalVkeys = witnesses.vkeywitnesses();
+    expect(originalVkeys).toBeDefined();
+    expect(originalVkeys!.len()).toBeGreaterThan(0);
+    const forgedVkeys = CML.VkeywitnessList.new();
+    forgedVkeys.add(
+      CML.Vkeywitness.new(
+        originalVkeys!.get(0).vkey(),
+        CML.Ed25519Signature.from_raw_bytes(new Uint8Array(64).fill(1)),
+      ),
+    );
+    witnesses.set_vkeywitnesses(forgedVkeys);
+    const forgedSignedTxCbor = CML.Transaction.new(
+      transaction.body(),
+      witnesses,
+      transaction.is_valid(),
+      transaction.auxiliary_data(),
+    ).to_cbor_hex();
+    const outputDirectory = await freshCaptureDirectory("forged-witness-");
+    try {
+      await expect(
+        captureSignedTxPreSubmit({
+          signedTxCbor: forgedSignedTxCbor,
+          txHash: builder.toHash(),
+          walletAddress: account.address,
+          capture: { ...capture, outputDirectory },
+          batch: {
+            ordinal: 0,
+            plannedBatchIndex: 0,
+            splitPath: "batch-0",
+            targets: [
+              {
+                name: "shape-only target",
+                scriptHash: "44".repeat(28),
+                outputIndex: 0,
+              },
+            ],
+            inputs: [{ outRef: `${"55".repeat(32)}#0`, lineage: "live_seed" }],
+            walletChangeOutputIndexes: [],
+          },
+        }),
+      ).rejects.toThrow(/invalid vkey witness signature/);
+      expect(await readdir(outputDirectory)).toEqual([".CAPTURE_SESSION.json"]);
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when captured input ancestry is missing or duplicated", async () => {
+    const outputDirectory = await freshCaptureDirectory("lineage-invalid-");
+    const baseBatch: SignedTxPreSubmitBatchContext = {
+      ordinal: 0,
+      plannedBatchIndex: 0,
+      splitPath: "batch-0.L",
+      targets: [
+        {
+          name: "first real leaf target",
+          scriptHash: "44".repeat(28),
+          outputIndex: 1,
+        },
+      ],
+      inputs: [
+        {
+          outRef: `${"3b0eba06cac1ad33e97ca9a25553d24e17ab21d46d4922e039e348511646ab75"}#2`,
+          lineage: "live_seed",
+        },
+      ],
+      walletChangeOutputIndexes: [0, 2],
+    };
+    try {
+      for (const inputs of [[], [baseBatch.inputs[0]!, baseBatch.inputs[0]!]]) {
+        await expect(
+          captureSignedTxPreSubmit({
+            signedTxCbor: "80",
+            txHash: "00".repeat(32),
+            walletAddress: "addr_test1invalid",
+            capture: { ...capture, outputDirectory },
+            batch: { ...baseBatch, inputs },
+          }),
+        ).rejects.toThrow(
+          /Pre-submit capture batch input lineage is missing or duplicated/,
+        );
+      }
+      expect(await readdir(outputDirectory)).toEqual([".CAPTURE_SESSION.json"]);
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-absolute or non-explicit diagnostic invocations", async () => {
+    await expect(
+      captureSignedTxPreSubmit({
+        signedTxCbor: "80",
+        txHash: "00",
+        walletAddress: "addr_test1invalid",
+        capture: { ...capture, outputDirectory: "relative" },
+        batch: {} as never,
+      }),
+    ).rejects.toThrow(/absolute/);
+    await expect(
+      captureSignedTxPreSubmit({
+        signedTxCbor: "80",
+        txHash: "00",
+        walletAddress: "addr_test1invalid",
+        capture: {
+          ...capture,
+          invocation: "phase4-live-pre-submit-capture" as const,
+          abortBeforeSubmit: false as never,
+          outputDirectory: "/tmp/unused",
+        },
+        batch: {} as never,
+      }),
+    ).rejects.toThrow(/explicit aborting diagnostic invocation/);
+    expect(() =>
+      assertSignedTxPreSubmitCaptureCliSafety({
+        capture,
+        freshRedeploy: true,
+        planOnly: false,
+      }),
+    ).toThrow(/cannot be combined with --fresh-redeploy/);
+  });
+
+  it("requires the prepared blueprint, run-state, and private directory identity on every capture", async () => {
+    await mkdir(testTempRoot, { recursive: true });
+    const stateDirectory = await mkdtemp(join(testTempRoot, "prepared-"));
+    const runStatePath = join(stateDirectory, "deployment-run-state.json");
+    const localBlueprintPath = join(stateDirectory, "plutus.json");
+    const blueprintBytes = Buffer.from("prepared-blueprint-v1");
+    await writeFile(localBlueprintPath, blueprintBytes);
+    const outputDirectory = join(stateDirectory, "capture");
+    const boundCapture: SignedTxPreSubmitCapture = {
+      ...capture,
+      outputDirectory,
+      session: {
+        ...capture.session,
+        runStatePath,
+        blueprintPath: localBlueprintPath,
+        blueprintSha256: createHash("sha256")
+          .update(blueprintBytes)
+          .digest("hex"),
+      },
+    };
+    const state = matchingRunState(boundCapture);
+    await writeFile(runStatePath, JSON.stringify(state));
+    await prepareSignedTxPreSubmitCaptureDirectory(boundCapture);
+    try {
+      await writeFile(localBlueprintPath, "tampered-blueprint");
+      await expect(
+        captureSignedTxPreSubmit({
+          signedTxCbor: "80",
+          txHash: "00",
+          walletAddress: "addr_test1invalid",
+          capture: boundCapture,
+          batch: {} as never,
+        }),
+      ).rejects.toThrow(/blueprint hash does not match/);
+
+      await writeFile(localBlueprintPath, blueprintBytes);
+      await writeFile(
+        runStatePath,
+        JSON.stringify({
+          ...state,
+          identity: { ...state.identity, network: "Preview" },
+        }),
+      );
+      await expect(
+        captureSignedTxPreSubmit({
+          signedTxCbor: "80",
+          txHash: "00",
+          walletAddress: "addr_test1invalid",
+          capture: boundCapture,
+          batch: {} as never,
+        }),
+      ).rejects.toThrow(/exactly match/);
+
+      await writeFile(runStatePath, JSON.stringify(state));
+      await chmod(outputDirectory, 0o755);
+      await expect(
+        captureSignedTxPreSubmit({
+          signedTxCbor: "80",
+          txHash: "00",
+          walletAddress: "addr_test1invalid",
+          capture: boundCapture,
+          batch: {} as never,
+        }),
+      ).rejects.toThrow(/canonical private owner-controlled directory/);
+    } finally {
+      await rm(stateDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("requires the capture auth, network, and one-shot identity to already be persisted", async () => {
+    await mkdir(testTempRoot, { recursive: true });
+    const stateDirectory = await mkdtemp(join(testTempRoot, "run-state-"));
+    const runStatePath = join(stateDirectory, "deployment-run-state.json");
+    const boundCapture: SignedTxPreSubmitCapture = {
+      ...capture,
+      session: { ...capture.session, runStatePath },
+    };
+    const state = {
+      schemaVersion: "midgard-deployment-run-state-v1",
+      identity: {
+        network: boundCapture.session.network,
+        hubOracleOneShot: {
+          txHash: "22".repeat(32),
+          outputIndex: 0,
+        },
+        referenceScriptAuthPolicyId:
+          boundCapture.session.referenceScriptAuthPolicyId,
+        referenceScriptAuthPolicy: {
+          policyId: boundCapture.session.referenceScriptAuthPolicyId,
+        },
+      },
+    };
+    await writeFile(runStatePath, JSON.stringify(state));
+    await expect(
+      assertPersistedSignedTxPreSubmitCaptureIdentity(boundCapture),
+    ).resolves.toBeUndefined();
+
+    await writeFile(
+      runStatePath,
+      JSON.stringify({
+        ...state,
+        identity: {
+          ...state.identity,
+          referenceScriptAuthPolicyId: "ff".repeat(28),
+        },
+      }),
+    );
+    await expect(
+      assertPersistedSignedTxPreSubmitCaptureIdentity(boundCapture),
+    ).rejects.toThrow(/exactly match/);
+  });
+});

--- a/demo/midgard-node/tests/reference-script-diagnostic-safety.test.ts
+++ b/demo/midgard-node/tests/reference-script-diagnostic-safety.test.ts
@@ -1,0 +1,360 @@
+import type { ReferenceScriptAuthMintingPolicy } from "@al-ft/midgard-sdk";
+import { CML, type LucidEvolution, type UTxO } from "@lucid-evolution/lucid";
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+const { completePublicationMock, handleSignSubmitMock, signCaptureMock } =
+  vi.hoisted(() => ({
+    completePublicationMock: vi.fn(),
+    handleSignSubmitMock: vi.fn(),
+    signCaptureMock: vi.fn(),
+  }));
+
+vi.mock("@al-ft/midgard-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@al-ft/midgard-sdk")>();
+  return {
+    ...actual,
+    completeReferenceScriptPublicationTxProgram: completePublicationMock,
+  };
+});
+
+vi.mock("@/transactions/utils.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/transactions/utils.js")>();
+  return {
+    ...actual,
+    handleSignSubmit: handleSignSubmitMock,
+    signTransactionForPreSubmitCapture: signCaptureMock,
+  };
+});
+
+import {
+  buildReferenceScriptDeploymentPlan,
+  ensureReferenceScriptTargetsProgram,
+} from "@/transactions/reference-scripts.js";
+
+const REFERENCE_SCRIPT_ADDRESS = "addr_test1reference";
+const FUNDING_ADDRESS = "addr_test1funding";
+
+const plainUtxo: UTxO = {
+  txHash: "11".repeat(32),
+  outputIndex: 0,
+  address: REFERENCE_SCRIPT_ADDRESS,
+  assets: { lovelace: 1_000_000n },
+};
+
+const target = {
+  name: "diagnostic target",
+  script: {
+    type: "Native" as const,
+    script: "8200",
+  },
+};
+
+const authPolicy = {
+  mintingScriptCBOR: "8200",
+  policyId: "aa".repeat(28),
+  mintingScript: {
+    type: "Native" as const,
+    script: "8200",
+  },
+  expiresAtUnixTime: Date.now() + 60 * 60 * 1_000,
+} satisfies ReferenceScriptAuthMintingPolicy;
+
+describe("reference-script diagnostic submission safety", () => {
+  it("refuses a required automatic top-up before any submit-capable funding path runs", async () => {
+    handleSignSubmitMock.mockClear();
+    const referenceWalletAddress = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValue(REFERENCE_SCRIPT_ADDRESS);
+    const referenceWalletUtxos = vi
+      .fn<() => Promise<UTxO[]>>()
+      .mockResolvedValue([plainUtxo]);
+    const referenceUtxosAt = vi
+      .fn<(address: string) => Promise<UTxO[]>>()
+      .mockResolvedValue([plainUtxo]);
+    const overrideReferenceUtxos = vi.fn();
+    const referenceScriptsLucid = {
+      wallet: () => ({
+        address: referenceWalletAddress,
+        getUtxos: referenceWalletUtxos,
+      }),
+      utxosAt: referenceUtxosAt,
+      overrideUTxOs: overrideReferenceUtxos,
+    } as unknown as LucidEvolution;
+
+    const fundingWalletAccess = vi.fn();
+    const fundingTransactionBuild = vi.fn();
+    const fundingLucid = {
+      wallet: () => {
+        fundingWalletAccess();
+        return {
+          address: async () => FUNDING_ADDRESS,
+          getUtxos: async () => [],
+        };
+      },
+      newTx: fundingTransactionBuild,
+    } as unknown as LucidEvolution;
+
+    const deploymentPlan = buildReferenceScriptDeploymentPlan({
+      scopeName: "diagnostic",
+      targets: [target],
+      existingTargetNames: new Set(),
+      walletUtxos: [plainUtxo],
+    });
+    expect(deploymentPlan.topUpLovelace).toBeGreaterThan(0n);
+
+    await expect(
+      Effect.runPromise(
+        ensureReferenceScriptTargetsProgram(
+          referenceScriptsLucid,
+          "diagnostic",
+          [target],
+          authPolicy,
+          fundingLucid,
+          undefined,
+          0,
+          new Set(),
+          {
+            outputDirectory: "/tmp/reference-script-diagnostic-safety",
+            invocation: "phase4-live-pre-submit-capture",
+            abortBeforeSubmit: true,
+            session: {
+              commandName: "diagnostic",
+              runStatePath: "/tmp/run-state.json",
+              blueprintPath: "/tmp/plutus.json",
+              blueprintSha256: "11".repeat(32),
+              network: "Preprod",
+              hubOracleOneShotOutRef: `${"22".repeat(32)}#0`,
+              referenceScriptAuthPolicyId: authPolicy.policyId,
+            },
+          },
+        ),
+      ),
+    ).rejects.toThrow(
+      /Pre-submit diagnostic capture refuses automatic reference-script wallet replenishment/,
+    );
+
+    expect(referenceWalletAddress).toHaveBeenCalled();
+    expect(referenceWalletUtxos).toHaveBeenCalled();
+    expect(referenceUtxosAt).toHaveBeenCalled();
+    expect(overrideReferenceUtxos).toHaveBeenCalled();
+    expect(fundingWalletAccess).not.toHaveBeenCalled();
+    expect(fundingTransactionBuild).not.toHaveBeenCalled();
+    expect(handleSignSubmitMock).not.toHaveBeenCalled();
+  });
+
+  it("captures all 27 targets exactly once across recursive split leaves while preserving synthetic change lineage", async () => {
+    completePublicationMock.mockReset();
+    handleSignSubmitMock.mockReset();
+    signCaptureMock.mockReset();
+    const targets = Array.from({ length: 27 }, (_, index) => ({
+      name: `target-${index.toString().padStart(2, "0")}`,
+      script: {
+        type: "Native" as const,
+        script: CML.NativeScript.new_script_invalid_hereafter(
+          999_999n + BigInt(index),
+        ).to_cbor_hex(),
+      },
+    }));
+    let walletUtxos: UTxO[] = [
+      {
+        txHash: "66".repeat(32),
+        outputIndex: 0,
+        address: REFERENCE_SCRIPT_ADDRESS,
+        assets: { lovelace: 10_000_000_000n },
+      },
+    ];
+    const utxosAt = vi.fn(async () => [...walletUtxos]);
+    const utxosByOutRef = vi.fn(async () => [] as UTxO[]);
+    const overrideUTxOs = vi.fn((next: UTxO[]) => {
+      walletUtxos = [...next];
+    });
+    const lucid = {
+      wallet: () => ({
+        address: async () => REFERENCE_SCRIPT_ADDRESS,
+        getUtxos: async () => [...walletUtxos],
+      }),
+      config: () => ({ provider: {} }),
+      utxosAt,
+      utxosByOutRef,
+      overrideUTxOs,
+    } as unknown as LucidEvolution;
+    const fundingWalletAccess = vi.fn();
+    const fundingLucid = {
+      wallet: () => {
+        fundingWalletAccess();
+        return {
+          address: async () => FUNDING_ADDRESS,
+          getUtxos: async () => [],
+        };
+      },
+    } as unknown as LucidEvolution;
+
+    completePublicationMock.mockImplementation(
+      ({
+        selectedFundingInputs,
+        referenceScriptsAddress,
+        missingTargets,
+      }: {
+        readonly selectedFundingInputs: readonly UTxO[];
+        readonly referenceScriptsAddress: string;
+        readonly missingTargets: typeof targets;
+      }) => {
+        if (missingTargets.length > 2) {
+          return Effect.fail(
+            new Error(
+              `Max transaction size of 16384 exceeded. Found: ${(
+                20_000 + missingTargets.length
+              ).toString()}`,
+            ),
+          );
+        }
+        const inputLovelace = selectedFundingInputs.reduce(
+          (total, utxo) => total + (utxo.assets.lovelace ?? 0n),
+          0n,
+        );
+        const localReferenceOutputs = new Map(
+          missingTargets.map((target, outputIndex) => [
+            target.name,
+            {
+              outputIndex,
+              address: referenceScriptsAddress,
+              assets: { lovelace: 4_000_000n },
+              scriptRef: target.script,
+            },
+          ]),
+        );
+        return Effect.succeed({
+          tx: { diagnostic: true },
+          layout: {
+            localReferenceOutputs,
+            walletOutputs: [
+              // Production publishes the script refs to the reference-script
+              // wallet's own address, so the SDK layout includes these in
+              // walletOutputs as well as localReferenceOutputs.
+              ...localReferenceOutputs.values(),
+              {
+                outputIndex: missingTargets.length,
+                address: referenceScriptsAddress,
+                assets: {
+                  lovelace:
+                    inputLovelace - BigInt(missingTargets.length) * 4_000_000n,
+                },
+              },
+            ],
+          },
+        });
+      },
+    );
+    signCaptureMock.mockImplementation(
+      (
+        _lucid: unknown,
+        _unsigned: unknown,
+        options: {
+          readonly batch: {
+            readonly ordinal: number;
+          };
+        },
+      ) =>
+        Effect.succeed({
+          status: "captured_not_submitted" as const,
+          txHash: (options.batch.ordinal + 1).toString(16).padStart(64, "0"),
+          signedTxCbor: "00",
+          walletAddress: REFERENCE_SCRIPT_ADDRESS,
+          cborPath: "/tmp/capture.cbor",
+          metadataPath: "/tmp/capture.cbor.json",
+        }),
+    );
+
+    const resolved = await Effect.runPromise(
+      ensureReferenceScriptTargetsProgram(
+        lucid,
+        "node-runtime",
+        targets,
+        authPolicy,
+        fundingLucid,
+        REFERENCE_SCRIPT_ADDRESS,
+        1,
+        new Set(),
+        {
+          outputDirectory: "/tmp/reference-script-all-batch-capture",
+          invocation: "phase4-live-pre-submit-capture",
+          abortBeforeSubmit: true,
+          session: {
+            commandName: "node-runtime",
+            runStatePath: "/tmp/run-state.json",
+            blueprintPath: "/tmp/plutus.json",
+            blueprintSha256: "77".repeat(32),
+            network: "Preprod",
+            hubOracleOneShotOutRef: `${"88".repeat(32)}#0`,
+            referenceScriptAuthPolicyId: authPolicy.policyId,
+          },
+        },
+      ),
+    );
+
+    expect(resolved.map(({ name }) => name)).toEqual(
+      targets.map(({ name }) => name),
+    );
+    const batches = signCaptureMock.mock.calls.map(
+      (call) =>
+        (
+          call[2] as {
+            readonly batch: {
+              readonly ordinal: number;
+              readonly splitPath: string;
+              readonly targets: readonly {
+                readonly name: string;
+                readonly outputIndex: number;
+              }[];
+              readonly inputs: readonly {
+                readonly lineage: "live_seed" | "synthetic_change";
+              }[];
+              readonly walletChangeOutputIndexes: readonly number[];
+            };
+          }
+        ).batch,
+    );
+    expect(batches).toHaveLength(14);
+    expect(batches.map(({ ordinal }) => ordinal)).toEqual(
+      Array.from({ length: 14 }, (_, index) => index),
+    );
+    const capturedTargetNames = batches.flatMap(({ targets }) =>
+      targets.map(({ name }) => name),
+    );
+    expect(capturedTargetNames).toHaveLength(27);
+    expect(new Set(capturedTargetNames)).toEqual(
+      new Set(targets.map(({ name }) => name)),
+    );
+    expect(batches.some(({ splitPath }) => splitPath.endsWith(".L"))).toBe(
+      true,
+    );
+    expect(batches.some(({ splitPath }) => splitPath.endsWith(".R"))).toBe(
+      true,
+    );
+    expect(batches[0]?.inputs).toEqual([
+      expect.objectContaining({ lineage: "live_seed" }),
+    ]);
+    for (const batch of batches.slice(1)) {
+      expect(batch.inputs).toEqual([
+        expect.objectContaining({ lineage: "synthetic_change" }),
+      ]);
+    }
+    for (const batch of batches) {
+      expect(batch.walletChangeOutputIndexes).toHaveLength(1);
+      const targetOutputIndexes = new Set(
+        batch.targets.map(({ outputIndex }) => outputIndex),
+      );
+      expect(
+        batch.walletChangeOutputIndexes.some((outputIndex) =>
+          targetOutputIndexes.has(outputIndex),
+        ),
+      ).toBe(false);
+    }
+    expect(utxosAt).toHaveBeenCalledTimes(1);
+    expect(utxosByOutRef).not.toHaveBeenCalled();
+    expect(fundingWalletAccess).not.toHaveBeenCalled();
+    expect(handleSignSubmitMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a diagnostic pre-submit capture path that signs once and records exact signed CBOR without submitting
- validate transaction and script hashes, Flat encoding, deployment session identity, batch coverage, and input lineage
- persist private capture artifacts atomically with fsync-backed completion

## Safety model

The capture path is structurally non-submitting. It aborts before any provider submission and produces durable evidence suitable for deployment diagnostics.

## Verification

- frozen offline install with pnpm 9.15.4
- Aiken testnet build
- Node 22 typecheck and production build
- 14 focused capture-safety tests
- 47 existing reference-script and deployment regression tests
- two real PostgreSQL-backed emulator paths
- independent final review
