### PR TITLE
docs: harden Midgard E2E acceptance runbook

### DIFF
--- a/.agents/skills/midgard-e2e-acceptance/SKILL.md
+++ b/.agents/skills/midgard-e2e-acceptance/SKILL.md
@@ -1,91 +1,113 @@
 ---
 name: midgard-e2e-acceptance
-description: Use when running or diagnosing the Midgard demo node end-to-end acceptance check after code changes, including attach/resume, interrupted fresh deployments, explicit clean redeploys, DA payload/attestation gates, and final health, DB, balance, and log verification.
+description: Run, resume, diagnose, or assess merge and release readiness for the Midgard demo-node live end-to-end acceptance flow. Use for fresh or interrupted Preprod deployments, local Kupmios, reference scripts, operator lifecycle, libp2p DA publication and attestation, deposits, L2 transfers, automatic merge/finality, structured evidence, and bounded opt-in throughput checks.
 ---
 
 # Midgard E2E Acceptance
 
-Use this skill from the Midgard repository root when asked to verify that
-Midgard changes have not broken the real demo-node path.
+Treat this as production L2 acceptance. Preserve deployment identity, durable
+state, transaction evidence, and the distinction between functional recovery
+and a clean first-attempt run.
 
-## Start Here: Choose The Run Mode
+## Required reading
 
-Choose a mode before any state-changing command:
+Before any state-changing command, read:
 
-1. **Attach/resume existing deployment** when a complete deployment already
-   exists and the goal is to run, diagnose, or continue the node. Do not run
-   `init`. Verify manifest identity, `HUB_ORACLE_ONE_SHOT_*`, reference-script
-   auth policy, provider route, operator status, DB route, `deployment-status`,
-   `/healthz`, and `/readyz`, then start `listen` or Docker.
-2. **Continue interrupted pre-init deployment** when a fresh deployment was
-   intentionally started and failed before `init`. Preserve logs, manifest
-   hash, reference-script policy id, and submitted tx hashes. Resume only within
-   the same documented identity rules; do not mix an old manifest with a new
-   one-shot.
-3. **Diagnose post-init ambiguity** when `init` or any later state-changing
-   step may have succeeded. Stop and reconcile chain/DB/run-state first.
-   Fresh redeploy is an explicit operator decision, not the default response.
-4. **Fresh deployment** only when starting a new acceptance identity on purpose:
-   fresh funded one-shot, fresh reference-script publication, fresh `init`, and
-   local durable state reset that matches the new on-chain identity.
-5. **Fresh redeploy recovery** only when state-reset rules require it. If local
-   durable state was wiped, do not attach value-submitting flows to an old
-   on-chain deployment. Restore matching local state or perform the full
-   explicit redeploy.
+- root `AGENTS.md`;
+- `docs/agents/production-l2.md`;
+- `docs/agents/state-reset.md`;
+- `docs/agents/transaction-finalization.md`; and
+- `docs/agents/midgard-node.md`.
 
-Provider, wallet, DA, projection, scheduler timing, merge-lease, and evidence
-failures are gate failures to fix or wait through. They are not automatic
-redeploy triggers.
+Then run the skill currency check from the repository root:
 
-## Hard Rules
+```bash
+node .agents/skills/midgard-e2e-acceptance/scripts/validate-runbook.mjs
+```
 
-- Read root `AGENTS.md` first and follow the production-grade L2 directive.
-- Work in `demo/midgard-node` for the operational run.
-- Start with the mode decision above and record the selected mode plus reason
-  in the final evidence.
-- `listen` and Docker startup are attach operations. `init` is a bootstrap
-  operation.
-- Do not fresh redeploy on every failure. Use reconciliation commands,
-  deployment-status, DB evidence, DA status, and run logs to choose the safe
-  next action.
-- Never wipe local durable node state unless the run also performs a full fresh on-chain deployment.
-- Never combine clean local DBs with an old on-chain deployment manifest or old hub-oracle one-shot outref.
-- Use a fresh operator-wallet UTxO for `HUB_ORACLE_ONE_SHOT_TX_HASH` and `HUB_ORACLE_ONE_SHOT_OUTPUT_INDEX`; do not reuse the current `.env` value.
-- Patch the fresh hub-oracle one-shot in `.env` before publishing reference
-  scripts. The reference-script manifest and protocol init must be built from
-  the same one-shot identity.
-- Publish node-runtime reference scripts through `e2e-run-step` wrapping
-  `node dist/index.js deploy-reference-script-node-runtime` before `init`.
-  `init` now expects the deployment-info manifest to already contain the
-  reference-script auth policy and reference-script UTxOs.
-- Keep `RUN_GENESIS_ON_STARTUP=false` and run explicit protocol init through
-  `e2e-run-step` wrapping
-  `node dist/index.js init --contract-deployment-info-output deploymentInfo/contract-deployment-info.json`.
-- Do not delete or reset `demo/midgard-node/cardano/db` or `demo/midgard-node/cardano/kupo` for this check. The clean slate is the Midgard node DB, Postgres volume, MPT/local DB files, and deployment manifest.
-- Never rely on the CLI's default `USER_WALLET` seed source. Local `.env`
-  files may only define `USER_SEED_PHRASE`; pass
-  `--wallet-seed-phrase-env USER_SEED_PHRASE` on user-wallet commands.
-- DB-backed CLI commands must either run inside the `midgard-node` container or
-  be prefixed on the host with `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433`.
-  Host commands fail with the container-only hostname `POSTGRES_HOST=postgres`.
-- `/tx-status` takes `tx_hash`, not `txId`.
-- Acceptance uses local Docker Kupmios only. `L1_PROVIDER` must be `Kupmios`,
-  Kupo/Ogmios must be local endpoints for the execution mode, and
-  `L1_PROVIDER_FAILOVER` must be empty or absent. If local Kupmios is unhealthy,
-  fix local Kupmios; do not switch acceptance to Blockfrost, Koios, or any
-  remote provider.
-- Run the demo DA committee node from `demo/da-committee-node` for DA
-  attestations. Do not
-  use `node dist/index.js attest-state-queue-once` as the acceptance path; if
-  the DA node cannot sign, submit, and apply the attestation, diagnose and fix
-  that path.
-- Do not use manual SQL rewrites, local-only finalization, or transaction completion with local UPLC evaluation disabled to make the check pass.
+If it fails, repair the runbook or use current source help before operating a
+live deployment. Never improvise past a stale command, missing evidence gate,
+or deployment-identity mismatch.
 
-## Pre-Acceptance Local Feedback Gate
+## Choose one run mode
 
-Before live e2e for transaction-preparation changes, run the relevant lower
-layers from `demo/midgard-node/docs/TX_PREP_FEEDBACK_LADDER.md` and record the
-commands in the live evidence:
+Record the mode and reason before changing state:
+
+1. **Attach**: a complete matching deployment exists. Do not run `init` or
+   reset durable state. Verify manifest, one-shot, reference scripts, provider,
+   operator, DB route, `/healthz`, and `/readyz`, then start `listen` or Docker.
+2. **Resume**: a fresh deployment was interrupted before `init`, or a submitted
+   post-init milestone has been reconciled. Preserve the same manifest,
+   run-state, policy, one-shot, and submitted transaction identities.
+3. **Post-init diagnosis**: a state-changing command may have submitted. Stop,
+   reconcile chain/DB/run-state evidence, and classify the attempt before any
+   retry.
+4. **Fresh**: intentionally create a new on-chain identity, fresh reference
+   scripts and `init`, and matching clean local state.
+
+“Fresh redeploy” is a reason for mode `fresh`, not an
+`e2e-finalize-summary --mode` value. The summary CLI accepts `fresh`, `attach`,
+`resume`, or `unknown`.
+
+Provider, wallet, DA, projection, scheduler, lease, and evidence failures are
+not automatic redeploy triggers. Use a fresh deployment only when requested or
+required by `docs/agents/state-reset.md`.
+
+## Route to the relevant reference
+
+- Read [references/live-acceptance.md](references/live-acceptance.md) completely
+  for a fresh run or value-submitting attach/resume flow.
+- Read [references/recovery.md](references/recovery.md) completely for an
+  interruption, ambiguous submission, readiness failure, DA failure, or merge
+  failure.
+- Read [references/benchmark.md](references/benchmark.md) only when the user
+  explicitly requests stress or throughput evidence. Functional E2E does not
+  include stress by default.
+
+## Hard rules
+
+- Work from `demo/midgard-node` for operational commands.
+- `listen` and Docker startup attach; `init` bootstraps.
+- Never wipe local durable state without a full fresh on-chain deployment.
+- Never attach value-submitting flows to an old deployment after local state was
+  wiped.
+- Do not delete `demo/midgard-node/cardano/db` or `cardano/kupo`; they are the
+  local Preprod provider state, not the Midgard deployment reset target.
+- Use a fresh funded operator UTxO for `HUB_ORACLE_ONE_SHOT_*`. Patch it before
+  reference-script publication and keep the same identity through `init`.
+- Build `onchain/aiken/plutus.json` with `aiken build --env testnet` before a
+  fresh demo/Preprod image build.
+- Publish node-runtime reference scripts before `init` and preserve the
+  deployment run-state used to create their auth policy.
+- Keep `RUN_GENESIS_ON_STARTUP=false`; run explicit `init` through
+  `e2e-run-step`.
+- Use local Docker Kupmios only. Require `L1_PROVIDER=Kupmios`, local Kupo and
+  Ogmios endpoints, and no `L1_PROVIDER_FAILOVER`.
+- Pass `--wallet-seed-phrase-env USER_SEED_PHRASE` on user-wallet commands.
+  Do not use a default `USER_WALLET` source.
+- Run DB-backed host commands with
+  `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433`, or run them inside the node
+  container.
+- `/tx-status` accepts `tx_hash`; the L2 submission response field is `txId`.
+- Use the DA committee node and libp2p manifests for acceptance. Do not replace
+  it with `attest-state-queue-once`.
+- Keep the DA signer and L1 submitter roles explicit. Require a configured,
+  funded `DA_L1_SUBMITTER_KEY_SOURCE`; never hardcode a local secret path in the
+  runbook.
+- Start enough DA committee listeners to meet threshold before the producer
+  bind/listen preflight. Generate matching producer and watcher manifests from
+  the finalized contract deployment manifest.
+- Do not use manual SQL rewrites, manual `/merge`,
+  `reconcile merge-complete --repair`, local-only finalization, or disabled
+  local UPLC evaluation to make acceptance pass.
+- Preserve raw logs. Report compact failure summaries with artifact paths rather
+  than pasting secrets or large bodies.
+
+## Lower-layer feedback gate
+
+For transaction builders, wallet/input selection, validity, workers, DA, or
+recovery changes, run the relevant layers in
+`demo/midgard-node/docs/TX_PREP_FEEDBACK_LADDER.md` before live E2E:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -95,636 +117,51 @@ pnpm run test:tx-prep:node
 pnpm run test:tx-prep:emulator
 ```
 
-If live e2e exposes a deterministic builder, wallet/input-selection, validity,
-DA payload, scheduler, or post-submit recovery bug, stop repeated live reruns.
-Add a targeted local or emulator regression first, fix it there, then return to
-live acceptance.
+If live E2E finds a deterministic defect, stop repeated live retries. Add a
+targeted local or emulator regression, fix it, rerun the lower layer, then
+return to live acceptance.
 
-## Attach/Resume Existing Deployment
+## Acceptance contract
 
-Use this mode when contracts are already deployed or a previous run was
-interrupted after `init`.
+For a fresh run, use `e2e-run-step` for every required milestone. The current
+finalizer source is authoritative for required step IDs and transaction labels;
+the runbook validator compares the documentation to that source.
 
-```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT/demo/midgard-node"
-pnpm build
-node dist/index.js deployment-status --json
-node dist/index.js reference-script-wallet-status --json
-node dist/index.js l1-provider-preflight --json
-node dist/index.js reconcile phas-registered --json
-node dist/index.js reconcile reference-scripts-complete --scope node-runtime --json
-```
+Acceptance is complete only when:
 
-Verify:
+- `e2e-finalize-summary` writes `summary.json` and `summary.md`;
+- `functionalVerdict`, `cleanRunVerdict`, and `verdict` are `success`;
+- `nextSafeAction` is `none_run_complete`;
+- `required_fresh_steps`, `required_transaction_evidence`, and
+  `required_fresh_step_attempt_quality` are satisfied for mode `fresh`;
+- both baseline L2 transactions are committed;
+- every transaction observation is reconciled, with no submitted, unknown,
+  timed-out, or signaled attempt left ambiguous;
+- DA payload publication, watcher verification, attestation init/add/apply, and
+  automatic merge/finality evidence are present for every committed header;
+- `/healthz` is healthy, `/readyz` is ready without reasons, and the DA watcher
+  is healthy and ready;
+- the state queue is empty; pending finalizations are finalized; volatile
+  tables and unfinished mutation jobs are empty; and confirmed/immutable state
+  reflects the run; and
+- the final error scan has no unexplained error, failure, abandonment, crash, or
+  hash mismatch.
 
-- manifest path, manifest SHA-256, reference-script auth policy id, and
-  node-runtime ref-script completeness;
-- one-shot outref in `.env` matches the deployment identity;
-- provider route is local Kupmios and failover is empty;
-- DB-backed host commands use `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433`, or
-  run inside the `midgard-node` container;
-- wallet roles are distinct: operator, merge, reference-script, user, and DA
-  submitter addresses or address hashes only, never seed phrases;
-- `RUN_GENESIS_ON_STARTUP=false`; and
-- startup uses `listen`/Docker, not `init`.
+A recovered run may reach functional success while `cleanRunVerdict` remains
+failed or interrupted. Report that honestly as recovery evidence; do not call
+it a clean acceptance run.
 
-For value-submitting attach flows, start the node, verify `/healthz` and
-`/readyz`, then use the deposit/L2/DA/merge gates below. If a milestone is
-ambiguous, use the `reconcile ... --json [--repair]` commands instead of
-blindly resubmitting.
+## Before handoff
 
-## Fresh Run Procedure
-
-Start from a rebuilt node image:
+Rerun:
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT/demo/midgard-node"
-pnpm build
-COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.kupmios.yaml"
-$COMPOSE build midgard-node midgard-node-migrate
-RUN_ID="${RUN_ID:-e2e-run-$(date -u +%Y%m%dT%H%M%SZ)}"
-E2E_STEP_DIR="logs/$RUN_ID/steps"
-mkdir -p "$E2E_STEP_DIR"
+node .agents/skills/midgard-e2e-acceptance/scripts/validate-runbook.mjs
+python3 /mnt/c/Users/phili/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+  .agents/skills/midgard-e2e-acceptance
 ```
 
