### PR TITLE
Update Mithril client image and links to IntersectMBO

### DIFF
--- a/l1-services/.env.example
+++ b/l1-services/.env.example
@@ -5,8 +5,8 @@ COMPOSE_PROJECT_NAME=midgard
 CARDANO_NODE_IMAGE=ghcr.io/intersectmbo/cardano-node:10.6.3
 
 # Mithril client image
-# Find the latest release at: https://github.com/input-output-hk/mithril/releases
-MITHRIL_CLIENT_IMAGE=ghcr.io/input-output-hk/mithril-client:latest
+# Find the latest release at: https://github.com/IntersectMBO/mithril/releases
+MITHRIL_CLIENT_IMAGE=ghcr.io/intersectmbo/mithril-client:latest
 
 # Cardano network (e.g. preprod, preview, mainnet)
 CARDANO_NETWORK=preprod
@@ -20,11 +20,11 @@ AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggre
 SNAPSHOT_DIGEST=latest
 
 # Genesis verification key for the target network
-# Preprod: https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey
+# Preprod: https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey
 GENESIS_VERIFICATION_KEY=
 
 # Ancillary verification key (needed for --include-ancillary)
-# Preprod: https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/ancillary.vkey
+# Preprod: https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/release-preprod/ancillary.vkey
 ANCILLARY_VERIFICATION_KEY=
 
 # Base directory for all service data volumes (relative to this directory)


### PR DESCRIPTION
This PR adapts the Mithril references to the move to `IntersectMBO`:
- Repoints `MITHRIL_CLIENT_IMAGE` in `l1-services/.env.example` to `ghcr.io/intersectmbo/mithril-client:latest`.
- Repoints the mithril URLs in the file's comments to `IntersectMBO/mithril`.