-Use the local Cardano/Ogmios/Kupo compose override for acceptance:
-
-```bash
-export CARDANO_NODE_IMAGE_TAG=<current-preprod-compatible-v11+-tag>
-COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.kupmios.yaml"
-node dist/index.js l1-provider-preflight --json
-```
-
-Create a fresh marked hub-oracle one-shot outref through the structured runner:
-
-```bash
-HUB_ORACLE_NONCE_LOG="logs/e2e-hub-oracle-nonce-$(date -u +%Y%m%dT%H%M%SZ).log"
-HUB_ORACLE_NONCE_STEP="$E2E_STEP_DIR/hub-oracle-nonce.json"
-RUN_STATE_PATH="logs/$RUN_ID/deployment-run-state.json"
-node dist/index.js e2e-run-step \
-  --id hub-oracle-nonce \
-  --cwd "$(pwd)" \
-  --raw-log "$HUB_ORACLE_NONCE_LOG" \
-  --summary-out "$HUB_ORACLE_NONCE_STEP" \
-  --timeout-ms 1200000 \
-  -- \
-  node dist/index.js prepare-hub-oracle-one-shot-nonce \
-  --run-state "$RUN_STATE_PATH" \
-  --fresh-redeploy \
-  --fresh-redeploy-reason "fresh e2e acceptance $RUN_ID" \
-  --json
-```
-
-Patch `.env` with the returned `txHash` and `outputIndex`, and preserve the
-same `$RUN_STATE_PATH` for reference-script publication. If nonce preparation
-fails due to funding, list operator wallet UTxOs and choose a fresh, funded
-outref that is not the current `.env` one-shot:
-
-```bash
-node --input-type=module -e 'import "dotenv/config"; import { Kupmios, Lucid, walletFromSeed } from "@lucid-evolution/lucid"; const network=process.env.NETWORK || "Preprod"; const kupo=process.env.L1_KUPO_KEY || `http://127.0.0.1:${process.env.KUPO_PORT || "1442"}`; const ogmios=process.env.L1_OGMIOS_KEY || `http://127.0.0.1:${process.env.OGMIOS_PORT || "1337"}`; const addr=walletFromSeed(process.env.L1_OPERATOR_SEED_PHRASE, { network }).address; const lucid=await Lucid(new Kupmios(kupo, ogmios), network); const utxos=await lucid.utxosAt(addr); console.log(JSON.stringify({addr, provider:"kupmios", utxos: utxos.map(u=>({txHash:u.txHash, outputIndex:u.outputIndex, lovelace:u.assets.lovelace?.toString()??"0", assets:Object.fromEntries(Object.entries(u.assets).map(([k,v])=>[k,v.toString()]))}))}, null, 2));'
-```
-
-Patch `.env` with `apply_patch` so `RUN_GENESIS_ON_STARTUP=false`, the fresh
-one-shot outref is set, and the intended provider is explicit. If no fresh
-operator UTxO exists, stop, fund the operator wallet, wait for confirmation,
-and relist UTxOs.
-
-Reset only Midgard local state and the Postgres volume after the fresh outref is selected:
-
-```bash
-$COMPOSE down -v --remove-orphans
-mkdir -p db deploymentInfo logs
-docker run --rm -v "$PWD/deploymentInfo:/mnt/deploymentInfo" -v "$PWD/db:/mnt/db" busybox sh -lc 'rm -rf /mnt/db/* /mnt/deploymentInfo/contract-deployment-info.json && chown -R 1000:1000 /mnt/db /mnt/deploymentInfo'
-```
-
-Publish the node-runtime reference scripts before `init` and save the full log:
-
-```bash
-REFERENCE_LOG="logs/e2e-reference-scripts-$(date -u +%Y%m%dT%H%M%SZ).log"
-REFERENCE_STEP="$E2E_STEP_DIR/reference-scripts.json"
-node dist/index.js e2e-run-step \
-  --id reference-scripts \
-  --cwd "$(pwd)" \
-  --raw-log "$REFERENCE_LOG" \
-  --summary-out "$REFERENCE_STEP" \
-  --timeout-ms 10800000 \
-  -- \
-  node dist/index.js deploy-reference-script-node-runtime \
-  --run-state "$RUN_STATE_PATH" \
-  --contract-deployment-info-output deploymentInfo/contract-deployment-info.json \
-```
-
-Expect this step to take a long time on preprod. Batch-split warnings such as
-`exceeded max tx size; retrying in smaller batches` and funding escalation
-warnings such as `retrying with N funding input(s)` are progress, not failure.
-Keep the command running while it continues to submit and confirm batches; note
-the highest funding-input count in the final report.
-
-If reference-script deployment is interrupted before a complete manifest is
-written, do not guess at reuse. Preserve the old log and inspect the run-state
-and manifest identity first. A rerun may resume the same reference-script auth
-policy only when the run-state or manifest matches the current network,
-hub-oracle one-shot outref, manifest path, and policy id. If that comparable
-identity is absent before `init`, start a new pre-init reference-script attempt
-only with an explicit fresh-redeploy reason. After `init`, any mismatch between
-manifest, reference scripts, and one-shot identity requires a full clean local
-reset plus a new fresh on-chain deployment identity.
-
-Verify that the node-runtime reference-script scope required by `init` is
-complete before moving on:
-
-```bash
-node dist/index.js reconcile reference-scripts-complete --scope node-runtime --json
-```
-
-This fresh acceptance path publishes and verifies the node-runtime reference
-scripts. The manifest may still contain `refScriptUTxO: null` for non-runtime
-contract groups that are not part of this flow; do not fail the fresh run solely
-because those optional groups are unpublished.
-
-Deploy fresh on-chain protocol state and complete operator lifecycle:
-
-```bash
-INIT_LOG="logs/e2e-init-$(date -u +%Y%m%dT%H%M%SZ).log"
-INIT_STEP="$E2E_STEP_DIR/init.json"
-node dist/index.js e2e-run-step \
-  --id init-protocol \
-  --cwd "$(pwd)" \
-  --raw-log "$INIT_LOG" \
-  --summary-out "$INIT_STEP" \
-  --timeout-ms 1200000 \
-  -- \
-  node dist/index.js init \
-  --contract-deployment-info-output deploymentInfo/contract-deployment-info.json
-OPERATOR_LOG="logs/e2e-operator-lifecycle-$(date -u +%Y%m%dT%H%M%SZ).log"
-OPERATOR_STEP="$E2E_STEP_DIR/operator-lifecycle.json"
-node dist/index.js e2e-run-step \
-  --id operator-lifecycle \
-  --cwd "$(pwd)" \
-  --raw-log "$OPERATOR_LOG" \
-  --summary-out "$OPERATOR_STEP" \
-  --timeout-ms 1200000 \
-  -- \
-  node dist/index.js register-active-operator
-$COMPOSE up -d midgard-node
-```
-
-If `register-active-operator` is interrupted after registration but before
-activation, do not use deregistration or test-only recovery. The combined
-`register-active-operator` command now resumes safely when chain state shows
-exactly one registered node for the operator and no active node: it skips
-registration and proceeds directly to activation. For an explicit activate-only
-recovery, use the supported CLI:
-
-```bash
-node dist/index.js activate-operator
-```
-
-If activation fails, stop and diagnose. Do not force progress with
-deregistration, SQL edits, test-only commands, or disabled local evaluation.
-
-Wait for the API to be ready:
-
-```bash
-READY_LOG="logs/e2e-midgard-node-ready-$(date -u +%Y%m%dT%H%M%SZ).log"
-READY_STEP="$E2E_STEP_DIR/midgard-node-ready.json"
-node dist/index.js e2e-run-step \
-  --id midgard-node-ready \
-  --cwd "$(pwd)" \
-  --raw-log "$READY_LOG" \
-  --summary-out "$READY_STEP" \
-  --timeout-ms 180000 \
-  -- \
-  node --input-type=module -e 'const deadline=Date.now()+170000; while (Date.now()<deadline) { const r=await fetch("http://127.0.0.1:3000/readyz").catch(()=>null); if (r?.ok) { console.log(JSON.stringify(await r.json())); process.exit(0); } await new Promise((resolve)=>setTimeout(resolve,5000)); } process.exit(1);'
-```
-
-Start the copied DA committee node before submitting L2 activity. The default
-acceptance path is the demo node's legacy 1-of-1 DA committee derived from
-`L1_OPERATOR_SEED_PHRASE`; if `.env` configures a multi-member committee, start
-enough DA node instances to meet `DA_THRESHOLD` instead of falling back to the
-manual `attest-state-queue-once` CLI. `DA_PAYLOAD_ENDPOINTS` entries are base
-URLs such as `http://127.0.0.1:3000`; do not append `/da/payload`.
-
-```bash
-REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
-DA_NODE_DIR="$REPO_ROOT/demo/da-committee-node"
-CONTRACT_INFO="$PWD/deploymentInfo/contract-deployment-info.json"
-DA_L1_SUBMITTER_KEY_SOURCE="$PWD/deploymentInfo/preprod-da-2of3/secrets/l1-submitter.seed"
-WATCHER_MANIFEST="$DA_NODE_DIR/run/e2e-watcher-manifest.json"
-WATCHER_DB="$DA_NODE_DIR/run/e2e-watcher-store.json"
-mkdir -p "$DA_NODE_DIR/run" "$DA_NODE_DIR/db" logs
-pnpm --dir "$DA_NODE_DIR" install --frozen-lockfile
-pnpm --dir "$DA_NODE_DIR" build
-
-set -a
-. ./.env
-set +a
-export CONTRACT_INFO WATCHER_MANIFEST
-if [ -z "${DA_COMMITTEE_HEX:-}" ]; then
-  unset DA_COMMITTEE_HEX
-fi
-if [ -z "${DA_THRESHOLD:-}" ]; then
-  DA_THRESHOLD=1
-  export DA_THRESHOLD
-fi
-if [ ! -f "$DA_L1_SUBMITTER_KEY_SOURCE" ]; then
-  echo "Missing DA L1 submitter key source: $DA_L1_SUBMITTER_KEY_SOURCE" >&2
-  exit 1
-fi
-node --input-type=module <<'NODE'
-import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
-import { CML, walletFromSeed } from "@lucid-evolution/lucid";
-
-const contractInfoPath = process.env.CONTRACT_INFO;
-const manifestPath = process.env.WATCHER_MANIFEST;
-if (!contractInfoPath || !manifestPath) {
-  throw new Error("CONTRACT_INFO and WATCHER_MANIFEST are required");
-}
-const network = process.env.NETWORK || "Preprod";
-const seed = process.env.L1_OPERATOR_SEED_PHRASE;
-if (!seed) {
-  throw new Error("L1_OPERATOR_SEED_PHRASE is required for demo DA signing");
-}
-const contractInfo = readFileSync(contractInfoPath);
-const fingerprint = createHash("sha256").update(contractInfo).digest("hex");
-const wallet = walletFromSeed(seed, { network });
-const privateKey = CML.PrivateKey.from_bech32(wallet.paymentKey);
-const vkey = Buffer.from(privateKey.to_public().to_raw_bytes()).toString("hex");
-const manifest = {
-  schemaVersion: "midgard-da-deployment-v1",
-  deploymentFingerprint: fingerprint,
-  network,
-  contractDeploymentInfoSha256: fingerprint,
-  da: {
-    threshold: Number(process.env.DA_THRESHOLD || 1),
-    members: [
-      {
-        index: 0,
-        vkey,
-        baseUrls: ["http://127.0.0.1:8787"],
-        canSubmitL1: true
-      }
-    ]
-  }
-};
-mkdirSync(dirname(manifestPath), { recursive: true });
-writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
-console.log(JSON.stringify({ manifestPath, fingerprint, signerIndex: 0, vkey }, null, 2));
-NODE
-
-if [ "${L1_PROVIDER:-Kupmios}" != "Kupmios" ]; then
-  echo "Acceptance requires L1_PROVIDER=Kupmios. Fix local Kupmios instead of switching providers." >&2
-  exit 1
-fi
-CARDANO_PROVIDER_URLS="kupmios:http://127.0.0.1:${KUPO_PORT:-1442}|http://127.0.0.1:${OGMIOS_PORT:-1337}"
-
-DA_NODE_LOG="logs/e2e-da-committee-node-$(date -u +%Y%m%dT%H%M%SZ).log"
-env \
-  MIDGARD_NETWORK="${NETWORK:-Preprod}" \
-  MIDGARD_DEPLOYMENT_MANIFEST_PATH="$WATCHER_MANIFEST" \
-  MIDGARD_CONTRACT_DEPLOYMENT_INFO_PATH="$CONTRACT_INFO" \
-  CARDANO_PROVIDER_URLS="$CARDANO_PROVIDER_URLS" \
-  CARDANO_FINALITY_DEPTH="${CARDANO_FINALITY_DEPTH:-2}" \
-  DA_PAYLOAD_ENDPOINTS="http://127.0.0.1:3000" \
-  DA_SIGNER_INDEX=0 \
-  DA_SIGNER_KEY_SOURCE="cardano-seed:${L1_OPERATOR_SEED_PHRASE}" \
-  DA_THRESHOLD="${DA_THRESHOLD:-1}" \
-  DA_L1_SUBMISSION_ENABLED=true \
-  L1_SUBMITTER_KEY_SOURCE="file:$DA_L1_SUBMITTER_KEY_SOURCE" \
-  WATCHER_DB_PATH="$WATCHER_DB" \
-  WATCHER_API_HOST=127.0.0.1 \
-  WATCHER_API_PORT=8787 \
-  WATCHER_POLL_INTERVAL_MS=15000 \
-  node dist/index.js e2e-start-service \
-    --service da-committee-node \
-    --cwd "$DA_NODE_DIR" \
-    --raw-log "$DA_NODE_LOG" \
-    --pid-file "$DA_NODE_DIR/run/e2e-watcher.pid" \
-    --ready-url http://127.0.0.1:8787/readyz \
-    --health-url http://127.0.0.1:8787/healthz \
-    --ready-timeout-ms 180000 \
-    --poll-interval-ms 5000 \
-    pnpm start
-```
-
-Derive L2 addresses and submit a deposit large enough to fund the following L2 transfers:
-
-```bash
-USER_L2_ADDRESS=$(node --input-type=module -e 'import "dotenv/config"; import { walletFromSeed } from "@lucid-evolution/lucid"; console.log(walletFromSeed(process.env.USER_SEED_PHRASE,{network:process.env.NETWORK}).address)')
-DEST_A=$(node --input-type=module -e 'import "dotenv/config"; import { walletFromSeed } from "@lucid-evolution/lucid"; console.log(walletFromSeed(process.env.TESTNET_GENESIS_WALLET_SEED_PHRASE_A,{network:process.env.NETWORK}).address)')
-DEST_B=$(node --input-type=module -e 'import "dotenv/config"; import { walletFromSeed } from "@lucid-evolution/lucid"; console.log(walletFromSeed(process.env.TESTNET_GENESIS_WALLET_SEED_PHRASE_B,{network:process.env.NETWORK}).address)')
-DEPOSIT_LOG="logs/e2e-submit-deposit-$(date -u +%Y%m%dT%H%M%SZ).log"
-DEPOSIT_STEP="$E2E_STEP_DIR/submit-deposit.json"
-node dist/index.js e2e-run-step \
-  --id submit-deposit \
-  --cwd "$(pwd)" \
-  --raw-log "$DEPOSIT_LOG" \
-  --summary-out "$DEPOSIT_STEP" \
-  --timeout-ms 1200000 \
-  -- \
-  env POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433 \
-  node dist/index.js submit-deposit \
-  --wallet-seed-phrase-env USER_SEED_PHRASE \
-  --l2-address "$USER_L2_ADDRESS" \
-  --lovelace 12000000
-```
-
-Wait for the deposit to be seen and projected. Prefer running DB-backed CLI
-commands inside the container:
-
-```bash
-PROJECT_DEPOSITS_LOG="logs/e2e-project-deposits-$(date -u +%Y%m%dT%H%M%SZ).log"
-PROJECT_DEPOSITS_STEP="$E2E_STEP_DIR/project-deposits.json"
-node dist/index.js e2e-run-step \
-  --id project-deposits \
-  --cwd "$(pwd)" \
-  --raw-log "$PROJECT_DEPOSITS_LOG" \
-  --summary-out "$PROJECT_DEPOSITS_STEP" \
-  --timeout-ms 300000 \
-  -- \
-  bash -lc "$COMPOSE exec -T midgard-node node dist/index.js project-deposits-once"
-curl -s "http://127.0.0.1:3000/utxos?address=$USER_L2_ADDRESS"
-```
-
-The host equivalent is:
-
-```bash
-PROJECT_DEPOSITS_LOG="logs/e2e-project-deposits-$(date -u +%Y%m%dT%H%M%SZ).log"
-PROJECT_DEPOSITS_STEP="$E2E_STEP_DIR/project-deposits.json"
-node dist/index.js e2e-run-step \
-  --id project-deposits \
-  --cwd "$(pwd)" \
-  --raw-log "$PROJECT_DEPOSITS_LOG" \
-  --summary-out "$PROJECT_DEPOSITS_STEP" \
-  --timeout-ms 300000 \
-  -- \
-  env POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433 \
-  node dist/index.js project-deposits-once
-```
-
-If `/utxos` is still empty, check whether the deposit was only reconciled from
-L1 but is not due for projection yet:
-
-```bash
-$COMPOSE exec -T postgres psql -U postgres -d midgard -c "select now() as db_now, min(inclusion_time) filter (where status = 'awaiting') as next_due_projection, count(*) filter (where status = 'awaiting') as awaiting, count(*) filter (where status = 'projected') as projected, count(*) filter (where status = 'consumed') as consumed from deposits_utxos;"
-```
-
-If `next_due_projection` is in the future, wait until that time plus a small
-buffer and rerun `project-deposits-once`. Do not count pre-inclusion-time
-non-projection as a failure.
-
-Only after the projected user L2 UTxO is visible and the DA committee node is
-still ready, submit L2 transfers that spend that projected value:
-
-```bash
-curl -sf http://127.0.0.1:8787/readyz
-L2_TRANSFER_A_LOG="logs/e2e-submit-l2-transfer-a-$(date -u +%Y%m%dT%H%M%SZ).log"
-L2_TRANSFER_A_STEP="$E2E_STEP_DIR/submit-l2-transfer-a.json"
-node dist/index.js e2e-run-step \
-  --id submit-l2-transfer-a \
-  --cwd "$(pwd)" \
-  --raw-log "$L2_TRANSFER_A_LOG" \
-  --summary-out "$L2_TRANSFER_A_STEP" \
-  --timeout-ms 300000 \
-  -- \
-  bash -lc "$COMPOSE exec -T midgard-node node dist/index.js submit-l2-transfer --wallet-seed-phrase-env USER_SEED_PHRASE --endpoint http://127.0.0.1:3000 --l2-address $DEST_A --lovelace 2000000"
-L2_TRANSFER_B_LOG="logs/e2e-submit-l2-transfer-b-$(date -u +%Y%m%dT%H%M%SZ).log"
-L2_TRANSFER_B_STEP="$E2E_STEP_DIR/submit-l2-transfer-b.json"
-node dist/index.js e2e-run-step \
-  --id submit-l2-transfer-b \
-  --cwd "$(pwd)" \
-  --raw-log "$L2_TRANSFER_B_LOG" \
-  --summary-out "$L2_TRANSFER_B_STEP" \
-  --timeout-ms 300000 \
-  -- \
-  bash -lc "$COMPOSE exec -T midgard-node node dist/index.js submit-l2-transfer --wallet-seed-phrase-env USER_SEED_PHRASE --endpoint http://127.0.0.1:3000 --l2-address $DEST_B --lovelace 1500000"
-```
-
-Poll each returned L2 transaction hash until `/tx-status` reports `committed`.
-Then wait for the DA committee node to sign, submit, and apply the DA
-attestation. The Midgard node merge path should show the queued header's
-`da_attestation` as the deployment's DA attestation policy before merge:
-
-```bash
-ADMIN_KEY="${ADMIN_API_KEY:-localdev-admin}"
-curl -s "http://127.0.0.1:3000/tx-status?tx_hash=$TX_A"
-curl -s "http://127.0.0.1:3000/tx-status?tx_hash=$TX_B"
-curl -s -H "x-midgard-admin-key: $ADMIN_KEY" http://127.0.0.1:3000/stateQueue
-HEADER_HASH="<queued-header-hash>"
-DEPLOYMENT_FINGERPRINT=$(node --input-type=module -e 'import { createHash } from "node:crypto"; import { readFileSync } from "node:fs"; process.stdout.write(createHash("sha256").update(readFileSync("deploymentInfo/contract-deployment-info.json")).digest("hex"))')
-curl -sf "http://127.0.0.1:3000/da/payload/metadata?header_hash=$HEADER_HASH"
-curl -sf "http://127.0.0.1:3000/da/payload?header_hash=$HEADER_HASH" >/tmp/midgard-da-payload.cbor
-curl -sf "http://127.0.0.1:8787/v1/deployments/$DEPLOYMENT_FINGERPRINT/headers/$HEADER_HASH/status"
-tail -n 80 "$DA_NODE_LOG"
-```
-
-Do not run `attest-state-queue-once` if the header remains unattested. Inspect
-`$DA_NODE_LOG`, the watcher store, `/da/payload?header_hash=...`, and the
-watcher `/v1/deployments/<fingerprint>/headers/<headerHash>/status` endpoint
-for the stuck header, then fix the DA node or configuration. Do not merge when
-the watcher status reports `root_mismatch`, `malformed_da`, or `conflicted`;
-that is a payload construction or endpoint-set blocker. Once payload metadata
-and CBOR are available, watcher payload status is `verified`, and watcher header
-status is `attested` or `merged`, force admin merges for any mature tail block
-that remains because `MIN_QUEUE_LENGTH_FOR_MERGING=2`:
-
-```bash
-MERGE_LOG="logs/e2e-merge-tail-$(date -u +%Y%m%dT%H%M%SZ).log"
-MERGE_STEP="$E2E_STEP_DIR/merge-tail.json"
-node dist/index.js e2e-run-step \
-  --id merge-tail \
-  --cwd "$(pwd)" \
-  --raw-log "$MERGE_LOG" \
-  --summary-out "$MERGE_STEP" \
-  --timeout-ms 300000 \
-  -- \
-  curl -sf -H "x-midgard-admin-key: $ADMIN_KEY" http://127.0.0.1:3000/merge
-```
-
-Wait and repeat `/merge` only as needed until `stateQueue.headers` is empty and the DB summary is clean.
-
-When investigating `ScriptIntegrityHashMismatch` or other hash mismatch
-failures, keep raw logs in a file and report a compact summary only: failing
-command or endpoint, tx hash if known, expected hash, actual hash, reference
-script policy/outref if shown, and the log filepath. Do not paste huge raw body
-logs into the final report; use them as attached evidence for the code fix that
-should make the node emit compact summaries with raw bodies available
-separately.
-
-## Interrupted Run Triage
-
-For any interrupted step, preserve raw logs first. Then record:
-
-- run mode and reason;
-- last submitted tx hashes and whether they are confirmed, unknown, or rejected;
-- manifest hash, reference-script auth policy id, and ref-script count;
-- one-shot outref, provider route, DB route, and wallet role addresses;
-- DA node PID/log path, watcher manifest path, watcher DB path, and per-header
-  watcher status when a header exists; and
-- classification: safe to retry before submit, reconcile submitted tx before
-  rerun, wait for provider/projection visibility, attach/resume, or explicit
-  fresh redeploy required by state-reset rules.
-
-Use reconciliation commands before repeating submitted milestones:
-
-```bash
-node dist/index.js reconcile phas-registered --json --repair
-node dist/index.js reconcile reference-scripts-complete --scope node-runtime --json --repair
-node dist/index.js reconcile deposit-projected --event-id <event-id> --json --repair
-node dist/index.js reconcile tx-committed --tx-hash <l2-tx-hash> --json
-node dist/index.js reconcile da-attested --header-hash <header-hash> --watcher-url http://127.0.0.1:8787 --deployment-fingerprint "$DEPLOYMENT_FINGERPRINT" --json --repair
-node dist/index.js reconcile block-committed --header-hash <header-hash> --json
-node dist/index.js reconcile merge-complete --header-hash <header-hash> --json --repair
-```
-
-## Failure Routing
-
-| Blocker                                                             | Safe next action                                                                                                                         |
-| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Local Kupmios unhealthy or failover configured                      | Run `l1-provider-preflight --json`; fix Kupo/Ogmios/Cardano-node locally. Do not switch acceptance to a remote provider.                 |
-| Fresh one-shot mismatch                                             | Stop. Use attach/resume if protocol already initialized; otherwise restart fresh deployment with a new one-shot and matching manifest.   |
-| Incomplete reference-script manifest before `init`                  | Resume/retry reference-script publication under documented identity rules; preserve old logs.                                            |
-| Manifest/reference-script mismatch after `init`                     | Stop and diagnose identity drift. Fresh redeploy only with state-reset rule.                                                             |
-| Operator registered but not active                                  | Reconcile operator lifecycle; use documented activate-only recovery only when chain state proves registration already exists.            |
-| Deposit not projected                                               | Check `deposits_utxos.inclusion_time`; wait until due, then run projection once.                                                         |
-| Submitted deposit confirmation timeout                              | Run `reconcile-deposit-submission --tx-hash <hash> --json`; do not blindly resubmit on `ambiguous`.                                      |
-| DA node not ready before L2 activity                                | Stop before L2 transfer/commit. Fix DA wallet/config/provider and restart the DA node.                                                   |
-| DA payload missing for committed header                             | Inspect `da_payloads`, pending finalization, local logs, and run `db:backfill-da-payloads --header-hash <hash>` only as repair evidence. |
-| DA payload conflict or root mismatch                                | Stop. Do not merge. Diagnose payload construction and endpoint set.                                                                      |
-| DA signatures below threshold                                       | Start enough DA signer instances or fix peer propagation. Do not lower threshold for acceptance.                                         |
-| Merge skipped by state-queue lease                                  | Inspect `/stateQueueMutationLease` and unfinished local mutation jobs; wait or repair the real stuck job.                                |
-| Scheduler/commit timing expired                                     | Rebuild through the worker path with fresh timing; do not reuse expired signed txs or pending rows.                                      |
-| Partial deployment or local state wiped under old on-chain identity | Follow `docs/agents/state-reset.md`; fresh redeploy only with clean local state and fresh on-chain identity.                             |
-
-## Stale-Instruction Audit
-
-Before claiming the runbook is current, audit active acceptance docs:
-
-```bash
-rg -n "attest-state-queue-once|txId|USER_WALLET|RUN_GENESIS_ON_STARTUP=true|docker compose down -v|pnpm init|/da/payload" .agents/skills/midgard-e2e-acceptance demo/midgard-node/docs docs/agents
-```
-
-Every hit must either be a correct current command, a base URL warning, or an
-explicit "do not use this as the acceptance path" note.
-
-## Required Final Evidence
-
-Collect and report:
-
-- Run mode (`fresh`, `attach`, `resume`, or `fresh-redeploy`) and reason.
-- Lower-layer transaction-preparation commands run before live e2e, when code
-  changes touched builders, transaction prep, workers, DA, or recovery.
-- Fresh hub-oracle one-shot outref used in `.env`.
-- Reference-script deployment duration, log filepath, auth policy id, reference-script count, any batch splits, and highest funding-input count observed.
-- Init, operator registration, operator activation, deposit, L2 transfer, commit, scheduler refresh, and merge transaction hashes.
-- Whether operator lifecycle used the normal CLI or the test-exposed activate-only recovery path.
-- DA committee node log filepath, PID file, generated watcher manifest path,
-  watcher DB path, payload endpoint base URL, `/healthz` and `/readyz` status,
-  payload metadata/CBOR evidence for every committed header, watcher
-  per-header status, and DA attestation `init`, `add_signatures`, and `apply`
-  transaction hashes from the watcher store/logs.
-- `/healthz` is healthy and `/readyz` is ready with no readiness reasons.
-- Both L2 transaction statuses are `committed`.
-- User and destination L2 balances reflect the deposit-funded transfers and expected change.
-- Scheduler advanced: logs show scheduler witness refresh or ActiveOperator scheduling for the commit window.
-- State commitments were submitted and finalized; state queue was merged until empty.
-- No unfinished local mutation jobs, no mempool residue, no processed mempool residue, and no unexpected errors in logs.
-- For any hash mismatch, a compact summary plus the raw log filepath.
-
-Generate the required dashboard first; use the raw probes after it only for
-extra context or failure diagnosis:
-
-```bash
-NODE_LOG="logs/e2e-midgard-node-$(date -u +%Y%m%dT%H%M%SZ).log"
-$COMPOSE logs --no-color --since=30m midgard-node > "$NODE_LOG"
-rg -i "error|failed|failure|unknownOutput|crashed|abandon|ScriptIntegrityHashMismatch|hash mismatch" "$NODE_LOG" || true
-step_tx_hash() {
-  node --input-type=module - "$1" "${2:-0}" <<'NODE'
-import { readFileSync } from "node:fs";
-const summary = JSON.parse(readFileSync(process.argv[2], "utf8"));
-const index = Number(process.argv[3] ?? 0);
-const hash = Array.isArray(summary.observedTxHashes)
-  ? summary.observedTxHashes[index]
-  : undefined;
-if (typeof hash === "string") {
-  process.stdout.write(hash);
-}
-NODE
-}
-HUB_ORACLE_NONCE_TX_HASH="$(step_tx_hash "${HUB_ORACLE_NONCE_STEP:-}" 0)"
-INIT_TX_HASH="$(step_tx_hash "$INIT_STEP" 0)"
-OPERATOR_REGISTRATION_TX_HASH="$(step_tx_hash "$OPERATOR_STEP" 0)"
-OPERATOR_ACTIVATION_TX_HASH="$(step_tx_hash "$OPERATOR_STEP" 1)"
-DEPOSIT_TX_HASH="$(step_tx_hash "$DEPOSIT_STEP" 0)"
-TX_A="$(step_tx_hash "$L2_TRANSFER_A_STEP" 0)"
-TX_B="$(step_tx_hash "$L2_TRANSFER_B_STEP" 0)"
-STEP_SUMMARY_ARGS=()
-for step in \
-  "$HUB_ORACLE_NONCE_STEP" \
-  "$REFERENCE_STEP" \
-  "$INIT_STEP" \
-  "$OPERATOR_STEP" \
-  "$READY_STEP" \
-  "$DEPOSIT_STEP" \
-  "$PROJECT_DEPOSITS_STEP" \
-  "$L2_TRANSFER_A_STEP" \
-  "$L2_TRANSFER_B_STEP" \
-  "$MERGE_STEP"; do
-  if [ -f "$step" ]; then
-    STEP_SUMMARY_ARGS+=(--step-summary "$step")
-  fi
-done
-TX_ARGS=()
-append_tx_arg() {
-  if [ -n "$2" ]; then
-    TX_ARGS+=(--tx "$1:$2:$3:$4")
-  fi
-}
-append_tx_arg hub-oracle-nonce "$HUB_ORACLE_NONCE_TX_HASH" confirmed "$HUB_ORACLE_NONCE_STEP"
-append_tx_arg init "$INIT_TX_HASH" confirmed "$INIT_STEP"
-append_tx_arg operator-registration "$OPERATOR_REGISTRATION_TX_HASH" confirmed "$OPERATOR_STEP"
-append_tx_arg operator-activation "$OPERATOR_ACTIVATION_TX_HASH" confirmed "$OPERATOR_STEP"
-append_tx_arg deposit "$DEPOSIT_TX_HASH" confirmed "$DEPOSIT_STEP"
-append_tx_arg l2-transfer-a "$TX_A" committed "$L2_TRANSFER_A_STEP"
-append_tx_arg l2-transfer-b "$TX_B" committed "$L2_TRANSFER_B_STEP"
-POSTGRES_HOST=127.0.0.1 \
-POSTGRES_PORT=5433 \
-ADMIN_API_KEY="${ADMIN_API_KEY:-localdev-admin}" \
-node dist/index.js e2e-finalize-summary \
-  --mode fresh \
-  --run-id "$RUN_ID" \
-  --out-dir "logs/$RUN_ID" \
-  --node-log "$NODE_LOG" \
-  "${STEP_SUMMARY_ARGS[@]}" \
-  "${TX_ARGS[@]}"
-
-# Supplemental raw probes when the dashboard is not success:
-curl -s http://127.0.0.1:3000/healthz
-curl -s http://127.0.0.1:3000/readyz
-curl -s http://127.0.0.1:8787/healthz
-curl -s http://127.0.0.1:8787/readyz
-curl -s -H "x-midgard-admin-key: ${ADMIN_API_KEY:-localdev-admin}" http://127.0.0.1:3000/stateQueue
-tail -n 120 "$DA_NODE_LOG"
-$COMPOSE logs --no-color --since=30m midgard-node | rg -i "scheduler|Refreshing scheduler|Scheduler refresh transaction submitted|ActiveOperator" || true
-$COMPOSE exec -T postgres psql -U postgres -d midgard -c "select 'pending_finalizations' as tbl, status::text as status, count(*) from pending_block_finalizations group by status union all select 'tx_admissions' as tbl, status::text as status, count(*) from tx_admissions group by status union all select 'deposits' as tbl, status::text as status, count(*) from deposits_utxos group by status order by tbl, status; select 'mempool' as tbl, count(*) from mempool union all select 'processed_mempool' as tbl, count(*) from processed_mempool union all select 'blocks' as tbl, count(*) from blocks union all select 'immutable' as tbl, count(*) from immutable union all select 'confirmed_ledger' as tbl, count(*) from confirmed_ledger union all select 'local_mutation_jobs_unfinished' as tbl, count(*) from local_mutation_jobs where status <> 'completed';"
-```
-
-Acceptance passes only when:
-
-- There is one consumed deposit and two accepted L2 admissions.
-- `pending_block_finalizations` rows are finalized.
-- `mempool`, `processed_mempool`, `blocks`, and unfinished local mutation jobs are zero after merges.
-- `immutable` and `confirmed_ledger` contain the merged results.
-- `stateQueue.headers` is empty after the final merge.
-- The final log scan has no unexplained error, failed, abandoned, or crash entries.
-- `logs/$RUN_ID/summary.json` and `logs/$RUN_ID/summary.md` exist and report
-  `verdict: success` with `nextSafeAction: none_run_complete`.
-
-If any gate fails, classify it with the failure-routing table and choose the
-safe next action. Fresh redeploy is required only when the local/on-chain
-identity is unsafe under `docs/agents/state-reset.md`; otherwise attach,
-reconcile, wait, or fix the specific gate and continue with recorded evidence.
+Also run the narrow Midgard tests for any source behavior changed alongside the
+skill. A documentation-only update still requires the runbook validator,
+frontmatter validator, formatting check, and review against the current CLI
+help/source.

--- a/.agents/skills/midgard-e2e-acceptance/agents/openai.yaml
+++ b/.agents/skills/midgard-e2e-acceptance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Midgard E2E Acceptance"
-  short_description: "Run clean Midgard node acceptance checks."
-  default_prompt: "Use $midgard-e2e-acceptance to run the fresh-deployment Midgard node acceptance check."
+  short_description: "Run or diagnose Midgard live acceptance safely."
+  default_prompt: "Use $midgard-e2e-acceptance to choose the safe run mode, run or resume Midgard live acceptance, and produce structured evidence."

--- a/.agents/skills/midgard-e2e-acceptance/references/benchmark.md
+++ b/.agents/skills/midgard-e2e-acceptance/references/benchmark.md
@@ -1,0 +1,132 @@
+# Optional Stress and Benchmark Evidence
+
+Read this reference only when the user explicitly requests stress, throughput,
+soak, or capacity evidence. Baseline E2E acceptance remains functional and does
+not run stress by default.
+
+## Contents
+
+1. [Select the evidence class](#select-the-evidence-class)
+2. [Use canonical scenarios](#use-canonical-scenarios)
+3. [Placement and comparability](#placement-and-comparability)
+4. [Bounded E2E stress](#bounded-e2e-stress)
+5. [Reporting](#reporting)
+
+## Select the evidence class
+
+- **Functional E2E** proves the real deposit, L2, DA, finality, and automatic
+  merge path. It is not a TPS benchmark.
+- **Class A** measures durable admission and validation. It may gate regression
+  but does not prove L1/DA/merge throughput.
+- **Class B** measures the full pipeline through L1, DA, and merge. It must
+  report observed Preprod conditions and cannot normalize away external block
+  timing.
+
+State the class before any rate or latency number. Never headline
+`node-container` closed-loop output as TPS.
+
+## Use canonical scenarios
+
+Treat repository scenario docs and package scripts as the source of truth. Read
+the one matching the request rather than copying an old local command:
+
+- `docs/benchmark-scenarios/mixed-workload-multi-io.md`;
+- `docs/benchmark-scenarios/phase-2-validation-gates.md`;
+- `docs/benchmark-scenarios/phase-3-architecture-g-closure.md`;
+- `docs/benchmark-scenarios/phase-3-architecture-g-soak.md`;
+- `docs/benchmark-scenarios/phase-4-pipelined-one-hour.md`; or
+- `docs/benchmark-scenarios/phase-5-da-50k-distribution.md`.
+
+Run the named gate and verifier from `demo/midgard-node/package.json`. Do not
+substitute an ad hoc smoke for a named scenario. Never cite ignored or missing
+local `logs/` paths as durable repository evidence.
+
+## Placement and comparability
+
+For an upper-bound claim, place the load generator on a separate host on the
+same LAN. Record:
+
+- `STRESS_LOAD_GENERATOR_PLACEMENT=separate-host`;
+- `STRESS_LOADGEN_COHOSTED=false`;
+- node and load-generator clock/NTP offset;
+- node/Postgres CPU and memory pins;
+- corpus, index, manifest, config, and binary hashes; and
+- observability profile state.
+
+If a second host is unavailable, use the documented cohosted container profile
+with disjoint CPU sets. Label it `separate-container`; use it for relative
+tracking, not absolute production-capacity claims. Loopback or execution inside
+the node container is smoke/calibration only.
+
+For Class B, record an `l1Observation` block with observed Preprod block count,
+tip slots, and min/median/max inter-block time. Do not average runs whose L1
+conditions materially differ.
+
+Reset local state between comparable benchmark runs only under the complete
+fresh-deployment rules in the main skill. Use disjoint corpus slices and at
+least three runs for median/deviation claims.
+
+## Bounded E2E stress
+
+When the user asks for bounded stress as part of a live E2E run, insert it after
+the two baseline L2 submissions and before waiting for the final automatic
+drain.
+
+Use `e2e-stress-l2-throughput` for the bounded harness. Keep defaults explicit:
+
+- `serial-chain` with concurrency 1 for the smallest functional stress;
+- `parallel-fanout` only with independent, pre-funded stress wallets;
+- no shared-wallet concurrency;
+- zero tolerated submission failures unless the user requests a failure-budget
+  experiment; and
+- adaptive polling unless a scenario specifies a fixed interval.
+
+For open-loop work, use `stress-corpus-generate`, `stress-corpus-verify`, and
+the canonical engine scripts in `demo/midgard-node/scripts`. Match corpus
+network, fee parameters, maximum submit size, and manifest to the live node.
+Fund from the planner's per-wallet requirement; do not estimate it from the
+transfer amount alone.
+
+Preserve the canonical artifacts:
+
+- config and environment fingerprint;
+- corpus and manifest;
+- engine report and events;
+- submission records;
+- no-op calibration;
+- DB stage metrics; and
+- stress `summary.json` and `summary.md`.
+
+Append only a successfully parsed stress summary to the functional dashboard:
+
+```bash
+STRESS_SUMMARY_ARGS=()
+if [ -f "logs/$RUN_ID/stress/summary.json" ]; then
+  STRESS_SUMMARY_ARGS+=(
+    --stress-summary "logs/$RUN_ID/stress/summary.json"
+  )
+fi
+```
+
+The stress admission gate is `metrics.l2Admission`. Immutable observation and
+full automatic-drain finality are distinct evidence. A passed admission metric
+does not prove full finality.
+
+## Reporting
+
+For Class A, report durable admission, accepted rate, latency percentiles,
+three-run median, and max deviation. For Class B, add committed/finality rates
+only with L1 observation evidence.
+
+Always report:
+
+- exact scenario/gate/verifier commands;
+- git commit and dirty-state status;
+- placement and resource isolation;
+- manifest/corpus/config hashes;
+- accepted, rejected, failed, timed-out, committed, and finalized counts;
+- clean-run versus recovered-run status; and
+- why the evidence does or does not support the requested claim.
+
+Do not extrapolate a local generator sizing run, smoke test, or short Preprod
+sample into production capacity.

--- a/.agents/skills/midgard-e2e-acceptance/references/live-acceptance.md
+++ b/.agents/skills/midgard-e2e-acceptance/references/live-acceptance.md
@@ -1,0 +1,772 @@
+# Live Acceptance Runbook
+
+Use this reference for fresh runs and value-submitting attach/resume runs. Read
+it completely before changing live state.
+
+## Contents
+
+1. [Shared preparation](#shared-preparation)
+2. [Attach or resume](#attach-or-resume)
+3. [Fresh deployment](#fresh-deployment)
+4. [DA manifests and watcher](#da-manifests-and-watcher)
+5. [Node, deposit, and L2 activity](#node-deposit-and-l2-activity)
+6. [DA, finality, and automatic merge](#da-finality-and-automatic-merge)
+7. [Final evidence](#final-evidence)
+
+## Shared preparation
+
+Start from the repository root. Keep local Preprod provider state intact.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+NODE_DIR="$REPO_ROOT/demo/midgard-node"
+DA_NODE_DIR="$REPO_ROOT/demo/da-committee-node"
+cd "$NODE_DIR"
+
+COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.kupmios.yaml"
+RUN_ID="${RUN_ID:-e2e-run-$(date -u +%Y%m%dT%H%M%SZ)}"
+E2E_STEP_DIR="logs/$RUN_ID/steps"
+RUN_STATE_PATH="logs/$RUN_ID/deployment-run-state.json"
+mkdir -p "$E2E_STEP_DIR" logs deploymentInfo db
+```
+
+Verify `.env` without printing seed phrases:
+
+- `NETWORK=Preprod`;
+- `L1_PROVIDER=Kupmios` and no `L1_PROVIDER_FAILOVER`;
+- host Kupo/Ogmios endpoints use `127.0.0.1`, while container endpoints use
+  Compose service names;
+- `RUN_GENESIS_ON_STARTUP=false`;
+- distinct operator, reference-script, merge, user, and DA submitter roles;
+- `MIDGARD_DEPLOYMENT_MANIFEST_PATH` points to the producer runtime manifest;
+  and
+- `DA_LIBP2P_PRIVATE_KEY_SOURCE` matches the producer manifest identity.
+
+Build the current CLI and start only the local provider plumbing needed by host
+commands. Compose dependencies start Cardano node and bootstrap services.
+
+```bash
+pnpm build
+$COMPOSE up -d cardano-node-ogmios kupo
+node dist/index.js l1-provider-preflight --json
+```
+
+Do not continue until the preflight reports local Kupmios healthy and no
+failover.
+
+## Attach or resume
+
+Do not run `init` or reset local state.
+
+```bash
+node dist/index.js deployment-status
+node dist/index.js reference-script-wallet-status --json
+node dist/index.js l1-provider-preflight --json
+node dist/index.js reconcile phas-registered --json
+node dist/index.js reconcile reference-scripts-complete \
+  --scope node-runtime \
+  --json
+```
+
+Verify manifest ID and SHA-256, network, hub-oracle one-shot, reference-script
+auth policy and UTxOs, operator status, provider route, DB route, and wallet
+role addresses. Use addresses or hashes in evidence, never seed phrases.
+
+For an interrupted milestone, read `recovery.md`, reconcile the specific
+transaction, and add the previous and recovery step summaries to the final
+dashboard. A recovery summary uses `--mode resume`; an ordinary attach summary
+uses `--mode attach`.
+
+Once identity is proven, generate or verify the DA manifests as described below,
+start the watcher, run the producer preflight in the appropriate mode, and then
+start the node with `$COMPOSE up -d midgard-node`.
+
+## Fresh deployment
+
+### Build contracts and images
+
+```bash
+cd "$REPO_ROOT/onchain/aiken"
+aiken build --env testnet
+cd "$NODE_DIR"
+pnpm build
+$COMPOSE build midgard-node midgard-node-migrate
+```
+
+### Create the fresh hub-oracle one-shot
+
+The local Kupmios stack must be healthy before this transaction.
+
+```bash
+HUB_ORACLE_NONCE_LOG="logs/$RUN_ID/hub-oracle-nonce.log"
+HUB_ORACLE_NONCE_STEP="$E2E_STEP_DIR/hub-oracle-nonce.json"
+node dist/index.js e2e-run-step \
+  --id hub-oracle-nonce \
+  --cwd "$NODE_DIR" \
+  --raw-log "$HUB_ORACLE_NONCE_LOG" \
+  --summary-out "$HUB_ORACLE_NONCE_STEP" \
+  --timeout-ms 1200000 \
+  -- \
+  node dist/index.js prepare-hub-oracle-one-shot-nonce \
+  --run-state "$RUN_STATE_PATH" \
+  --fresh-redeploy \
+  --fresh-redeploy-reason "fresh e2e acceptance $RUN_ID" \
+  --json
+```
+
+Patch `.env` with the returned `txHash` and `outputIndex`. Confirm they differ
+from the previous deployment and that the UTxO is funded and confirmed. Keep
+the same `$RUN_STATE_PATH` for reference-script publication.
+
+If the command reports insufficient funding, use `l1-utxos` or
+`reference-script-wallet-status --json` for the intended role, fund it, wait
+for confirmation, and retry only after proving the first attempt did not
+submit.
+
+### Reset only matching Midgard state
+
+This reset is allowed only because the same run proceeds to fresh reference
+scripts and fresh `init`. It deliberately does not delete `cardano/db` or
+`cardano/kupo`.
+
+```bash
+$COMPOSE down -v --remove-orphans
+mkdir -p db deploymentInfo logs
+docker run --rm \
+  -v "$PWD/deploymentInfo:/mnt/deploymentInfo" \
+  -v "$PWD/db:/mnt/db" \
+  busybox sh -lc \
+  'rm -rf /mnt/db/* /mnt/deploymentInfo/* && chown -R 1000:1000 /mnt/db /mnt/deploymentInfo'
+
+$COMPOSE up -d cardano-node-ogmios kupo
+node dist/index.js l1-provider-preflight --json
+```
+
+The run-state is under `logs/$RUN_ID`, so the reset preserves the new
+deployment identity.
+
+### Publish node-runtime reference scripts
+
+```bash
+REFERENCE_LOG="logs/$RUN_ID/reference-scripts.log"
+REFERENCE_STEP="$E2E_STEP_DIR/reference-scripts.json"
+node dist/index.js e2e-run-step \
+  --id reference-scripts \
+  --cwd "$NODE_DIR" \
+  --raw-log "$REFERENCE_LOG" \
+  --summary-out "$REFERENCE_STEP" \
+  --timeout-ms 10800000 \
+  -- \
+  node dist/index.js deploy-reference-script-node-runtime \
+  --run-state "$RUN_STATE_PATH" \
+  --contract-deployment-info-output \
+  deploymentInfo/contract-deployment-info.json
+
+node dist/index.js reconcile reference-scripts-complete \
+  --scope node-runtime \
+  --json
+```
+
+Batch splits and funding-input escalation are progress while transactions keep
+submitting and confirming. Record duration, policy ID, UTxO count, batch splits,
+highest funding-input count, step summary, and raw log.
+
+If interrupted, preserve the run-state and log. Resume only when network,
+one-shot, manifest path, and auth policy all match. Never guess a policy or mix
+identities.
+
+### Initialize and activate the operator
+
+```bash
+INIT_LOG="logs/$RUN_ID/init-protocol.log"
+INIT_STEP="$E2E_STEP_DIR/init-protocol.json"
+node dist/index.js e2e-run-step \
+  --id init-protocol \
+  --cwd "$NODE_DIR" \
+  --raw-log "$INIT_LOG" \
+  --summary-out "$INIT_STEP" \
+  --timeout-ms 1200000 \
+  -- \
+  node dist/index.js init \
+  --contract-deployment-info-output \
+  deploymentInfo/contract-deployment-info.json
+
+INIT_TX_HASH="$(node --input-type=module -e '
+  import { readFileSync } from "node:fs";
+  const summary = JSON.parse(readFileSync(process.argv[1], "utf8"));
+  const hash = summary?.parsedJson?.initTxHash
+    ?? summary?.parsedJson?.txHash
+    ?? summary?.observedTxHashes?.[0];
+  if (typeof hash !== "string" || !/^[0-9a-f]{64}$/i.test(hash)) {
+    throw new Error("init step summary contains no transaction hash");
+  }
+  process.stdout.write(hash.toLowerCase());
+' "$INIT_STEP")"
+
+node dist/index.js reconcile deployment-manifest \
+  --out deploymentInfo/contract-deployment-info.json \
+  --init-tx-hash "$INIT_TX_HASH" \
+  --json
+
+OPERATOR_LOG="logs/$RUN_ID/operator-lifecycle.log"
+OPERATOR_STEP="$E2E_STEP_DIR/operator-lifecycle.json"
+node dist/index.js e2e-run-step \
+  --id operator-lifecycle \
+  --cwd "$NODE_DIR" \
+  --raw-log "$OPERATOR_LOG" \
+  --summary-out "$OPERATOR_STEP" \
+  --timeout-ms 1200000 \
+  -- \
+  node dist/index.js register-active-operator
+```
+
+The combined operator command may resume an exactly-one-registered,
+not-yet-active operator. Use `activate-operator` only after chain evidence proves
+that exact recovery state. Do not deregister or rewrite SQL to recover.
+
+## DA manifests and watcher
+
+Generate three manifests from the finalized v2 contract deployment manifest:
+
+- a producer runtime manifest for the producer container;
+- a producer host-preflight manifest used while the producer is stopped; and
+- a watcher runtime manifest for the host watcher.
+
+The host-preflight manifest matters: `host.docker.internal` is a container route,
+so the host preflight must use the `host` address profile.
+
+Set an explicit funded L1 submitter key source without printing it. Supported
+forms include `seed:<mnemonic>` and `file:<path-containing-a-supported-source>`.
+Keep this wallet distinct from the operator and DA signer.
+
+The command block below is the default legacy 1-of-1 profile. If `.env`
+configures a larger committee or threshold, supply one `--committee-member`
+entry per configured member, generate a target-specific watcher manifest for
+each signer, and start enough watcher instances to reach the configured
+threshold. Do not lower the threshold or collapse the committee to make the
+run pass.
+
+```bash
+cd "$NODE_DIR"
+set -a
+. ./.env
+set +a
+
+: "${L1_OPERATOR_SEED_PHRASE:?missing L1 operator seed phrase}"
+: "${DA_L1_SUBMITTER_KEY_SOURCE:?set a funded DA L1 submitter key source}"
+
+CONTRACT_INFO="$NODE_DIR/deploymentInfo/contract-deployment-info.json"
+PRODUCER_MANIFEST="$NODE_DIR/deploymentInfo/da-libp2p-producer-manifest.json"
+PRODUCER_PREFLIGHT_MANIFEST="$NODE_DIR/deploymentInfo/da-libp2p-producer-host-preflight-manifest.json"
+WATCHER_MANIFEST="$DA_NODE_DIR/run/$RUN_ID-watcher-manifest.json"
+WATCHER_DB="$DA_NODE_DIR/run/$RUN_ID-watcher-store.json"
+PRODUCER_LIBP2P_KEY_SOURCE="${DA_PRODUCER_LIBP2P_KEY_SOURCE:-seed:0000000000000000000000000000000000000000000000000000000000000001}"
+WATCHER_LIBP2P_KEY_SOURCE="${DA_WATCHER_LIBP2P_KEY_SOURCE:-seed:0000000000000000000000000000000000000000000000000000000000000002}"
+DA_THRESHOLD="${DA_THRESHOLD:-1}"
+mkdir -p "$DA_NODE_DIR/run" "$DA_NODE_DIR/db"
+
+DA_VKEY="$(node --input-type=module <<'NODE'
+import { CML, walletFromSeed } from "@lucid-evolution/lucid";
+const network = process.env.NETWORK || "Preprod";
+const seed = process.env.L1_OPERATOR_SEED_PHRASE;
+if (!seed) throw new Error("L1_OPERATOR_SEED_PHRASE is required");
+const wallet = walletFromSeed(seed, { network });
+const privateKey = CML.PrivateKey.from_bech32(wallet.paymentKey);
+process.stdout.write(
+  Buffer.from(privateKey.to_public().to_raw_bytes()).toString("hex"),
+);
+NODE
+)"
+
+COMMON_MANIFEST_ARGS=(
+  --contract-deployment-info "$CONTRACT_INFO"
+  --producer-libp2p-key-source "$PRODUCER_LIBP2P_KEY_SOURCE"
+  --threshold "$DA_THRESHOLD"
+  --committee-member "0,$DA_VKEY,$WATCHER_LIBP2P_KEY_SOURCE,committee+retrieval+coordinator"
+  --network "${NETWORK:-Preprod}"
+)
+
+node dist/index.js da-libp2p-generate-manifest \
+  --target producer \
+  --profile producer-container-watcher-host \
+  "${COMMON_MANIFEST_ARGS[@]}" \
+  --out "$PRODUCER_MANIFEST"
+
+node dist/index.js da-libp2p-generate-manifest \
+  --target producer \
+  --profile host \
+  "${COMMON_MANIFEST_ARGS[@]}" \
+  --out "$PRODUCER_PREFLIGHT_MANIFEST"
+
+node dist/index.js da-libp2p-generate-manifest \
+  --target watcher \
+  --profile producer-container-watcher-host \
+  "${COMMON_MANIFEST_ARGS[@]}" \
+  --local-signer-index 0 \
+  --out "$WATCHER_MANIFEST"
+```
+
+Ensure `.env` contains the container-relative producer runtime path and matching
+producer identity, and does not define `DA_PAYLOAD_ENDPOINTS`:
+
+```dotenv
+MIDGARD_DEPLOYMENT_MANIFEST_PATH=deploymentInfo/da-libp2p-producer-manifest.json
+DA_LIBP2P_PRIVATE_KEY_SOURCE=seed:0000000000000000000000000000000000000000000000000000000000000001
+```
+
+Build the watcher and export its environment for the wallet preflight and
+service. `export` is a shell builtin, so secret-bearing values do not become
+child-process arguments. Do not enable shell tracing or print the array because
+it contains key sources.
+
+```bash
+pnpm --dir "$DA_NODE_DIR" install --frozen-lockfile
+pnpm --dir "$DA_NODE_DIR" build
+
+if [ -z "${DA_COMMITTEE_HEX:-}" ]; then
+  unset DA_COMMITTEE_HEX
+fi
+
+DA_WATCHER_ENV=(
+  "MIDGARD_NETWORK=${NETWORK:-Preprod}"
+  "MIDGARD_DEPLOYMENT_MANIFEST_PATH=$WATCHER_MANIFEST"
+  "MIDGARD_CONTRACT_DEPLOYMENT_INFO_PATH=$CONTRACT_INFO"
+  "CARDANO_PROVIDER_URLS=kupmios:http://127.0.0.1:${KUPO_PORT:-1442}|http://127.0.0.1:${OGMIOS_PORT:-1337}"
+  "CARDANO_FINALITY_DEPTH=${CARDANO_FINALITY_DEPTH:-2}"
+  "DA_LIBP2P_PRIVATE_KEY_SOURCE=$WATCHER_LIBP2P_KEY_SOURCE"
+  "DA_SIGNER_INDEX=0"
+  "DA_SIGNER_KEY_SOURCE=cardano-seed:$L1_OPERATOR_SEED_PHRASE"
+  "DA_THRESHOLD=$DA_THRESHOLD"
+  "DA_L1_SUBMISSION_ENABLED=true"
+  "L1_SUBMITTER_KEY_SOURCE=$DA_L1_SUBMITTER_KEY_SOURCE"
+  "WATCHER_DB_PATH=$WATCHER_DB"
+  "WATCHER_API_HOST=127.0.0.1"
+  "WATCHER_API_PORT=8787"
+  "WATCHER_POLL_INTERVAL_MS=15000"
+)
+export "${DA_WATCHER_ENV[@]}"
+
+DA_WALLET_PREFLIGHT_LOG="logs/$RUN_ID/da-l1-wallet-preflight.log"
+DA_WALLET_PREFLIGHT_STEP="$E2E_STEP_DIR/da-l1-wallet-preflight.json"
+node dist/index.js e2e-run-step \
+  --id da-l1-wallet-preflight \
+  --cwd "$NODE_DIR" \
+  --raw-log "$DA_WALLET_PREFLIGHT_LOG" \
+  --summary-out "$DA_WALLET_PREFLIGHT_STEP" \
+  --timeout-ms 180000 \
+  -- \
+  node "$DA_NODE_DIR/dist/index.js" l1-wallet-preflight --json
+```
+
+Stop if the submitter wallet is not ready. Fund the distinct submitter wallet,
+wait for confirmation, and rerun the preflight.
+
+Start the watcher before probing producer-to-committee reachability:
+
+```bash
+DA_NODE_LOG="logs/$RUN_ID/da-committee-node.log"
+DA_NODE_PID="$DA_NODE_DIR/run/$RUN_ID-watcher.pid"
+node dist/index.js e2e-start-service \
+  --service da-committee-node \
+  --cwd "$DA_NODE_DIR" \
+  --raw-log "$DA_NODE_LOG" \
+  --pid-file "$DA_NODE_PID" \
+  --ready-url http://127.0.0.1:8787/readyz \
+  --health-url http://127.0.0.1:8787/healthz \
+  --ready-timeout-ms 180000 \
+  --poll-interval-ms 5000 \
+  pnpm start
+
+# The managed watcher has inherited its environment. Remove the values from
+# this shell before starting producer-side commands.
+for assignment in "${DA_WATCHER_ENV[@]}"; do
+  unset "${assignment%%=*}"
+done
+unset DA_WATCHER_ENV
+
+DA_LIBP2P_PREFLIGHT_LOG="logs/$RUN_ID/da-libp2p-bind-listen-preflight.log"
+DA_LIBP2P_PREFLIGHT_STEP="$E2E_STEP_DIR/da-libp2p-bind-listen-preflight.json"
+node dist/index.js e2e-run-step \
+  --id da-libp2p-bind-listen-preflight \
+  --cwd "$NODE_DIR" \
+  --raw-log "$DA_LIBP2P_PREFLIGHT_LOG" \
+  --summary-out "$DA_LIBP2P_PREFLIGHT_STEP" \
+  --timeout-ms 180000 \
+  -- \
+  env \
+  "MIDGARD_DEPLOYMENT_MANIFEST_PATH=$PRODUCER_PREFLIGHT_MANIFEST" \
+  "DA_LIBP2P_PRIVATE_KEY_SOURCE=$PRODUCER_LIBP2P_KEY_SOURCE" \
+  node dist/index.js da-libp2p-preflight --mode bind-listen --json
+```
+
+Require `passed: true`, a bound producer listener, and reachable committee
+signer indexes at or above threshold. If the producer port is already bound,
+stop the stale producer and rerun. Do not substitute `dial-only` for fresh
+listener bind evidence.
+
+After the producer is running, attach/resume diagnostics may use `dial-only`
+with the runtime producer manifest. Label that evidence as reachability only.
+
+## Node, deposit, and L2 activity
+
+### Start the node and prove readiness
+
+```bash
+$COMPOSE up -d midgard-node
+
+READY_LOG="logs/$RUN_ID/midgard-node-ready.log"
+READY_STEP="$E2E_STEP_DIR/midgard-node-ready.json"
+node dist/index.js e2e-run-step \
+  --id midgard-node-ready \
+  --cwd "$NODE_DIR" \
+  --raw-log "$READY_LOG" \
+  --summary-out "$READY_STEP" \
+  --timeout-ms 180000 \
+  -- \
+  node --input-type=module -e '
+    const deadline = Date.now() + 170000;
+    while (Date.now() < deadline) {
+      const health = await fetch("http://127.0.0.1:3000/healthz").catch(() => null);
+      const ready = await fetch("http://127.0.0.1:3000/readyz").catch(() => null);
+      if (health?.ok && ready?.ok) {
+        const body = await ready.json();
+        console.log(JSON.stringify({ healthz: await health.json(), readyz: body }));
+        process.exit(body.ready === true && (body.reasons?.length ?? 0) === 0 ? 0 : 1);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+    process.exit(1);
+  '
+```
+
+### Deposit and project
+
+```bash
+USER_L2_ADDRESS="$(node --input-type=module -e '
+  import "dotenv/config";
+  import { walletFromSeed } from "@lucid-evolution/lucid";
+  console.log(walletFromSeed(process.env.USER_SEED_PHRASE, {
+    network: process.env.NETWORK,
+  }).address);
+')"
+DEST_A="$(node --input-type=module -e '
+  import "dotenv/config";
+  import { walletFromSeed } from "@lucid-evolution/lucid";
+  console.log(walletFromSeed(process.env.TESTNET_GENESIS_WALLET_SEED_PHRASE_A, {
+    network: process.env.NETWORK,
+  }).address);
+')"
+DEST_B="$(node --input-type=module -e '
+  import "dotenv/config";
+  import { walletFromSeed } from "@lucid-evolution/lucid";
+  console.log(walletFromSeed(process.env.TESTNET_GENESIS_WALLET_SEED_PHRASE_B, {
+    network: process.env.NETWORK,
+  }).address);
+')"
+
+DEPOSIT_LOG="logs/$RUN_ID/submit-deposit.log"
+DEPOSIT_STEP="$E2E_STEP_DIR/submit-deposit.json"
+node dist/index.js e2e-run-step \
+  --id submit-deposit \
+  --cwd "$NODE_DIR" \
+  --raw-log "$DEPOSIT_LOG" \
+  --summary-out "$DEPOSIT_STEP" \
+  --timeout-ms 1200000 \
+  -- \
+  env POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433 \
+  node dist/index.js submit-deposit \
+  --wallet-seed-phrase-env USER_SEED_PHRASE \
+  --l2-address "$USER_L2_ADDRESS" \
+  --lovelace 12000000
+
+PROJECT_DEPOSITS_LOG="logs/$RUN_ID/project-deposits.log"
+PROJECT_DEPOSITS_STEP="$E2E_STEP_DIR/project-deposits.json"
+node dist/index.js e2e-run-step \
+  --id project-deposits \
+  --cwd "$NODE_DIR" \
+  --raw-log "$PROJECT_DEPOSITS_LOG" \
+  --summary-out "$PROJECT_DEPOSITS_STEP" \
+  --timeout-ms 300000 \
+  -- \
+  bash -lc "$COMPOSE exec -T midgard-node node dist/index.js project-deposits-once"
+
+curl -sf "http://127.0.0.1:3000/utxos?address=$USER_L2_ADDRESS"
+```
+
+If projection is empty, inspect `deposits_utxos.inclusion_time`. Wait until the
+record is due plus a small buffer, then rerun `project-deposits-once`. A deposit
+not yet due is not a failure.
+
+### Submit two baseline L2 transfers
+
+Require the watcher to remain ready first:
+
+```bash
+curl -sf http://127.0.0.1:8787/healthz
+curl -sf http://127.0.0.1:8787/readyz
+
+L2_TRANSFER_A_LOG="logs/$RUN_ID/submit-l2-transfer-a.log"
+L2_TRANSFER_A_STEP="$E2E_STEP_DIR/submit-l2-transfer-a.json"
+node dist/index.js e2e-run-step \
+  --id submit-l2-transfer-a \
+  --cwd "$NODE_DIR" \
+  --raw-log "$L2_TRANSFER_A_LOG" \
+  --summary-out "$L2_TRANSFER_A_STEP" \
+  --timeout-ms 300000 \
+  -- \
+  bash -lc "$COMPOSE exec -T midgard-node node dist/index.js submit-l2-transfer --wallet-seed-phrase-env USER_SEED_PHRASE --endpoint http://127.0.0.1:3000 --l2-address '$DEST_A' --lovelace 2000000"
+
+L2_TRANSFER_B_LOG="logs/$RUN_ID/submit-l2-transfer-b.log"
+L2_TRANSFER_B_STEP="$E2E_STEP_DIR/submit-l2-transfer-b.json"
+node dist/index.js e2e-run-step \
+  --id submit-l2-transfer-b \
+  --cwd "$NODE_DIR" \
+  --raw-log "$L2_TRANSFER_B_LOG" \
+  --summary-out "$L2_TRANSFER_B_STEP" \
+  --timeout-ms 300000 \
+  -- \
+  bash -lc "$COMPOSE exec -T midgard-node node dist/index.js submit-l2-transfer --wallet-seed-phrase-env USER_SEED_PHRASE --endpoint http://127.0.0.1:3000 --l2-address '$DEST_B' --lovelace 1500000"
+```
+
+Use the `txId` fields from the two step summaries with `/tx-status?tx_hash=`.
+Poll until both are `committed`. Do not treat `accepted` as committed or final.
+
+## DA, finality, and automatic merge
+
+For every committed header:
+
+1. Fetch `/da/payload/metadata?header_hash=<hash>`.
+2. Save `/da/payload?header_hash=<hash>` as a raw artifact.
+3. Query the watcher deployment/header status.
+4. Record payload hash/schema, watcher verification, attestation init,
+   add-signatures, and apply transaction hashes.
+5. Require watcher status `attested` or `merged` before automatic merge.
+
+Derive the deployment fingerprint from the contract manifest ID, not a file
+hash:
+
+```bash
+DEPLOYMENT_FINGERPRINT="$(node --input-type=module -e '
+  import { readFileSync } from "node:fs";
+  const manifest = JSON.parse(readFileSync(
+    "deploymentInfo/contract-deployment-info.json",
+    "utf8",
+  ));
+  if (manifest.schemaVersion !== "midgard-deployment-manifest-v2"
+      || typeof manifest.manifestId !== "string") {
+    throw new Error("expected finalized v2 deployment manifest");
+  }
+  process.stdout.write(manifest.manifestId.toLowerCase());
+')"
+```
+
+If the watcher reports `root_mismatch`, `malformed_da`, or `conflicted`, stop.
+Do not merge. Diagnose payload construction, retained data, and peer identity.
+
+Wait for the running merge fiber to empty the state queue:
+
+```bash
+AUTOMATIC_MERGE_LOG="logs/$RUN_ID/await-automatic-merge.log"
+AUTOMATIC_MERGE_STEP="$E2E_STEP_DIR/await-automatic-merge.json"
+node dist/index.js e2e-run-step \
+  --id await-automatic-merge \
+  --cwd "$NODE_DIR" \
+  --raw-log "$AUTOMATIC_MERGE_LOG" \
+  --summary-out "$AUTOMATIC_MERGE_STEP" \
+  --timeout-ms 900000 \
+  -- \
+  bash -lc '
+    set -euo pipefail
+    deadline=$((SECONDS + 900))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+      body="$(curl -sf \
+        -H "x-midgard-admin-key: ${ADMIN_API_KEY:-localdev-admin}" \
+        http://127.0.0.1:3000/stateQueue)"
+      printf "%s\n" "$body"
+      if node --input-type=module - "$body" <<'"'"'NODE'"'"'
+const body = JSON.parse(process.argv[2]);
+process.exit(Array.isArray(body.headers) && body.headers.length === 0 ? 0 : 1);
+NODE
+      then
+        exit 0
+      fi
+      curl -s http://127.0.0.1:3000/readyz || true
+      curl -s \
+        -H "x-midgard-admin-key: ${ADMIN_API_KEY:-localdev-admin}" \
+        http://127.0.0.1:3000/stateQueueMutationLease || true
+      sleep 5
+    done
+    echo "automatic merge fiber did not empty stateQueue" >&2
+    exit 1
+  '
+```
+
+If it times out, inspect readiness, the state queue, mutation lease, unfinished
+jobs, scheduler refresh, commit/finality workers, and merge-fiber logs. Use
+`recovery.md`; never call `/merge` to manufacture success.
+
+## Final evidence
+
+### Extract transaction hashes
+
+The helper prefers structured transaction observations and falls back to a
+named JSON field:
+
+```bash
+step_tx_hash() {
+  node --input-type=module - "$1" "$2" <<'NODE'
+import { readFileSync } from "node:fs";
+const [summaryPath, selector] = process.argv.slice(2);
+const pattern = /^[0-9a-f]{64}$/i;
+const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+const observations = Array.isArray(summary.txObservations)
+  ? summary.txObservations
+  : [];
+const observation = observations.find((entry) =>
+  typeof entry?.txHash === "string"
+  && pattern.test(entry.txHash)
+  && (entry.field === selector || entry.field?.endsWith(`.${selector}`)),
+);
+if (observation) {
+  process.stdout.write(observation.txHash.toLowerCase());
+  process.exit(0);
+}
+const find = (value) => {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = find(entry);
+      if (found) return found;
+    }
+  } else if (value && typeof value === "object") {
+    if (typeof value[selector] === "string" && pattern.test(value[selector])) {
+      return value[selector];
+    }
+    for (const entry of Object.values(value)) {
+      const found = find(entry);
+      if (found) return found;
+    }
+  }
+};
+const hash = find(summary.parsedJson);
+if (hash) process.stdout.write(hash.toLowerCase());
+NODE
+}
+
+HUB_ORACLE_NONCE_TX_HASH="$(step_tx_hash "$HUB_ORACLE_NONCE_STEP" txHash)"
+INIT_TX_HASH="$(step_tx_hash "$INIT_STEP" txHash)"
+OPERATOR_REGISTRATION_TX_HASH="$(step_tx_hash "$OPERATOR_STEP" registerTxHash)"
+OPERATOR_ACTIVATION_TX_HASH="$(step_tx_hash "$OPERATOR_STEP" activateTxHash)"
+DEPOSIT_TX_HASH="$(step_tx_hash "$DEPOSIT_STEP" txHash)"
+TX_A="$(step_tx_hash "$L2_TRANSFER_A_STEP" txId)"
+TX_B="$(step_tx_hash "$L2_TRANSFER_B_STEP" txId)"
+```
+
+After automatic merge, obtain the two fresh header-commit transaction hashes
+from the fresh database. Fail if the run does not have exactly two distinct,
+confirmed header commits; do not invent labels or use unrelated hashes.
+
+```bash
+mapfile -t HEADER_COMMIT_TX_HASHES < <(
+  $COMPOSE exec -T postgres \
+    psql -U postgres -d midgard -At \
+    -c "select encode(submitted_tx_hash, 'hex') from pending_block_finalizations where status = 'finalized' and submitted_tx_hash is not null order by created_at"
+)
+if [ "${#HEADER_COMMIT_TX_HASHES[@]}" -ne 2 ] \
+  || [ "${HEADER_COMMIT_TX_HASHES[0]}" = "${HEADER_COMMIT_TX_HASHES[1]}" ]; then
+  echo "expected exactly two distinct finalized header commits" >&2
+  exit 1
+fi
+HEADER_COMMIT_A_TX_HASH="${HEADER_COMMIT_TX_HASHES[0]}"
+HEADER_COMMIT_B_TX_HASH="${HEADER_COMMIT_TX_HASHES[1]}"
+```
+
+### Generate the dashboard
+
+Include every required step summary, including the DA bind/listen preflight.
+
+```bash
+NODE_LOG="logs/$RUN_ID/midgard-node.log"
+$COMPOSE logs --no-color --since=60m midgard-node > "$NODE_LOG"
+rg -i \
+  "error|failed|failure|unknownOutput|crashed|abandon|ScriptIntegrityHashMismatch|hash mismatch" \
+  "$NODE_LOG" || true
+
+STEP_SUMMARY_ARGS=()
+for step in \
+  "$HUB_ORACLE_NONCE_STEP" \
+  "$REFERENCE_STEP" \
+  "$INIT_STEP" \
+  "$OPERATOR_STEP" \
+  "$DA_WALLET_PREFLIGHT_STEP" \
+  "$DA_LIBP2P_PREFLIGHT_STEP" \
+  "$READY_STEP" \
+  "$DEPOSIT_STEP" \
+  "$PROJECT_DEPOSITS_STEP" \
+  "$L2_TRANSFER_A_STEP" \
+  "$L2_TRANSFER_B_STEP" \
+  "$AUTOMATIC_MERGE_STEP"; do
+  if [ -f "$step" ]; then
+    STEP_SUMMARY_ARGS+=(--step-summary "$step")
+  fi
+done
+
+TX_ARGS=()
+append_tx_arg() {
+  [ -z "$2" ] || TX_ARGS+=(--tx "$1:$2:$3:$4")
+}
+require_committed_l2_tx() {
+  local body
+  body="$(curl -sf "http://127.0.0.1:3000/tx-status?tx_hash=$1")"
+  node --input-type=module - "$body" <<'NODE'
+const body = JSON.parse(process.argv[2]);
+process.exit(body.status === "committed" ? 0 : 1);
+NODE
+}
+require_committed_l2_tx "$TX_A"
+require_committed_l2_tx "$TX_B"
+append_tx_arg hub-oracle-nonce "$HUB_ORACLE_NONCE_TX_HASH" confirmed "$HUB_ORACLE_NONCE_STEP"
+append_tx_arg init "$INIT_TX_HASH" confirmed "$INIT_STEP"
+append_tx_arg operator-registration "$OPERATOR_REGISTRATION_TX_HASH" confirmed "$OPERATOR_STEP"
+append_tx_arg operator-activation "$OPERATOR_ACTIVATION_TX_HASH" confirmed "$OPERATOR_STEP"
+append_tx_arg deposit "$DEPOSIT_TX_HASH" confirmed "$DEPOSIT_STEP"
+append_tx_arg l2-transfer-a "$TX_A" committed "tx-status:$TX_A"
+append_tx_arg l2-transfer-b "$TX_B" committed "tx-status:$TX_B"
+append_tx_arg header-commit-a "$HEADER_COMMIT_A_TX_HASH" confirmed "postgres:pending_block_finalizations"
+append_tx_arg header-commit-b "$HEADER_COMMIT_B_TX_HASH" confirmed "postgres:pending_block_finalizations"
+
+SUMMARY_MODE="${SUMMARY_MODE:-fresh}"
+case "$SUMMARY_MODE" in
+  fresh|attach|resume) ;;
+  *) echo "invalid summary mode: $SUMMARY_MODE" >&2; exit 1 ;;
+esac
+
+POSTGRES_HOST=127.0.0.1 \
+POSTGRES_PORT=5433 \
+ADMIN_API_KEY="${ADMIN_API_KEY:-localdev-admin}" \
+node dist/index.js e2e-finalize-summary \
+  --mode "$SUMMARY_MODE" \
+  --run-id "$RUN_ID" \
+  --out-dir "logs/$RUN_ID" \
+  --node-log "$NODE_LOG" \
+  "${STEP_SUMMARY_ARGS[@]}" \
+  "${TX_ARGS[@]}"
+```
+
+For opt-in stress, follow `benchmark.md` and append the verified
+`--stress-summary` artifact.
+
+### Audit the result
+
+Inspect `logs/$RUN_ID/summary.json` and `summary.md`, not only the CLI exit code.
+Confirm every acceptance condition in `SKILL.md`. Also record:
+
+- run mode and reason;
+- manifest ID/hash, one-shot, reference-script policy/count;
+- all step/log paths and transaction hashes;
+- watcher manifest/store/PID/log paths and per-header status;
+- endpoint health/readiness and L2 balances;
+- scheduler, finalization, DA and automatic merge evidence; and
+- any recovered attempt and why clean-run status differs from functional status.
+
+Do not call the run complete while any transaction or required evidence item is
+missing or ambiguous.

--- a/.agents/skills/midgard-e2e-acceptance/references/recovery.md
+++ b/.agents/skills/midgard-e2e-acceptance/references/recovery.md
@@ -1,0 +1,132 @@
+# Recovery and Failure Routing
+
+Read this reference completely before retrying an interrupted or ambiguous live
+step.
+
+## Contents
+
+1. [Preserve evidence](#preserve-evidence)
+2. [Classify the attempt](#classify-the-attempt)
+3. [Reconciliation commands](#reconciliation-commands)
+4. [Failure routing](#failure-routing)
+5. [Recovery completion](#recovery-completion)
+
+## Preserve evidence
+
+Before restarting a process or command, record:
+
+- selected run mode and reason;
+- every attempted step ID, status, summary path, and raw log path;
+- every observed transaction hash and whether it is prepared, submitted,
+  confirmed, committed, rejected, or unknown;
+- deployment manifest path, manifest ID/hash, network, hub-oracle one-shot,
+  reference-script policy ID and UTxO count;
+- deployment run-state path and identity;
+- provider and DB routes;
+- operator, reference-script, merge, user, DA signer, and L1 submitter addresses
+  or hashes, never credentials;
+- producer and watcher manifest paths and hashes;
+- watcher PID, log, store, health/readiness, and per-header status; and
+- state queue, mutation lease, pending finalization, scheduler, and unfinished
+  local mutation-job evidence.
+
+Do not delete a raw log because a retry produced a cleaner one. Supply all
+attempt summaries to the final dashboard so clean-run quality remains honest.
+
+## Classify the attempt
+
+Choose exactly one classification:
+
+1. **Safe before submit**: the runner and raw log prove no transaction was
+   signed or submitted. Fix the local cause and rerun with a new attempt log.
+2. **Submitted, reconcile before retry**: a hash exists or submission may have
+   occurred. Query provider/chain and use the matching reconciliation command.
+3. **Wait for visibility**: provider confirmation, inclusion-time projection,
+   finality depth, DA propagation, lease ownership, or a valid protocol window
+   has not matured. Wait against authoritative evidence.
+4. **Attach/resume**: deployment identity is complete and matches local durable
+   state. Continue without `init` or reset.
+5. **Fresh required**: local durable state was lost or the one-shot, manifest,
+   reference-script policy, and on-chain deployment can no longer be proven to
+   match. Follow `docs/agents/state-reset.md` and create a complete fresh
+   identity.
+
+A timeout or signal with no transaction observation is ambiguous for a
+transaction-bearing step. Do not classify it as safe-before-submit without raw
+evidence.
+
+## Reconciliation commands
+
+Run from `demo/midgard-node`. Add `--repair` only where shown and only after the
+read-only result proves the repair is appropriate.
+
+```bash
+node dist/index.js reconcile phas-registered --json
+node dist/index.js reconcile reference-scripts-complete \
+  --scope node-runtime \
+  --json
+node dist/index.js reconcile deployment-manifest \
+  --out deploymentInfo/contract-deployment-info.json \
+  --init-tx-hash <confirmed-init-tx-hash> \
+  --json
+node dist/index.js reconcile deposit-projected \
+  --event-id <event-id> \
+  --json
+node dist/index.js reconcile tx-committed \
+  --tx-hash <l2-tx-hash> \
+  --json
+node dist/index.js reconcile da-attested \
+  --header-hash <header-hash> \
+  --watcher-url http://127.0.0.1:8787 \
+  --contract-deployment-info \
+  deploymentInfo/contract-deployment-info.json \
+  --json
+node dist/index.js reconcile block-committed \
+  --header-hash <header-hash> \
+  --json
+node dist/index.js reconcile-deposit-submission \
+  --tx-hash <deposit-tx-hash> \
+  --json
+```
+
+Where a read-only reconciliation result explicitly supports it, rerun that same
+command with `--repair`. Never run `reconcile merge-complete --repair` for
+acceptance. The running merge fiber must prove liveness.
+
+## Failure routing
+
+| Blocker                                                | Safe next action                                                                                                                                                           |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local Kupmios unhealthy or failover configured         | Run `l1-provider-preflight --json`; repair local Cardano node, Ogmios, or Kupo. Do not switch to a remote provider.                                                        |
+| Fresh one-shot mismatch                                | Stop. Attach only if the existing initialized identity is complete; otherwise restart the full fresh deployment with a new one-shot.                                       |
+| Reference-script publication interrupted before `init` | Preserve run-state/logs and resume only when network, one-shot, manifest, and auth policy match.                                                                           |
+| Manifest/reference-script mismatch after `init`        | Stop and diagnose identity drift. Fresh deploy only when state-reset rules require it.                                                                                     |
+| Operator registered but not active                     | Prove exactly one matching registered node and no active node; then use `activate-operator`.                                                                               |
+| Deposit submission timeout                             | Run `reconcile-deposit-submission`; do not resubmit an `ambiguous` result.                                                                                                 |
+| Deposit not projected                                  | Inspect `deposits_utxos.inclusion_time`; wait until due, then run projection once.                                                                                         |
+| Watcher wallet preflight fails                         | Fund or correct the distinct configured L1 submitter wallet. Do not substitute the operator wallet silently.                                                               |
+| DA watcher below threshold                             | Start or repair enough matching committee listeners. Do not lower threshold.                                                                                               |
+| Producer bind/listen preflight fails                   | Stop stale producer instances; regenerate matching host-preflight/runtime manifests; rerun before node startup.                                                            |
+| DA payload missing                                     | Inspect producer publication rows, retained payload, pending finalization, and watcher logs. Use `db:backfill-da-payloads --header-hash` only as explicit repair evidence. |
+| DA payload root mismatch, malformed data, or conflict  | Stop. Do not merge. Fix payload construction, deployment identity, or endpoint/peer set.                                                                                   |
+| State-queue lease blocks merge                         | Inspect `/stateQueueMutationLease` and unfinished mutation jobs; wait or repair the actual owner.                                                                          |
+| Scheduler/commit validity expired                      | Rebuild through the worker path with fresh timing; never reuse expired signed transactions or pending rows.                                                                |
+| Automatic merge wait times out                         | Inspect readiness, queue, lease, scheduler, finalization, DA status, and merge logs. Fix the merge fiber; do not call `/merge`.                                            |
+| Hash mismatch                                          | Preserve raw body/log separately; report command, tx hash, expected/actual hash, script policy/outref, and artifact path.                                                  |
+| Local state wiped under an old deployment              | Stop all value-submitting activity and perform a complete fresh on-chain deployment or restore provably matching durable state.                                            |
+
+## Recovery completion
+
+After recovery:
+
+- rerun the affected reconciliation and health/readiness checks;
+- add both failed/interrupted and recovery step summaries to
+  `e2e-finalize-summary`;
+- reconcile every transaction observation;
+- use summary mode `resume`, unless this became a complete new deployment, in
+  which case use `fresh` and retain all attempt evidence; and
+- report functional and clean-run verdicts separately.
+
+Recovery is complete only when the normal acceptance contract is satisfied. A
+working endpoint by itself does not close an ambiguous transaction, DA, or
+finality failure.

--- a/.agents/skills/midgard-e2e-acceptance/scripts/validate-runbook.mjs
+++ b/.agents/skills/midgard-e2e-acceptance/scripts/validate-runbook.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const skillDir = resolve(scriptDir, "..");
+const repoRoot = resolve(skillDir, "../../..");
+
+const paths = {
+  skill: join(skillDir, "SKILL.md"),
+  live: join(skillDir, "references/live-acceptance.md"),
+  recovery: join(skillDir, "references/recovery.md"),
+  benchmark: join(skillDir, "references/benchmark.md"),
+  cli: join(repoRoot, "demo/midgard-node/src/index.ts"),
+  finalizer: join(
+    repoRoot,
+    "demo/midgard-node/src/commands/e2e-finalize-summary.ts",
+  ),
+};
+
+const failures = [];
+const fail = (message) => failures.push(message);
+const read = (path) => {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (error) {
+    fail(`cannot read ${path}: ${error.message}`);
+    return "";
+  }
+};
+
+const documents = Object.fromEntries(
+  ["skill", "live", "recovery", "benchmark"].map((name) => [
+    name,
+    read(paths[name]),
+  ]),
+);
+const cliSource = read(paths.cli);
+const finalizerSource = read(paths.finalizer);
+const allDocs = Object.values(documents).join("\n");
+
+const requireText = (text, needle, label) => {
+  if (!text.includes(needle)) fail(`missing ${label}: ${needle}`);
+};
+
+const skillLines = documents.skill.split("\n").length;
+if (skillLines > 500) {
+  fail(`SKILL.md has ${skillLines} lines; keep the entrypoint at or below 500`);
+}
+
+for (const [name, text] of Object.entries(documents)) {
+  const fences = text.match(/^```/gm)?.length ?? 0;
+  if (fences % 2 !== 0) fail(`${name} has an unmatched fenced code block`);
+  if (/\\\n```/m.test(text)) {
+    fail(`${name} has a dangling shell continuation before a closing fence`);
+  }
+  if (text.includes("\r")) fail(`${name} contains CRLF line endings`);
+  if (name !== "skill" && text.split("\n").length > 100) {
+    requireText(text, "## Contents", `${name} table of contents`);
+  }
+}
+
+requireText(
+  documents.skill,
+  "references/live-acceptance.md",
+  "live runbook route",
+);
+requireText(documents.skill, "references/recovery.md", "recovery route");
+requireText(documents.skill, "references/benchmark.md", "benchmark route");
+
+for (const forbidden of [
+  "logs/phase-1-full-corpus-",
+  "logs/phase-1-live-acceptance/",
+  "preprod-da-2of3/secrets/l1-submitter.seed",
+  "--mode fresh-redeploy",
+]) {
+  if (allDocs.includes(forbidden))
+    fail(`forbidden stale instruction: ${forbidden}`);
+}
+
+const declaredCommands = new Set(
+  [...cliSource.matchAll(/\.command\("([a-zA-Z0-9:_-]+)"\)/g)].map(
+    (match) => match[1],
+  ),
+);
+const referencedCommands = new Set(
+  [...allDocs.matchAll(/node dist\/index\.js\s+([a-zA-Z0-9:_-]+)/g)].map(
+    (match) => match[1],
+  ),
+);
+for (const command of referencedCommands) {
+  const dynamicReferenceScriptCommand =
+    command.startsWith("deploy-reference-script-") &&
+    cliSource.includes("deploy-reference-script-${commandName}");
+  if (!declaredCommands.has(command) && !dynamicReferenceScriptCommand) {
+    fail(`documented Midgard CLI command is not declared: ${command}`);
+  }
+}
+
+const parseConstStringArray = (source, name) => {
+  const match = source.match(
+    new RegExp(`export const ${name} = \\[([\\s\\S]*?)\\] as const`),
+  );
+  if (!match) {
+    fail(`cannot parse ${name} from e2e-finalize-summary.ts`);
+    return [];
+  }
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+};
+
+const requiredStepIds = parseConstStringArray(
+  finalizerSource,
+  "REQUIRED_FRESH_E2E_STEP_IDS",
+);
+const requiredTransactionLabels = parseConstStringArray(
+  finalizerSource,
+  "REQUIRED_FRESH_TRANSACTION_LABELS",
+);
+
+const summaryStart = documents.live.indexOf("STEP_SUMMARY_ARGS=()");
+const summaryEnd = documents.live.indexOf("TX_ARGS=()", summaryStart);
+if (summaryStart < 0 || summaryEnd < 0) {
+  fail("cannot find final STEP_SUMMARY_ARGS block");
+} else {
+  const summaryBlock = documents.live.slice(summaryStart, summaryEnd);
+  for (const stepId of requiredStepIds) {
+    const escaped = stepId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const stepMatch = documents.live.match(
+      new RegExp(
+        `--id\\s+${escaped}[\\s\\S]{0,500}?--summary-out\\s+"\\$([A-Z0-9_]+)"`,
+      ),
+    );
+    if (!stepMatch) {
+      fail(
+        `required fresh step lacks a documented structured runner: ${stepId}`,
+      );
+      continue;
+    }
+    const variable = stepMatch[1];
+    if (!summaryBlock.includes(`"$${variable}"`)) {
+      fail(`required fresh step summary is omitted from dashboard: ${stepId}`);
+    }
+  }
+}
+
+for (const label of requiredTransactionLabels) {
+  if (!documents.live.includes(`append_tx_arg ${label} `)) {
+    fail(`required transaction label is omitted from dashboard: ${label}`);
+  }
+}
+
+for (const marker of [
+  "--target producer",
+  "--profile producer-container-watcher-host",
+  "--profile host",
+  "--target watcher",
+  "$PRODUCER_PREFLIGHT_MANIFEST",
+  "DA_L1_SUBMITTER_KEY_SOURCE",
+]) {
+  requireText(documents.live, marker, "DA workflow marker");
+}
+
+const daSection = documents.live.slice(
+  documents.live.indexOf("## DA manifests and watcher"),
+);
+const watcherStart = daSection.indexOf("e2e-start-service");
+const bindPreflight = daSection.indexOf("--id da-libp2p-bind-listen-preflight");
+const nodeStart = daSection.indexOf("$COMPOSE up -d midgard-node");
+if (
+  watcherStart < 0 ||
+  bindPreflight < 0 ||
+  nodeStart < 0 ||
+  !(watcherStart < bindPreflight && bindPreflight < nodeStart)
+) {
+  fail(
+    "DA order must be watcher start, bind/listen preflight, then node start",
+  );
+}
+
+const bashBlocks = [];
+for (const [name, text] of Object.entries(documents)) {
+  for (const match of text.matchAll(/```bash\n([\s\S]*?)\n```/g)) {
+    bashBlocks.push({ name, body: match[1] });
+  }
+}
+for (const [index, block] of bashBlocks.entries()) {
+  const sanitized = block.body.replace(/<[^>\n]+>/g, "placeholder");
+  const result = spawnSync("bash", ["-n", "-c", sanitized], {
+    encoding: "utf8",
+    timeout: 2000,
+  });
+  if (result.error?.code === "ETIMEDOUT") {
+    fail(`${block.name} bash block ${index + 1} timed out in bash -n`);
+  } else if (result.status !== 0) {
+    fail(
+      `${block.name} bash block ${index + 1} fails bash -n: ${result.stderr.trim()}`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  process.stderr.write(
+    `Midgard E2E skill validation failed (${failures.length}):\n${failures
+      .map((entry) => `- ${entry}`)
+      .join("\n")}\n`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  JSON.stringify(
+    {
+      status: "ok",
+      skillLines,
+      referencedCommandCount: referencedCommands.size,
+      requiredStepIds,
+      requiredTransactionLabels,
+      bashBlockCount: bashBlocks.length,
+    },
+    null,
+    2,
+  ) + "\n",
+);


### PR DESCRIPTION
## Summary

- split the oversized skill entrypoint into a concise router plus live acceptance, recovery, and benchmark references
- correct the DA manifest, watcher, bind/listen preflight, and producer startup sequence while keeping signing material out of process arguments
- align fresh-run evidence with the current finalizer step and transaction requirements and add a repository-aware runbook validator

## Validation

- Midgard E2E runbook validator
- skill-creator quick validator
- Prettier check and Git diff check
- Aiken testnet blueprint build
- Midgard node and DA committee node builds
- focused E2E runner, service supervisor, DA manifest/gates, environment, and finalizer suite: 56 tests passed